### PR TITLE
fix: returns 401 status code for unauthenticated requests

### DIFF
--- a/terraso_backend/apps/auth/views.py
+++ b/terraso_backend/apps/auth/views.py
@@ -128,7 +128,7 @@ class CheckUserView(View):
     def get(self, request, *args, **kwargs):
         if not request.user.is_authenticated:
             return JsonResponse(
-                {"error": "Permission denied"}, status=403
+                {"error": "Unauthenticated request."}, status=401
             )
 
         return JsonResponse(

--- a/terraso_backend/apps/graphql/views.py
+++ b/terraso_backend/apps/graphql/views.py
@@ -6,7 +6,7 @@ class TerrasoGraphQLView(GraphQLView):
         # TODO: uncomment following code when client ready for authentication
         #  if not request.user.is_authenticated:
         #      return JsonResponse(
-        #          {"error": "Permission denied"}, status=403
+        #          {"error": "Unauthenticated request"}, status=401
         #      )
 
         return super().dispatch(request, *args, **kwargs)

--- a/terraso_backend/tests/auth/test_views.py
+++ b/terraso_backend/tests/auth/test_views.py
@@ -192,7 +192,7 @@ def test_get_user_information_not_logged_in(client):
     url = reverse("terraso_auth:user")
     response = client.get(url)
 
-    assert response.status_code == 403
+    assert response.status_code == 401
     assert "error" in response.json()
 
 


### PR DESCRIPTION
This change updates the HTTP response status code for unauthenticated
requests. Before it was returning 403 (Forbidden) while 401
(Unauthorized) is more appropriate.
