### PR TITLE
feat: improve filters by slug on Groups and Landscapes

### DIFF
--- a/terraso_backend/apps/graphql/schema/groups.py
+++ b/terraso_backend/apps/graphql/schema/groups.py
@@ -12,7 +12,7 @@ class GroupNode(DjangoObjectType):
         model = Group
         filter_fields = {
             "name": ["exact", "icontains", "istartswith"],
-            "slug": ["icontains"],
+            "slug": ["exact", "icontains"],
             "description": ["icontains"],
             "associations_as_parent__child_group": ["exact"],
             "associations_as_child__parent_group": ["exact"],

--- a/terraso_backend/apps/graphql/schema/landscapes.py
+++ b/terraso_backend/apps/graphql/schema/landscapes.py
@@ -13,10 +13,18 @@ class LandscapeNode(DjangoObjectType):
         filter_fields = {
             "name": ["icontains"],
             "description": ["icontains"],
+            "slug": ["exact", "icontains"],
             "website": ["icontains"],
             "location": ["icontains"],
         }
-        fields = ("name", "slug", "description", "website", "location", "associated_groups")
+        fields = (
+            "name",
+            "slug",
+            "description",
+            "website",
+            "location",
+            "associated_groups",
+        )
         interfaces = (relay.Node,)
 
 


### PR DESCRIPTION
This change adds the filter by slug to the Landscapes GraphQL query and
improve the filter on Group adding the exact comparison.

This fix:
- #42 