### PR TITLE
feat: add Group filter to get independent groups

### DIFF
--- a/terraso_backend/apps/graphql/schema/groups.py
+++ b/terraso_backend/apps/graphql/schema/groups.py
@@ -20,6 +20,7 @@ class GroupNode(DjangoObjectType):
             "associations_as_child__parent_group__slug": ["icontains"],
             "memberships": ["exact"],
             "associated_landscapes__is_default_landscape_group": ["exact"],
+            "associated_landscapes": ["isnull"],
             "members__email": ["exact"],
         }
         fields = (


### PR DESCRIPTION
This change adds a filter to the Group GraphQL schema, so it makes
possible to filter by Groups that aren't associated to any Landscape.