### PR TITLE
feat: add User mutation to the GraphQL API

### DIFF
--- a/terraso_backend/apps/graphql/schema/__init__.py
+++ b/terraso_backend/apps/graphql/schema/__init__.py
@@ -14,7 +14,7 @@ from .landscapes import (
     LandscapeNode,
     LandscapeUpdateMutation,
 )
-from .users import UserNode
+from .users import UserAddMutation, UserDeleteMutation, UserNode, UserUpdateMutation
 
 
 class Query(graphene.ObjectType):
@@ -29,10 +29,13 @@ class Query(graphene.ObjectType):
 class Mutations(graphene.ObjectType):
     add_group = GroupAddMutation.Field()
     add_landscape = LandscapeAddMutation.Field()
+    add_user = UserAddMutation.Field()
     update_group = GroupUpdateMutation.Field()
     update_landscape = LandscapeUpdateMutation.Field()
+    update_user = UserUpdateMutation.Field()
     delete_group = GroupDeleteMutation.Field()
     delete_landscape = LandscapeDeleteMutation.Field()
+    delete_user = UserDeleteMutation.Field()
 
 
 schema = graphene.Schema(query=Query, mutation=Mutations)

--- a/terraso_backend/apps/graphql/schema/users.py
+++ b/terraso_backend/apps/graphql/schema/users.py
@@ -1,7 +1,11 @@
+import graphene
+import graphql_relay
 from graphene import relay
 from graphene_django import DjangoObjectType
 
 from apps.core.models import User
+
+from .commons import BaseDeleteMutation
 
 
 class UserNode(DjangoObjectType):
@@ -13,3 +17,60 @@ class UserNode(DjangoObjectType):
             "last_name": ["icontains"],
         }
         interfaces = (relay.Node,)
+
+
+class UserAddMutation(relay.ClientIDMutation):
+    user = graphene.Field(UserNode)
+
+    class Input:
+        first_name = graphene.String()
+        last_name = graphene.String()
+        email = graphene.String(required=True)
+        password = graphene.String(required=True)
+
+    @classmethod
+    def mutate_and_get_payload(cls, root, info, **kwargs):
+        user = User.objects.create_user(
+            kwargs.pop("email"), password=kwargs.pop("password"), **kwargs
+        )
+
+        return cls(user=user)
+
+
+class UserUpdateMutation(relay.ClientIDMutation):
+    user = graphene.Field(UserNode)
+
+    model_class = User
+
+    class Input:
+        id = graphene.ID(required=True)
+        first_name = graphene.String()
+        last_name = graphene.String()
+        email = graphene.String()
+        password = graphene.String()
+
+    @classmethod
+    def mutate_and_get_payload(cls, root, info, **kwargs):
+        graphql_id = kwargs.pop("id")
+
+        _, _pk = graphql_relay.from_global_id(graphql_id)
+        user = User.objects.get(pk=_pk)
+        new_password = kwargs.pop("password", None)
+
+        if new_password:
+            user.set_password(new_password)
+
+        for attr, value in kwargs.items():
+            setattr(user, attr, value)
+
+        user.save()
+
+        return cls(user=user)
+
+
+class UserDeleteMutation(BaseDeleteMutation):
+    user = graphene.Field(UserNode)
+    model_class = User
+
+    class Input:
+        id = graphene.ID()

--- a/terraso_backend/tests/graphql/test_user_mutations.py
+++ b/terraso_backend/tests/graphql/test_user_mutations.py
@@ -1,0 +1,107 @@
+import pytest
+from graphene_django.utils.testing import graphql_query
+
+from apps.core.models import User
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def client_query(client):
+    def _client_query(*args, **kwargs):
+        return graphql_query(*args, **kwargs, client=client)
+
+    return _client_query
+
+
+def test_users_add(client_query):
+    user_email = "Testing User"
+    user_password = "123456"
+    response = client_query(
+        """
+        mutation addUser($input: UserAddMutationInput!){
+          addUser(input: $input) {
+            user {
+              id
+              email
+            }
+          }
+        }
+        """,
+        variables={"input": {"email": user_email, "password": user_password}},
+    )
+    user_result = response.json()["data"]["addUser"]["user"]
+
+    assert user_result["id"]
+    assert user_result["email"] == user_email
+
+
+def test_users_update(client_query, users):
+    old_user = _get_users(client_query)[0]
+    new_data = {
+        "id": old_user["id"],
+        "firstName": "Tina",
+        "lastName": "Testing",
+        "email": "tinatesting@example.com",
+        "password": "mynewsafepass",
+    }
+    response = client_query(
+        """
+        mutation updateUser($input: UserUpdateMutationInput!) {
+          updateUser(input: $input) {
+            user {
+              id
+              firstName
+              lastName
+              email
+            }
+          }
+        }
+        """,
+        variables={"input": new_data},
+    )
+    user_result = response.json()["data"]["updateUser"]["user"]
+    del new_data["password"]
+
+    assert user_result == new_data
+
+
+def test_users_delete(client_query, users):
+    old_user = _get_users(client_query)[0]
+    response = client_query(
+        """
+        mutation deleteUser($input: UserDeleteMutationInput!){
+          deleteUser(input: $input) {
+            user {
+              id
+              email
+            }
+          }
+        }
+        """,
+        variables={"input": {"id": old_user["id"]}},
+    )
+
+    user_result = response.json()["data"]["deleteUser"]["user"]
+
+    assert user_result["email"] == old_user["email"]
+    assert not User.objects.filter(email=user_result["email"])
+
+
+def _get_users(client_query):
+    response = client_query(
+        """
+        {
+          users {
+            edges {
+              node {
+                id
+                email
+              }
+            }
+          }
+        }
+        """
+    )
+    edges = response.json()["data"]["users"]["edges"]
+    return [e["node"] for e in edges]


### PR DESCRIPTION
This change adds the mutations (add, update, delete) to the User
resource on GraphQL API. The operations are still a bit naive and can be
improved in matters of validation, mainly. Anyway, this already looks
like a good increment to the project.

Since User creation and update are a bit different from other models because
of password, the add and update mutations don't inherit from base write
mutation class.