### PR TITLE
feat: add authentication callback for Google and Apple

### DIFF
--- a/.env
+++ b/.env
@@ -6,7 +6,10 @@ DATABASE_URL=postgres://postgres:postgres@db:5432/terraso_backend
 DATABASE_EXTERNAL_PORT=5432
 ALLOWED_HOSTS=*
 PYTHONBREAKPOINT=ipdb.set_trace
-CORS_ORIGIN_WHITELIST=http://localhost:3000
+
+WEB_CLIENT_ENDPOINT=http://127.0.0.1:3000
+CORS_ORIGIN_WHITELIST=http://127.0.0.1:3000
+
 AIRTABLE_API_KEY=your-key-here
 
 GOOGLE_CLIENT_ID=client-id

--- a/terraso_backend/apps/auth/urls.py
+++ b/terraso_backend/apps/auth/urls.py
@@ -1,11 +1,16 @@
 from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
 
-from apps.auth.views import AppleAuthorizeView, GoogleAuthorizeView
+from apps.auth.views import AppleAuthorizeView, GoogleAuthorizeView, GoogleCallbackView
 
 app_name = "apps.auth"
 
 urlpatterns = [
     path("apple/authorize", csrf_exempt(AppleAuthorizeView.as_view()), name="apple-authorize"),
     path("google/authorize", csrf_exempt(GoogleAuthorizeView.as_view()), name="google-authorize"),
+    path(
+        "google/callback",
+        csrf_exempt(GoogleCallbackView.as_view()),
+        name="google-callback",
+    ),
 ]

--- a/terraso_backend/apps/auth/urls.py
+++ b/terraso_backend/apps/auth/urls.py
@@ -1,12 +1,22 @@
 from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
 
-from apps.auth.views import AppleAuthorizeView, GoogleAuthorizeView, GoogleCallbackView
+from apps.auth.views import (
+    AppleAuthorizeView,
+    AppleCallbackView,
+    GoogleAuthorizeView,
+    GoogleCallbackView,
+)
 
 app_name = "apps.auth"
 
 urlpatterns = [
     path("apple/authorize", csrf_exempt(AppleAuthorizeView.as_view()), name="apple-authorize"),
+    path(
+        "apple/callback",
+        csrf_exempt(AppleCallbackView.as_view()),
+        name="apple-callback",
+    ),
     path("google/authorize", csrf_exempt(GoogleAuthorizeView.as_view()), name="google-authorize"),
     path(
         "google/callback",

--- a/terraso_backend/apps/auth/views.py
+++ b/terraso_backend/apps/auth/views.py
@@ -54,37 +54,47 @@ class AppleAuthorizeView(View):
     def get(self, request, *args, **kwargs):
         return JsonResponse({"request_url": AppleProvider.login_url()})
 
+
+class AppleCallbackView(View):
     def post(self, request, *args, **kwargs):
-        try:
-            request_data = json.loads(request.body)
-        except json.decoder.JSONDecodeError:
-            return JsonResponse(
-                {"error": "The authorization request expects a JSON body"}, status=400
-            )
+        authorization_code = request.POST.get("code")
+        error = request.POST.get("error")
+
+        if error:
+            return HttpResponse(f"Error: {error}", status=400)
+
+        if not authorization_code:
+            return HttpResponse("Error: no authorization code informed", status=400)
 
         try:
-            authorization_code = request_data["code"]
+            apple_user_data = json.loads(request.POST.get("user", "{}"))
+            first_name = apple_user_data["name"]["firstName"]
+            last_name = apple_user_data["name"]["lastName"]
+        except json.JSONDecodeError:
+            return HttpResponse("Error: couldn't parse User data from Apple", status=400)
         except KeyError:
-            return JsonResponse(
-                {"error": "The authorization request expects a 'code' parameter"}, status=400
-            )
-
-        first_name = request_data.get("first_name", "")
-        last_name = request_data.get("last_name", "")
+            return HttpResponse("Error: couldn't get User name from Apple", status=400)
 
         try:
             user = AccountService().sign_up_with_apple(
                 authorization_code, first_name=first_name, last_name=last_name
             )
         except Exception as exc:
-            return JsonResponse({"error": str(exc)}, status=400)
+            return HttpResponse(f"Error: {exc}", status=400)
 
-        return JsonResponse(
-            {
-                "user": {
-                    "email": user.email,
-                    "first_name": user.first_name,
-                    "last_name": user.last_name,
-                },
-            }
+        user_data = {
+            "email": user.email,
+            "user": {
+                "first_name": user.first_name,
+                "last_name": user.last_name,
+            },
+        }
+
+        response = HttpResponseRedirect(settings.WEB_CLIENT_URL)
+        response.set_cookie(
+            "user",
+            json.dumps(user_data),
+            domain=settings.AUTH_COOKIE_DOMAIN,
         )
+
+        return response

--- a/terraso_backend/apps/auth/views.py
+++ b/terraso_backend/apps/auth/views.py
@@ -1,7 +1,8 @@
 import json
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.http import JsonResponse
+from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.views import View
 
 from .providers import AppleProvider, GoogleProvider
@@ -14,35 +15,39 @@ class GoogleAuthorizeView(View):
     def get(self, request, *args, **kwargs):
         return JsonResponse({"request_url": GoogleProvider.login_url()})
 
-    def post(self, request, *args, **kwargs):
-        try:
-            request_data = json.loads(request.body)
-        except json.decoder.JSONDecodeError:
-            return JsonResponse(
-                {"error": "The authorization request expects a JSON body"}, status=400
-            )
 
-        try:
-            authorization_code = request_data["code"]
-        except KeyError:
-            return JsonResponse(
-                {"error": "The authorization request expects a 'code' parameter"}, status=400
-            )
+class GoogleCallbackView(View):
+    def get(self, request, *args, **kwargs):
+        authorization_code = request.GET.get("code")
+        error = request.GET.get("error")
+
+        if error:
+            return HttpResponse(f"Error: {error}", status=400)
+
+        if not authorization_code:
+            return HttpResponse("Error: no authorization code informed", status=400)
 
         try:
             user = AccountService().sign_up_with_google(authorization_code)
         except Exception as exc:
-            return JsonResponse({"error": str(exc)}, status=400)
+            return HttpResponse(f"Error: {exc}", status=400)
 
-        return JsonResponse(
-            {
-                "user": {
-                    "email": user.email,
-                    "first_name": user.first_name,
-                    "last_name": user.last_name,
-                },
+        user_data = {
+            "user": {
+                "email": user.email,
+                "first_name": user.first_name,
+                "last_name": user.last_name,
             }
+        }
+
+        response = HttpResponseRedirect(settings.WEB_CLIENT_URL)
+        response.set_cookie(
+            "user",
+            json.dumps(user_data),
+            domain=settings.AUTH_COOKIE_DOMAIN,
         )
+
+        return response
 
 
 class AppleAuthorizeView(View):

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -113,10 +113,11 @@ GRAPHENE = {
     "SCHEMA": "apps.graphql.schema.schema",
 }
 
+WEB_CLIENT_URL = config("WEB_CLIENT_ENDPOINT", default="")
+AUTH_COOKIE_DOMAIN = config("AUTH_COOKIE_DOMAIN", default="terraso.org")
 CORS_ORIGIN_WHITELIST = config("CORS_ORIGIN_WHITELIST", default=[], cast=config.list)
 
 AIRTABLE_API_KEY = config("AIRTABLE_API_KEY", default="")
-
 
 GOOGLE_CLIENT_ID = config("GOOGLE_CLIENT_ID", default="")
 GOOGLE_CLIENT_SECRET = config("GOOGLE_CLIENT_SECRET", default="")


### PR DESCRIPTION
This change adds the endpoint responsible for processing the Apple
and Google callback after user authorize Terraso application access 
their data. By the end of the success process, the API procedure will
redirect user back to the web client application with auth details 
attached in a cookie.

It's important to mention that the cookie value isn't still a JWT because
this part depends on integrating this PR with the following one:

- #48 

I intend to do that in a separated PR.