### PR TITLE
feat: makes slug update once the base field update

### DIFF
--- a/terraso_backend/apps/core/models/commons.py
+++ b/terraso_backend/apps/core/models/commons.py
@@ -19,9 +19,8 @@ class SlugModel(BaseModel):
     slug = models.SlugField(max_length=250, unique=True, blank=True, editable=False)
 
     def save(self, *args, **kwargs):
-        if not self.slug:
-            value_to_slugify = getattr(self, self.field_to_slug)
-            self.slug = slugify(value_to_slugify)
+        value_to_slugify = getattr(self, self.field_to_slug)
+        self.slug = slugify(value_to_slugify)
         return super().save(*args, **kwargs)
 
     class Meta(BaseModel.Meta):

--- a/terraso_backend/tests/core/models/test_groups.py
+++ b/terraso_backend/tests/core/models/test_groups.py
@@ -20,6 +20,15 @@ def test_group_is_slugifiable_by_name():
     assert group.slug == "this-is-my-name"
 
 
+def test_group_slug_is_updatable():
+    group = mixer.blend(Group, name="This is My Name", slug=None)
+    group.name = "New name"
+    group.save()
+
+    assert group.slug == "new-name"
+    assert group.name == "New name"
+
+
 def test_group_can_have_group_associations():
     group = mixer.blend(Group)
     subgroup = mixer.blend(Group)

--- a/terraso_backend/tests/core/models/test_landscapes.py
+++ b/terraso_backend/tests/core/models/test_landscapes.py
@@ -20,6 +20,15 @@ def test_landscape_is_slugifiable_by_name():
     assert landscape.slug == "this-is-my-name"
 
 
+def test_landscape_slug_is_updatable():
+    landscape = mixer.blend(Landscape, name="This is My Name", slug=None)
+    landscape.name = "New name"
+    landscape.save()
+
+    assert landscape.slug == "new-name"
+    assert landscape.name == "New name"
+
+
 def test_landscape_groups_are_created_when_association_added():
     landscape = mixer.blend(Landscape)
     groups = mixer.cycle(3).blend(Group)


### PR DESCRIPTION
The previous implementation was not updating the slug content when the
base slug field were updated. This change improve this behavior, making
the slug generation regardless the model operation: create or update.
This may not be an issue, since the slug right now is not planned to be
a long-term key for the model.