### PR TITLE
refactor: creates AuthenticationRequiredMixin to auth check

### DIFF
--- a/terraso_backend/apps/auth/mixins.py
+++ b/terraso_backend/apps/auth/mixins.py
@@ -1,0 +1,11 @@
+from django.http.response import JsonResponse
+
+
+class AuthenticationRequiredMixin:
+    def dispatch(self, request, *args, **kwargs):
+        if not request.user.is_authenticated:
+            return JsonResponse(
+                {"error": "Unauthenticated request"}, status=401
+            )
+
+        return super().dispatch(request, *args, **kwargs)

--- a/terraso_backend/apps/auth/views.py
+++ b/terraso_backend/apps/auth/views.py
@@ -5,6 +5,7 @@ from django.contrib.auth import get_user_model
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.views import View
 
+from .mixins import AuthenticationRequiredMixin
 from .providers import AppleProvider, GoogleProvider
 from .services import AccountService, JWTService
 
@@ -131,11 +132,8 @@ class RefreshAccessTokenView(View):
         )
 
 
-class CheckUserView(View):
+class CheckUserView(AuthenticationRequiredMixin, View):
     def get(self, request, *args, **kwargs):
-        if not request.user.is_authenticated:
-            return JsonResponse({"error": "Unauthenticated request."}, status=401)
-
         return JsonResponse(
             {
                 "user": {

--- a/terraso_backend/apps/graphql/views.py
+++ b/terraso_backend/apps/graphql/views.py
@@ -1,12 +1,7 @@
 from graphene_django.views import GraphQLView
 
+from apps.auth.mixins import AuthenticationRequiredMixin
 
-class TerrasoGraphQLView(GraphQLView):
-    def dispatch(self, request, *args, **kwargs):
-        # TODO: uncomment following code when client ready for authentication
-        #  if not request.user.is_authenticated:
-        #      return JsonResponse(
-        #          {"error": "Unauthenticated request"}, status=401
-        #      )
 
-        return super().dispatch(request, *args, **kwargs)
+class TerrasoGraphQLView(AuthenticationRequiredMixin, GraphQLView):
+    pass

--- a/terraso_backend/tests/graphql/test_auth_request.py
+++ b/terraso_backend/tests/graphql/test_auth_request.py
@@ -1,0 +1,22 @@
+import pytest
+
+pytestmark = pytest.mark.django_db
+
+
+def test_graphql_query_with_expired_token_returns_401_error(expired_client_query):
+    response = expired_client_query(
+        """
+        query {
+            landscapes {
+                edges {
+                    node {
+                        slug
+                    }
+                }
+            }
+        }
+        """
+    )
+
+    assert response.status_code == 401
+    assert "error" in response.json()


### PR DESCRIPTION
This change creates a mixin to centralize the check if user is logged in
or not. It also properly builds the response object with the expected
status code. It's worth to see that for requests with authentication
failure, the response will always be a JSON response with a proper HTTP
status code (401).

The added mixin is intended to be used instead of multiplying across the
code base the verification `if not user.is_authenticated`. So, on every
view that is making this check, the `AuthenticationRequiredMixin` should
be used instead.

The Django's `LoginRequiredMixin` wasn't used because:

1 - It returns 403 responses for non authenticated requests;
2 - There are only redirect or HTML responses in case of authentication
  failure and we need a JSON response since it's more convenient for our
  use case.

As any other mixin, the `AuthenticationRequiredMixin` should be at the
leftmost position in the inheritance list.