### PR TITLE
fix: Apple login after sign-up

### DIFF
--- a/terraso_backend/apps/auth/views.py
+++ b/terraso_backend/apps/auth/views.py
@@ -60,12 +60,11 @@ class AppleCallbackView(View):
 
         try:
             apple_user_data = json.loads(request.POST.get("user", "{}"))
-            first_name = apple_user_data["name"]["firstName"]
-            last_name = apple_user_data["name"]["lastName"]
         except json.JSONDecodeError:
             return HttpResponse("Error: couldn't parse User data from Apple", status=400)
-        except KeyError:
-            return HttpResponse("Error: couldn't get User name from Apple", status=400)
+
+        first_name = apple_user_data.get("name", {}).get("firstName", "")
+        last_name = apple_user_data.get("name", {}).get("lastName", "")
 
         try:
             user = AccountService().sign_up_with_apple(


### PR DESCRIPTION
This change updates the Apple process for logins after the sign-up.
Since Apple shares user name only during the first authentication flow
(sign up), the process cannot consider the user names will always be
available.

The previous implementation was allowing to update user names with empty
string, specially during Apple sign in, but it was also possible for
Google. This change fixes that and assure the user names are updated only
if there's some content.