### PR TITLE
feat: add Group mutation to the GraphQL API

### DIFF
--- a/terraso_backend/apps/graphql/schema/__init__.py
+++ b/terraso_backend/apps/graphql/schema/__init__.py
@@ -2,7 +2,12 @@ import graphene
 from graphene import relay
 from graphene_django.filter import DjangoFilterConnectionField
 
-from .groups import GroupNode
+from .groups import (
+    GroupAddMutation,
+    GroupDeleteMutation,
+    GroupNode,
+    GroupUpdateMutation,
+)
 from .landscapes import (
     LandscapeAddMutation,
     LandscapeDeleteMutation,
@@ -22,8 +27,11 @@ class Query(graphene.ObjectType):
 
 
 class Mutations(graphene.ObjectType):
+    add_group = GroupAddMutation.Field()
     add_landscape = LandscapeAddMutation.Field()
+    update_group = GroupUpdateMutation.Field()
     update_landscape = LandscapeUpdateMutation.Field()
+    delete_group = GroupDeleteMutation.Field()
     delete_landscape = LandscapeDeleteMutation.Field()
 
 

--- a/terraso_backend/apps/graphql/schema/groups.py
+++ b/terraso_backend/apps/graphql/schema/groups.py
@@ -1,8 +1,11 @@
+import graphene
 from graphene import relay
 from graphene_django import DjangoObjectType
 from graphene_django.filter import DjangoFilterConnectionField
 
 from apps.core.models import Group, GroupAssociation, Membership
+
+from .commons import BaseDeleteMutation, BaseWriteMutation
 
 
 class GroupAssociationNode(DjangoObjectType):
@@ -42,3 +45,34 @@ class GroupNode(DjangoObjectType):
 
     def resolve_associations_as_child(self, info):
         return self.associations_as_child.all()
+
+
+class GroupAddMutation(BaseWriteMutation):
+    group = graphene.Field(GroupNode)
+
+    model_class = Group
+
+    class Input:
+        name = graphene.String(required=True)
+        description = graphene.String()
+        website = graphene.String()
+
+
+class GroupUpdateMutation(BaseWriteMutation):
+    group = graphene.Field(GroupNode)
+
+    model_class = Group
+
+    class Input:
+        id = graphene.ID(required=True)
+        name = graphene.String()
+        description = graphene.String()
+        website = graphene.String()
+
+
+class GroupDeleteMutation(BaseDeleteMutation):
+    group = graphene.Field(GroupNode)
+    model_class = Group
+
+    class Input:
+        id = graphene.ID()

--- a/terraso_backend/tests/graphql/test_group_mutations.py
+++ b/terraso_backend/tests/graphql/test_group_mutations.py
@@ -1,0 +1,105 @@
+import pytest
+from graphene_django.utils.testing import graphql_query
+
+from apps.core.models import Group
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def client_query(client):
+    def _client_query(*args, **kwargs):
+        return graphql_query(*args, **kwargs, client=client)
+
+    return _client_query
+
+
+def test_groups_add(client_query):
+    group_name = "Testing Group"
+    response = client_query(
+        """
+        mutation addGroup($input: GroupAddMutationInput!){
+          addGroup(input: $input) {
+            group {
+              id
+              name
+            }
+          }
+        }
+        """,
+        variables={"input": {"name": group_name}},
+    )
+    group_result = response.json()["data"]["addGroup"]["group"]
+
+    assert group_result["id"]
+    assert group_result["name"] == group_name
+
+
+def test_groups_update(client_query, groups):
+    old_group = _get_groups(client_query)[0]
+    new_data = {
+        "id": old_group["id"],
+        "description": "New description",
+        "name": "New Name",
+        "website": "www.example.com/updated-group",
+    }
+    response = client_query(
+        """
+        mutation updateGroup($input: GroupUpdateMutationInput!) {
+          updateGroup(input: $input) {
+            group {
+              id
+              name
+              description
+              website
+            }
+          }
+        }
+        """,
+        variables={"input": new_data},
+    )
+    group_result = response.json()["data"]["updateGroup"]["group"]
+
+    assert group_result == new_data
+
+
+def test_groups_delete(client_query, groups):
+    old_group = _get_groups(client_query)[0]
+    response = client_query(
+        """
+        mutation deleteGroup($input: GroupDeleteMutationInput!){
+          deleteGroup(input: $input) {
+            group {
+              id
+              slug
+            }
+          }
+        }
+
+        """,
+        variables={"input": {"id": old_group["id"]}},
+    )
+
+    group_result = response.json()["data"]["deleteGroup"]["group"]
+
+    assert group_result["slug"] == old_group["slug"]
+    assert not Group.objects.filter(slug=group_result["slug"])
+
+
+def _get_groups(client_query):
+    response = client_query(
+        """
+        {
+          groups {
+            edges {
+              node {
+                id
+                slug
+              }
+            }
+          }
+        }
+        """
+    )
+    edges = response.json()["data"]["groups"]["edges"]
+    return [e["node"] for e in edges]


### PR DESCRIPTION
This change adds the mutations (add, update, delete) to the Group
resource on GraphQL API. The operations are still a bit naive and can be
improved in matters of validation, mainly. Anyway, this already looks
like a good increment to the project.