### PR TITLE
feat: improve filter and field on GraphQL API

### DIFF
--- a/terraso_backend/apps/graphql/schema/group_associations.py
+++ b/terraso_backend/apps/graphql/schema/group_associations.py
@@ -10,7 +10,12 @@ from .commons import BaseDeleteMutation
 class GroupAssociationNode(DjangoObjectType):
     class Meta:
         model = GroupAssociation
-        filter_fields = ("parent_group", "child_group")
+        filter_fields = {
+            "parent_group": ["exact"],
+            "child_group": ["exact"],
+            "parent_group__slug": ["icontains"],
+            "child_group__slug": ["icontains"],
+        }
         fields = ("parent_group", "child_group")
         interfaces = (relay.Node,)
 

--- a/terraso_backend/apps/graphql/schema/groups.py
+++ b/terraso_backend/apps/graphql/schema/groups.py
@@ -1,38 +1,36 @@
 import graphene
 from graphene import relay
 from graphene_django import DjangoObjectType
-from graphene_django.filter import DjangoFilterConnectionField
 
 from apps.core.models import Group
 
 from .commons import BaseDeleteMutation, BaseWriteMutation
-from .group_associations import GroupAssociationNode
-from .memberships import MembershipNode
 
 
 class GroupNode(DjangoObjectType):
-    associations_as_parent = DjangoFilterConnectionField(GroupAssociationNode)
-    associations_as_child = DjangoFilterConnectionField(GroupAssociationNode)
-    memberships = DjangoFilterConnectionField(MembershipNode)
-
     class Meta:
         model = Group
         filter_fields = {
             "name": ["exact", "icontains", "istartswith"],
             "slug": ["icontains"],
             "description": ["icontains"],
-            "associations_as_parent": ["exact"],
-            "associations_as_child": ["exact"],
-            "members__email": ["icontains"],
+            "associations_as_parent__child_group": ["exact"],
+            "associations_as_child__parent_group": ["exact"],
+            "associations_as_parent__child_group__slug": ["icontains"],
+            "associations_as_child__parent_group__slug": ["icontains"],
             "memberships": ["exact"],
         }
+        fields = (
+            "name",
+            "slug",
+            "description",
+            "website",
+            "email",
+            "memberships",
+            "associations_as_parent",
+            "associations_as_child",
+        )
         interfaces = (relay.Node,)
-
-    def resolve_associations_as_parent(self, info):
-        return self.associations_as_parent.all()
-
-    def resolve_associations_as_child(self, info):
-        return self.associations_as_child.all()
 
 
 class GroupAddMutation(BaseWriteMutation):

--- a/terraso_backend/apps/graphql/schema/landscape_groups.py
+++ b/terraso_backend/apps/graphql/schema/landscape_groups.py
@@ -11,7 +11,13 @@ from .commons import BaseDeleteMutation
 class LandscapeGroupNode(DjangoObjectType):
     class Meta:
         model = LandscapeGroup
-        filter_fields = ("landscape", "group", "is_default_landscape_group")
+        filter_fields = {
+            "landscape": ["exact"],
+            "landscape__slug": ["icontains"],
+            "group": ["exact"],
+            "group__slug": ["icontains"],
+            "is_default_landscape_group": ["exact"],
+        }
         fields = ("landscape", "group", "is_default_landscape_group")
         interfaces = (relay.Node,)
 

--- a/terraso_backend/apps/graphql/schema/landscapes.py
+++ b/terraso_backend/apps/graphql/schema/landscapes.py
@@ -10,7 +10,13 @@ from .commons import BaseDeleteMutation, BaseWriteMutation
 class LandscapeNode(DjangoObjectType):
     class Meta:
         model = Landscape
-        filter_fields = ["name", "description", "groups"]
+        filter_fields = {
+            "name": ["icontains"],
+            "description": ["icontains"],
+            "website": ["icontains"],
+            "location": ["icontains"],
+        }
+        fields = ("name", "slug", "description", "website", "location", "associated_groups")
         interfaces = (relay.Node,)
 
 

--- a/terraso_backend/apps/graphql/schema/memberships.py
+++ b/terraso_backend/apps/graphql/schema/memberships.py
@@ -11,8 +11,14 @@ from .commons import BaseDeleteMutation
 class MembershipNode(DjangoObjectType):
     class Meta:
         model = Membership
-        filter_fields = ["group", "user", "user_role"]
-        fields = ["group", "user", "user_role"]
+        filter_fields = {
+            "group": ["exact"],
+            "user": ["exact"],
+            "user_role": ["exact"],
+            "group__slug": ["icontains"],
+            "user__email": ["icontains"],
+        }
+        fields = ("group", "user", "user_role")
         interfaces = (relay.Node,)
 
 

--- a/terraso_backend/apps/graphql/schema/users.py
+++ b/terraso_backend/apps/graphql/schema/users.py
@@ -16,6 +16,7 @@ class UserNode(DjangoObjectType):
             "first_name": ["icontains"],
             "last_name": ["icontains"],
         }
+        fields = ("email", "first_name", "last_name", "memberships")
         interfaces = (relay.Node,)
 
 


### PR DESCRIPTION
This change improves the filters and the fields specifications on
GraphQL API. After this, there will be more options to filter entities
and more consistency over available fields across different entities.
Before this change the control fields `created_at` and `updated_at` were
available through the API, for example.