### PR TITLE
fix: flaky Membership mutation test

### DIFF
--- a/terraso_backend/tests/graphql/conftest.py
+++ b/terraso_backend/tests/graphql/conftest.py
@@ -29,7 +29,7 @@ def landscapes():
 
 @pytest.fixture
 def groups():
-    return mixer.cycle(4).blend(Group)
+    return mixer.cycle(5).blend(Group)
 
 
 @pytest.fixture
@@ -39,7 +39,7 @@ def subgroups():
 
 @pytest.fixture
 def users():
-    return mixer.cycle(2).blend(User)
+    return mixer.cycle(5).blend(User)
 
 
 @pytest.fixture
@@ -58,7 +58,10 @@ def group_associations(groups, subgroups):
 @pytest.fixture
 def memberships(groups, users):
     return mixer.cycle(5).blend(
-        Membership, group=mixer.SELECT, user=mixer.SELECT, user_role=Membership.ROLE_MEMBER
+        Membership,
+        group=(g for g in groups),
+        user=(u for u in users),
+        user_role=Membership.ROLE_MEMBER,
     )
 
 


### PR DESCRIPTION
Before this change, it was being possible to have more then one
membership for the same user in a given group. This was causing the
delete mutation test randomly fail, not because of process failure, but
because the way the result were being checked. This change makes sure
only one user will be present on each group for GraphQL tests.

This is the quick win fix. Since there's a possibility of implementing
soft delete (so, changing the way to check object removal), let's move
on with this implementation at the moment.