### PR TITLE
feat: add Group email on add/update mutations

### DIFF
--- a/terraso_backend/apps/graphql/schema/groups.py
+++ b/terraso_backend/apps/graphql/schema/groups.py
@@ -44,6 +44,7 @@ class GroupAddMutation(BaseWriteMutation):
         name = graphene.String(required=True)
         description = graphene.String()
         website = graphene.String()
+        email = graphene.String()
 
 
 class GroupUpdateMutation(BaseWriteMutation):
@@ -56,6 +57,7 @@ class GroupUpdateMutation(BaseWriteMutation):
         name = graphene.String()
         description = graphene.String()
         website = graphene.String()
+        email = graphene.String()
 
 
 class GroupDeleteMutation(BaseDeleteMutation):

--- a/terraso_backend/tests/graphql/mutations/test_group_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_group_mutations.py
@@ -33,6 +33,7 @@ def test_groups_update(client_query, groups):
         "description": "New description",
         "name": "New Name",
         "website": "www.example.com/updated-group",
+        "email": "a-new-email@example.com"
     }
     response = client_query(
         """
@@ -43,6 +44,7 @@ def test_groups_update(client_query, groups):
               name
               description
               website
+              email
             }
           }
         }


### PR DESCRIPTION
This change adds the new Group field email to the write (add/update)
mutations.