### PR TITLE
fix: gracefully handle nth apple login

### DIFF
--- a/terraso_backend/apps/auth/services.py
+++ b/terraso_backend/apps/auth/services.py
@@ -36,12 +36,16 @@ class AccountService:
         if not tokens.is_valid:
             raise Exception("Error fetching auth tokens: " + tokens.error_description)
 
+        name_defaults = {}
+        if first_name:
+            name_defaults["first_name"] = first_name
+
+        if last_name:
+            name_defaults["last_name"] = last_name
+
         user, _ = User.objects.update_or_create(
             email=tokens.open_id.email,
-            defaults={
-                "first_name": first_name,
-                "last_name": last_name,
-            },
+            defaults=name_defaults,
         )
 
         return user

--- a/terraso_backend/apps/auth/views.py
+++ b/terraso_backend/apps/auth/views.py
@@ -51,6 +51,8 @@ class AppleCallbackView(View):
     def post(self, request, *args, **kwargs):
         authorization_code = request.POST.get("code")
         error = request.POST.get("error")
+        first_name = None
+        last_name = None
 
         if error:
             return HttpResponse(f"Error: {error}", status=400)
@@ -60,8 +62,9 @@ class AppleCallbackView(View):
 
         try:
             apple_user_data = json.loads(request.POST.get("user", "{}"))
-            first_name = apple_user_data["name"]["firstName"]
-            last_name = apple_user_data["name"]["lastName"]
+            if "name" in apple_user_data:
+                first_name = apple_user_data["name"]["firstName"]
+                last_name = apple_user_data["name"]["lastName"]
         except json.JSONDecodeError:
             return HttpResponse("Error: couldn't parse User data from Apple", status=400)
         except KeyError:


### PR DESCRIPTION
## Description
Since first and last names are not supplied by Apple on logins after the first, don't attempt to use null/empty fields or insert them in to the database.

Resolves the following errors:
```
Error: couldn't get User name from Apple
```

```
Error: null value in column "first_name" of relation "core_user" violates not-null constraint
DETAIL: Failing row contains (, null, f, null, null, f, t, 2021-12-24 02:58:45.630905+00,
6323b526-d75d-43fd-bc0d-eeb2d66422ba, 2021-12-24 02:58:45.631401+00, 2021-12-24 03:19:11.411189+00, 
xxxx@gmail.com).
```

### Verification steps
1. Sign in to Terraso with Apple
2. Log out
3. Sign in to Terraso with Apple