### PR TITLE
feat: enhance authentication failure response codes

### DIFF
--- a/terraso_backend/apps/auth/exceptions.py
+++ b/terraso_backend/apps/auth/exceptions.py
@@ -1,0 +1,2 @@
+class ExpiredTokenError(Exception):
+    pass

--- a/terraso_backend/apps/auth/services.py
+++ b/terraso_backend/apps/auth/services.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 
+from .exceptions import ExpiredTokenError
 from .providers import AppleProvider, GoogleProvider
 
 User = get_user_model()
@@ -71,7 +72,10 @@ class JWTService:
         return jwt.encode(payload, self.JWT_SECRET, algorithm=self.JWT_ALGORITHM)
 
     def verify_token(self, token):
-        return jwt.decode(token, self.JWT_SECRET, algorithms=self.JWT_ALGORITHM)
+        try:
+            return jwt.decode(token, self.JWT_SECRET, algorithms=self.JWT_ALGORITHM)
+        except jwt.exceptions.ExpiredSignatureError as e:
+            raise ExpiredTokenError(e)
 
     def _get_base_payload(self, user):
         return {

--- a/terraso_backend/tests/auth/conftest.py
+++ b/terraso_backend/tests/auth/conftest.py
@@ -58,5 +58,11 @@ def refresh_token(user):
 
 @pytest.fixture
 @freeze_time(timezone.now() - timedelta(days=10))
+def expired_access_token(user):
+    return JWTService().create_access_token(user)
+
+
+@pytest.fixture
+@freeze_time(timezone.now() - timedelta(days=10))
 def expired_refresh_token(user):
     return JWTService().create_refresh_token(user)

--- a/terraso_backend/tests/auth/test_views.py
+++ b/terraso_backend/tests/auth/test_views.py
@@ -231,6 +231,16 @@ def test_get_user_information_not_logged_in(client):
     assert "error" in response.json()
 
 
+def test_get_user_information_with_expired_token(client, expired_access_token):
+    url = reverse("terraso_auth:user")
+    response = client.get(
+        url, HTTP_AUTHORIZATION=f"Bearer {expired_access_token}", HTTP_ACCEPT="application/json"
+    )
+
+    assert response.status_code == 403
+    assert "error" in response.json()
+
+
 def test_get_user_information(client, user, access_token):
     url = reverse("terraso_auth:user")
     response = client.get(url, HTTP_AUTHORIZATION=f"Bearer {access_token}")


### PR DESCRIPTION
This change enhances the current implementation of
`JWTService.verify_token` to make it return a specific exception when
the token signature is expired. This way, the client of the service can
implement specific handlers for this case.

It also adapts the JWT authentication middleware so it now properly
answers requests with 401 Unauthorized (general token verification
errors) and 403 Forbidden (expired token errors).

It fixes:
- #61 