### PR TITLE
feat: add Landscape mutation to the GraphQL API

### DIFF
--- a/terraso_backend/apps/graphql/schema/__init__.py
+++ b/terraso_backend/apps/graphql/schema/__init__.py
@@ -3,7 +3,12 @@ from graphene import relay
 from graphene_django.filter import DjangoFilterConnectionField
 
 from .groups import GroupNode
-from .landscapes import LandscapeNode
+from .landscapes import (
+    LandscapeAddMutation,
+    LandscapeDeleteMutation,
+    LandscapeNode,
+    LandscapeUpdateMutation,
+)
 from .users import UserNode
 
 
@@ -16,4 +21,10 @@ class Query(graphene.ObjectType):
     users = DjangoFilterConnectionField(UserNode)
 
 
-schema = graphene.Schema(query=Query)
+class Mutations(graphene.ObjectType):
+    add_landscape = LandscapeAddMutation.Field()
+    update_landscape = LandscapeUpdateMutation.Field()
+    delete_landscape = LandscapeDeleteMutation.Field()
+
+
+schema = graphene.Schema(query=Query, mutation=Mutations)

--- a/terraso_backend/apps/graphql/schema/landscapes.py
+++ b/terraso_backend/apps/graphql/schema/landscapes.py
@@ -1,3 +1,5 @@
+import graphene
+import graphql_relay
 from graphene import relay
 from graphene_django import DjangoObjectType
 
@@ -9,3 +11,67 @@ class LandscapeNode(DjangoObjectType):
         model = Landscape
         filter_fields = ["name", "description", "groups"]
         interfaces = (relay.Node,)
+
+
+class LandscapeWriteMutation(relay.ClientIDMutation):
+    landscape = graphene.Field(LandscapeNode)
+
+    @classmethod
+    def mutate_and_get_payload(cls, root, info, **kwargs):
+        """
+        This is the method performed everytime this mutation is submitted.
+        Since this is the base class for write operations, this method will be
+        called both when adding and updating Landscapes. The `kwargs` receives
+        a dictionary with all inputs informed.
+        """
+        graphql_id = kwargs.pop("id", None)
+
+        if graphql_id:
+            _, _pk = graphql_relay.from_global_id(graphql_id)
+            landscape = Landscape.objects.get(pk=_pk)
+        else:
+            landscape = Landscape()
+
+        for attr, value in kwargs.items():
+            setattr(landscape, attr, value)
+
+        landscape.save()
+
+        return LandscapeWriteMutation(landscape=landscape)
+
+
+class LandscapeAddMutation(LandscapeWriteMutation):
+    class Input:
+        name = graphene.String(required=True)
+        description = graphene.String()
+        website = graphene.String()
+        location = graphene.String()
+
+
+class LandscapeUpdateMutation(LandscapeWriteMutation):
+    class Input:
+        id = graphene.ID(required=True)
+        name = graphene.String()
+        description = graphene.String()
+        website = graphene.String()
+        location = graphene.String()
+
+
+class LandscapeDeleteMutation(relay.ClientIDMutation):
+    landscape = graphene.Field(LandscapeNode)
+
+    class Input:
+        id = graphene.ID()
+
+    @classmethod
+    def mutate_and_get_payload(cls, root, info, **kwargs):
+        graphql_id = kwargs.pop("id", None)
+
+        if not graphql_id:
+            return LandscapeDeleteMutation(landscape=None)
+
+        _, _pk = graphql_relay.from_global_id(graphql_id)
+        landscape = Landscape.objects.get(pk=_pk)
+        landscape.delete()
+
+        return LandscapeDeleteMutation(landscape=landscape)

--- a/terraso_backend/tests/graphql/test_landscape_mutations.py
+++ b/terraso_backend/tests/graphql/test_landscape_mutations.py
@@ -1,0 +1,105 @@
+import pytest
+from graphene_django.utils.testing import graphql_query
+
+from apps.core.models import Landscape
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def client_query(client):
+    def _client_query(*args, **kwargs):
+        return graphql_query(*args, **kwargs, client=client)
+
+    return _client_query
+
+
+def test_landscapes_add(client_query):
+    landscape_name = "Testing Landscape"
+    response = client_query(
+        """
+        mutation addLandscape($input: LandscapeAddMutationInput!){
+          addLandscape(input: $input) {
+            landscape {
+              id
+              name
+            }
+          }
+        }
+        """,
+        variables={"input": {"name": landscape_name}},
+    )
+    landscape_result = response.json()["data"]["addLandscape"]["landscape"]
+
+    assert landscape_result["id"]
+    assert landscape_result["name"] == landscape_name
+
+
+def test_landscapes_update(client_query, landscapes):
+    old_landscape = _get_landscapes(client_query)[0]
+    new_data = {
+        "id": old_landscape["id"],
+        "description": "New description",
+        "name": "New Name",
+        "website": "www.example.com/updated-landscape",
+    }
+    response = client_query(
+        """
+        mutation updateLandscape($input: LandscapeUpdateMutationInput!) {
+          updateLandscape(input: $input) {
+            landscape {
+              id
+              name
+              description
+              website
+            }
+          }
+        }
+        """,
+        variables={"input": new_data},
+    )
+    landscape_result = response.json()["data"]["updateLandscape"]["landscape"]
+
+    assert landscape_result == new_data
+
+
+def test_landscapes_delete(client_query, landscapes):
+    old_landscape = _get_landscapes(client_query)[0]
+    response = client_query(
+        """
+        mutation deleteLandscape($input: LandscapeDeleteMutationInput!){
+          deleteLandscape(input: $input) {
+            landscape {
+              id
+              slug
+            }
+          }
+        }
+
+        """,
+        variables={"input": {"id": old_landscape["id"]}},
+    )
+
+    landscape_result = response.json()["data"]["deleteLandscape"]["landscape"]
+
+    assert landscape_result["slug"] == old_landscape["slug"]
+    assert not Landscape.objects.filter(slug=landscape_result["slug"])
+
+
+def _get_landscapes(client_query):
+    response = client_query(
+        """
+        {
+          landscapes {
+            edges {
+              node {
+                id
+                slug
+              }
+            }
+          }
+        }
+        """
+    )
+    edges = response.json()["data"]["landscapes"]["edges"]
+    return [e["node"] for e in edges]


### PR DESCRIPTION
This change adds the mutations (add, update, delete) to the Landscape
resource on GraphQL API. The operations are still a bit naive and can be
improved in matters of validation, mainly. Anyway, this already looks
like a good increment to the project.