### PR TITLE
fix: pre-commit scripts on MacOS

### DIFF
--- a/scripts/commit-msg.sample
+++ b/scripts/commit-msg.sample
@@ -26,7 +26,7 @@ def main():
     print("")
     print("[optional footer]")
     print("")
-    print(f"Allowed types: {CC_TYPES}")
+    print("Allowed types: " + CC_TYPES)
 
     sys.exit(1)
 

--- a/scripts/pre-commit.sample
+++ b/scripts/pre-commit.sample
@@ -1,2 +1,2 @@
-#!/usr/bin/sh
+#!/bin/sh
 make pre-commit


### PR DESCRIPTION
Changes to make pre-commit scripts work on macOS. To update the scripts,
run `make setup-git-hooks`.