### PR TITLE
feat: call model validation on GraphQL mutations

### DIFF
--- a/terraso_backend/apps/graphql/exceptions.py
+++ b/terraso_backend/apps/graphql/exceptions.py
@@ -1,0 +1,12 @@
+class GraphQLValidationException(Exception):
+    @classmethod
+    def from_validation_error(cls, validation_error):
+        messages = []
+
+        for field, validation_errors in validation_error.error_dict.items():
+            for error in validation_errors:
+                messages.extend([f"field={field}, error={message}" for message in error.messages])
+
+        error_message = ";".join(messages)
+
+        return cls(error_message)

--- a/terraso_backend/apps/graphql/schema/commons.py
+++ b/terraso_backend/apps/graphql/schema/commons.py
@@ -1,7 +1,10 @@
 import re
 
 import graphql_relay
+from django.core.exceptions import ValidationError
 from graphene import relay
+
+from apps.graphql.exceptions import GraphQLValidationException
 
 RE_CAMEL_TO_SNAKE_CASE = re.compile(r"(?<!^)(?=[A-Z])")
 
@@ -27,6 +30,11 @@ class BaseWriteMutation(relay.ClientIDMutation):
 
         for attr, value in kwargs.items():
             setattr(model_instance, attr, value)
+
+        try:
+            model_instance.full_clean()
+        except ValidationError as exc:
+            raise GraphQLValidationException.from_validation_error(exc)
 
         model_instance.save()
 

--- a/terraso_backend/apps/graphql/schema/group_associations.py
+++ b/terraso_backend/apps/graphql/schema/group_associations.py
@@ -1,8 +1,10 @@
 import graphene
+from django.core.exceptions import ValidationError
 from graphene import relay
 from graphene_django import DjangoObjectType
 
 from apps.core.models import Group, GroupAssociation
+from apps.graphql.exceptions import GraphQLValidationException
 
 from .commons import BaseDeleteMutation
 
@@ -32,6 +34,11 @@ class GroupAssociationAddMutation(relay.ClientIDMutation):
         group_association = GroupAssociation()
         group_association.parent_group = Group.objects.get(slug=kwargs.pop("parent_group_slug"))
         group_association.child_group = Group.objects.get(slug=kwargs.pop("child_group_slug"))
+
+        try:
+            group_association.full_clean()
+        except ValidationError as exc:
+            raise GraphQLValidationException.from_validation_error(exc)
 
         group_association.save()
 

--- a/terraso_backend/apps/graphql/schema/landscape_groups.py
+++ b/terraso_backend/apps/graphql/schema/landscape_groups.py
@@ -1,9 +1,11 @@
 import graphene
 import graphql_relay
+from django.core.exceptions import ValidationError
 from graphene import relay
 from graphene_django import DjangoObjectType
 
 from apps.core.models import Group, Landscape, LandscapeGroup
+from apps.graphql.exceptions import GraphQLValidationException
 
 from .commons import BaseDeleteMutation
 
@@ -49,6 +51,11 @@ class LandscapeGroupWriteMutation(relay.ClientIDMutation):
         default_group = kwargs.pop("is_default_landscape_group", None)
         if default_group is not None:
             landscape_group.is_default_landscape_group = default_group
+
+        try:
+            landscape_group.full_clean()
+        except ValidationError as exc:
+            raise GraphQLValidationException.from_validation_error(exc)
 
         landscape_group.save()
 

--- a/terraso_backend/apps/graphql/schema/memberships.py
+++ b/terraso_backend/apps/graphql/schema/memberships.py
@@ -1,9 +1,11 @@
 import graphene
 import graphql_relay
+from django.core.exceptions import ValidationError
 from graphene import relay
 from graphene_django import DjangoObjectType
 
 from apps.core.models import Group, Membership, User
+from apps.graphql.exceptions import GraphQLValidationException
 
 from .commons import BaseDeleteMutation
 
@@ -38,6 +40,11 @@ class MembershipWriteMutation(relay.ClientIDMutation):
             membership.group = Group.objects.get(slug=kwargs.pop("group_slug"))
 
         membership.user_role = Membership.get_user_role_from_text(kwargs.pop("user_role", None))
+
+        try:
+            membership.full_clean()
+        except ValidationError as exc:
+            raise GraphQLValidationException.from_validation_error(exc)
 
         membership.save()
 

--- a/terraso_backend/tests/graphql/mutations/test_group_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_group_mutations.py
@@ -26,14 +26,35 @@ def test_groups_add(client_query):
     assert group_result["name"] == group_name
 
 
+def test_groups_add_duplicated(client_query, groups):
+    group_name = groups[0].name
+    response = client_query(
+        """
+        mutation addGroup($input: GroupAddMutationInput!){
+          addGroup(input: $input) {
+            group {
+              id
+              name
+            }
+          }
+        }
+        """,
+        variables={"input": {"name": group_name}},
+    )
+    error_result = response.json()["errors"][0]
+
+    assert error_result
+    assert "field=name" in error_result["message"]
+
+
 def test_groups_update(client_query, groups):
     old_group = _get_groups(client_query)[0]
     new_data = {
         "id": old_group["id"],
         "description": "New description",
         "name": "New Name",
-        "website": "www.example.com/updated-group",
-        "email": "a-new-email@example.com"
+        "website": "https://www.example.com/updated-group",
+        "email": "a-new-email@example.com",
     }
     response = client_query(
         """

--- a/terraso_backend/tests/graphql/mutations/test_landscape_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_landscape_mutations.py
@@ -26,13 +26,34 @@ def test_landscapes_add(client_query):
     assert landscape_result["name"] == landscape_name
 
 
+def test_landscapes_add_duplicated(client_query, landscapes):
+    landscape_name = landscapes[0].name
+    response = client_query(
+        """
+        mutation addLandscape($input: LandscapeAddMutationInput!){
+          addLandscape(input: $input) {
+            landscape {
+              id
+              name
+            }
+          }
+        }
+        """,
+        variables={"input": {"name": landscape_name}},
+    )
+    error_result = response.json()["errors"][0]
+
+    assert error_result
+    assert "field=name" in error_result["message"]
+
+
 def test_landscapes_update(client_query, landscapes):
     old_landscape = _get_landscapes(client_query)[0]
     new_data = {
         "id": old_landscape["id"],
         "description": "New description",
         "name": "New Name",
-        "website": "www.example.com/updated-landscape",
+        "website": "https://www.example.com/updated-landscape",
     }
     response = client_query(
         """


### PR DESCRIPTION
This change calls for Django model validation[1] before database writing
during the GraphQL mutations (add and update). This implementation was
done having in mind the GraphQL specs about response errors.

According to the GraphQL Spec[2]:
> A response to a GraphQL request must be a map.
> If the request raised any errors, the response map must contain an
> entry with key errors.

Taking this into consideration and the only way to return errors on
response supported by graphene-django, this implementation of model
validation has to raise an exception during the mutation execution.
This exception will be caught and handled by the graphene-django
view and the proper error element will be added to the response
payload.

A custom GraphQL validation exception were created both to have a
semantic error, but also to implement the logic of extracting the error
messages from the Django ValidationError and putting into one single
message. Currently, graphene-django supports only one error message 
per response.

This is part of:
- #17 

[1] - https://docs.djangoproject.com/en/3.2/ref/models/instances/#validating-objects
[2] - http://spec.graphql.org/October2021/#sec-Response-Format