### PR TITLE
refactor: makes Landscape mutations inherit from common Mutations

### DIFF
--- a/terraso_backend/apps/graphql/schema/landscapes.py
+++ b/terraso_backend/apps/graphql/schema/landscapes.py
@@ -1,9 +1,10 @@
 import graphene
-import graphql_relay
 from graphene import relay
 from graphene_django import DjangoObjectType
 
 from apps.core.models import Landscape
+
+from .commons import BaseDeleteMutation, BaseWriteMutation
 
 
 class LandscapeNode(DjangoObjectType):
@@ -13,34 +14,11 @@ class LandscapeNode(DjangoObjectType):
         interfaces = (relay.Node,)
 
 
-class LandscapeWriteMutation(relay.ClientIDMutation):
+class LandscapeAddMutation(BaseWriteMutation):
     landscape = graphene.Field(LandscapeNode)
 
-    @classmethod
-    def mutate_and_get_payload(cls, root, info, **kwargs):
-        """
-        This is the method performed everytime this mutation is submitted.
-        Since this is the base class for write operations, this method will be
-        called both when adding and updating Landscapes. The `kwargs` receives
-        a dictionary with all inputs informed.
-        """
-        graphql_id = kwargs.pop("id", None)
+    model_class = Landscape
 
-        if graphql_id:
-            _, _pk = graphql_relay.from_global_id(graphql_id)
-            landscape = Landscape.objects.get(pk=_pk)
-        else:
-            landscape = Landscape()
-
-        for attr, value in kwargs.items():
-            setattr(landscape, attr, value)
-
-        landscape.save()
-
-        return LandscapeWriteMutation(landscape=landscape)
-
-
-class LandscapeAddMutation(LandscapeWriteMutation):
     class Input:
         name = graphene.String(required=True)
         description = graphene.String()
@@ -48,7 +26,11 @@ class LandscapeAddMutation(LandscapeWriteMutation):
         location = graphene.String()
 
 
-class LandscapeUpdateMutation(LandscapeWriteMutation):
+class LandscapeUpdateMutation(BaseWriteMutation):
+    landscape = graphene.Field(LandscapeNode)
+
+    model_class = Landscape
+
     class Input:
         id = graphene.ID(required=True)
         name = graphene.String()
@@ -57,21 +39,10 @@ class LandscapeUpdateMutation(LandscapeWriteMutation):
         location = graphene.String()
 
 
-class LandscapeDeleteMutation(relay.ClientIDMutation):
+class LandscapeDeleteMutation(BaseDeleteMutation):
     landscape = graphene.Field(LandscapeNode)
+
+    model_class = Landscape
 
     class Input:
         id = graphene.ID()
-
-    @classmethod
-    def mutate_and_get_payload(cls, root, info, **kwargs):
-        graphql_id = kwargs.pop("id", None)
-
-        if not graphql_id:
-            return LandscapeDeleteMutation(landscape=None)
-
-        _, _pk = graphql_relay.from_global_id(graphql_id)
-        landscape = Landscape.objects.get(pk=_pk)
-        landscape.delete()
-
-        return LandscapeDeleteMutation(landscape=landscape)


### PR DESCRIPTION
This change makes Landscape mutations inherit from generic mutations.
This way they don't need to implement common procedures to add, update
and delete.