### PR TITLE
fix: set one cookie for each JWT token after sign up

### DIFF
--- a/terraso_backend/apps/auth/views.py
+++ b/terraso_backend/apps/auth/views.py
@@ -35,13 +35,9 @@ class GoogleCallbackView(View):
         except Exception as exc:
             return HttpResponse(f"Error: {exc}", status=400)
 
-        tokens = {
-            "access_token": access_token,
-            "refresh_token": refresh_token,
-        }
-
         response = HttpResponseRedirect(settings.WEB_CLIENT_URL)
-        response.set_cookie("tokens", json.dumps(tokens), domain=settings.AUTH_COOKIE_DOMAIN)
+        response.set_cookie("atoken", access_token, domain=settings.AUTH_COOKIE_DOMAIN)
+        response.set_cookie("rtoken", refresh_token, domain=settings.AUTH_COOKIE_DOMAIN)
 
         return response
 
@@ -81,13 +77,9 @@ class AppleCallbackView(View):
         except Exception as exc:
             return HttpResponse(f"Error: {exc}", status=400)
 
-        tokens = {
-            "access_token": access_token,
-            "refresh_token": refresh_token,
-        }
-
         response = HttpResponseRedirect(settings.WEB_CLIENT_URL)
-        response.set_cookie("tokens", json.dumps(tokens), domain=settings.AUTH_COOKIE_DOMAIN)
+        response.set_cookie("atoken", access_token, domain=settings.AUTH_COOKIE_DOMAIN)
+        response.set_cookie("rtoken", refresh_token, domain=settings.AUTH_COOKIE_DOMAIN)
 
         return response
 

--- a/terraso_backend/tests/auth/test_views.py
+++ b/terraso_backend/tests/auth/test_views.py
@@ -40,7 +40,8 @@ def test_get_google_callback(client, access_tokens_google, respx_mock):
     response = client.get(url, {"code": "testing-code-google-auth"})
 
     assert response.status_code == 302
-    assert response.cookies.get("tokens")
+    assert response.cookies.get("atoken")
+    assert response.cookies.get("rtoken")
 
 
 def test_get_google_callback_without_code(client):
@@ -87,7 +88,8 @@ def test_post_apple_callback(client, access_tokens_apple, respx_mock):
         )
 
     assert response.status_code == 302
-    assert response.cookies.get("tokens")
+    assert response.cookies.get("atoken")
+    assert response.cookies.get("rtoken")
 
 
 def test_post_apple_callback_without_code(client):


### PR DESCRIPTION
This change updates the callback process of sign up to create two
cookies for access token and refresh token respectively. Each cookie 
(`atoken`, `rtoken`) will keep its own token instead of serializing a
JSON object for that. This is necessary both to make client work 
more straightforward and to avoid serialization errors.