### PR TITLE
feat: use model pk UUID as API id

### DIFF
--- a/terraso_backend/apps/graphql/schema/commons.py
+++ b/terraso_backend/apps/graphql/schema/commons.py
@@ -9,6 +9,14 @@ from apps.graphql.exceptions import GraphQLValidationException
 RE_CAMEL_TO_SNAKE_CASE = re.compile(r"(?<!^)(?=[A-Z])")
 
 
+def from_camel_to_snake_case(model_class):
+    """
+    Transforms camel case to snake case. MyModel becomes my_model.
+    """
+    model_class_name = model_class.__name__
+    return RE_CAMEL_TO_SNAKE_CASE.sub("_", model_class_name).lower()
+
+
 class BaseWriteMutation(relay.ClientIDMutation):
     model_class = None
 
@@ -38,7 +46,7 @@ class BaseWriteMutation(relay.ClientIDMutation):
 
         model_instance.save()
 
-        result_kwargs = {cls.model_class.__name__.lower(): model_instance}
+        result_kwargs = {from_camel_to_snake_case(cls.model_class): model_instance}
 
         return cls(**result_kwargs)
 
@@ -57,15 +65,6 @@ class BaseDeleteMutation(relay.ClientIDMutation):
             model_instance = cls.model_class.objects.get(pk=_pk)
             model_instance.delete()
 
-        result_kwargs = {cls._get_result_attribute_name(): model_instance}
+        result_kwargs = {from_camel_to_snake_case(cls.model_class): model_instance}
 
         return cls(**result_kwargs)
-
-    @classmethod
-    def _get_result_attribute_name(cls):
-        """
-        Transforms model class name from camel case to snake case. MyModel
-        becomes my_model.
-        """
-        model_class_name = cls.model_class.__name__
-        return RE_CAMEL_TO_SNAKE_CASE.sub("_", model_class_name).lower()

--- a/terraso_backend/apps/graphql/schema/commons.py
+++ b/terraso_backend/apps/graphql/schema/commons.py
@@ -1,6 +1,5 @@
 import re
 
-import graphql_relay
 from django.core.exceptions import ValidationError
 from graphene import relay
 
@@ -28,11 +27,10 @@ class BaseWriteMutation(relay.ClientIDMutation):
         called both when adding and updating a model. The `kwargs` receives
         a dictionary with all inputs informed.
         """
-        graphql_id = kwargs.pop("id", None)
+        _id = kwargs.pop("id", None)
 
-        if graphql_id:
-            _, _pk = graphql_relay.from_global_id(graphql_id)
-            model_instance = cls.model_class.objects.get(pk=_pk)
+        if _id:
+            model_instance = cls.model_class.objects.get(pk=_id)
         else:
             model_instance = cls.model_class()
 
@@ -56,13 +54,12 @@ class BaseDeleteMutation(relay.ClientIDMutation):
 
     @classmethod
     def mutate_and_get_payload(cls, root, info, **kwargs):
-        graphql_id = kwargs.pop("id", None)
+        _id = kwargs.pop("id", None)
 
-        if not graphql_id:
+        if not _id:
             model_instance = None
         else:
-            _, _pk = graphql_relay.from_global_id(graphql_id)
-            model_instance = cls.model_class.objects.get(pk=_pk)
+            model_instance = cls.model_class.objects.get(pk=_id)
             model_instance.delete()
 
         result_kwargs = {from_camel_to_snake_case(cls.model_class): model_instance}

--- a/terraso_backend/apps/graphql/schema/group_associations.py
+++ b/terraso_backend/apps/graphql/schema/group_associations.py
@@ -10,6 +10,8 @@ from .commons import BaseDeleteMutation
 
 
 class GroupAssociationNode(DjangoObjectType):
+    id = graphene.ID(source='pk', required=True)
+
     class Meta:
         model = GroupAssociation
         filter_fields = {

--- a/terraso_backend/apps/graphql/schema/groups.py
+++ b/terraso_backend/apps/graphql/schema/groups.py
@@ -8,6 +8,8 @@ from .commons import BaseDeleteMutation, BaseWriteMutation
 
 
 class GroupNode(DjangoObjectType):
+    id = graphene.ID(source='pk', required=True)
+
     class Meta:
         model = Group
         filter_fields = {

--- a/terraso_backend/apps/graphql/schema/landscape_groups.py
+++ b/terraso_backend/apps/graphql/schema/landscape_groups.py
@@ -1,5 +1,4 @@
 import graphene
-import graphql_relay
 from django.core.exceptions import ValidationError
 from graphene import relay
 from graphene_django import DjangoObjectType
@@ -11,6 +10,8 @@ from .commons import BaseDeleteMutation
 
 
 class LandscapeGroupNode(DjangoObjectType):
+    id = graphene.ID(source="pk", required=True)
+
     class Meta:
         model = LandscapeGroup
         filter_fields = {
@@ -35,11 +36,10 @@ class LandscapeGroupWriteMutation(relay.ClientIDMutation):
         called both when adding and updating Landscape Groups. The `kwargs`
         receives a dictionary with all inputs informed.
         """
-        graphql_id = kwargs.pop("id", None)
+        _id = kwargs.pop("id", None)
 
-        if graphql_id:
-            _, _pk = graphql_relay.from_global_id(graphql_id)
-            landscape_group = LandscapeGroup.objects.get(pk=_pk)
+        if _id:
+            landscape_group = LandscapeGroup.objects.get(pk=_id)
             new_landscape = kwargs.pop("landscape_slug", None)
             new_group = kwargs.pop("group_slug", None)
 

--- a/terraso_backend/apps/graphql/schema/landscapes.py
+++ b/terraso_backend/apps/graphql/schema/landscapes.py
@@ -8,6 +8,8 @@ from .commons import BaseDeleteMutation, BaseWriteMutation
 
 
 class LandscapeNode(DjangoObjectType):
+    id = graphene.ID(source='pk', required=True)
+
     class Meta:
         model = Landscape
         filter_fields = {

--- a/terraso_backend/apps/graphql/schema/memberships.py
+++ b/terraso_backend/apps/graphql/schema/memberships.py
@@ -1,5 +1,4 @@
 import graphene
-import graphql_relay
 from django.core.exceptions import ValidationError
 from graphene import relay
 from graphene_django import DjangoObjectType
@@ -11,6 +10,8 @@ from .commons import BaseDeleteMutation
 
 
 class MembershipNode(DjangoObjectType):
+    id = graphene.ID(source='pk', required=True)
+
     class Meta:
         model = Membership
         filter_fields = {
@@ -35,11 +36,10 @@ class MembershipWriteMutation(relay.ClientIDMutation):
         called both when adding and updating Memberships. The `kwargs` receives
         a dictionary with all inputs informed.
         """
-        graphql_id = kwargs.pop("id", None)
+        _id = kwargs.pop("id", None)
 
-        if graphql_id:
-            _, _pk = graphql_relay.from_global_id(graphql_id)
-            membership = Membership.objects.get(pk=_pk)
+        if _id:
+            membership = Membership.objects.get(pk=_id)
         else:
             membership = Membership()
             membership.user = User.objects.get(email=kwargs.pop("user_email"))

--- a/terraso_backend/apps/graphql/schema/users.py
+++ b/terraso_backend/apps/graphql/schema/users.py
@@ -1,5 +1,4 @@
 import graphene
-import graphql_relay
 from graphene import relay
 from graphene_django import DjangoObjectType
 
@@ -9,6 +8,8 @@ from .commons import BaseDeleteMutation
 
 
 class UserNode(DjangoObjectType):
+    id = graphene.ID(source="pk", required=True)
+
     class Meta:
         model = User
         filter_fields = {
@@ -52,10 +53,9 @@ class UserUpdateMutation(relay.ClientIDMutation):
 
     @classmethod
     def mutate_and_get_payload(cls, root, info, **kwargs):
-        graphql_id = kwargs.pop("id")
+        _id = kwargs.pop("id")
 
-        _, _pk = graphql_relay.from_global_id(graphql_id)
-        user = User.objects.get(pk=_pk)
+        user = User.objects.get(pk=_id)
         new_password = kwargs.pop("password", None)
 
         if new_password:

--- a/terraso_backend/tests/graphql/mutations/test_group_associations_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_group_associations_mutations.py
@@ -65,45 +65,23 @@ def test_group_associations_add_duplicated(client_query, group_associations):
 
 
 def test_group_associations_delete(client_query, group_associations):
-    old_group_association = _get_group_associations(client_query)[0]
+    old_group_association = group_associations[0]
     response = client_query(
         """
         mutation deleteGroupAssociation($input: GroupAssociationDeleteMutationInput!){
           deleteGroupAssociation(input: $input) {
             groupAssociation {
-              id
               parentGroup { slug }
               childGroup { slug }
             }
           }
         }
         """,
-        variables={"input": {"id": old_group_association["id"]}},
+        variables={"input": {"id": str(old_group_association.id)}},
     )
     group_association = response.json()["data"]["deleteGroupAssociation"]["groupAssociation"]
 
-    assert group_association["id"]
     assert not GroupAssociation.objects.filter(
         parent_group__slug=group_association["parentGroup"]["slug"],
         child_group__slug=group_association["childGroup"]["slug"],
     )
-
-
-def _get_group_associations(client_query):
-    response = client_query(
-        """
-        {
-          groupAssociations {
-            edges {
-              node {
-                id
-                parentGroup { slug }
-                childGroup { slug }
-              }
-            }
-          }
-        }
-        """
-    )
-    edges = response.json()["data"]["groupAssociations"]["edges"]
-    return [e["node"] for e in edges]

--- a/terraso_backend/tests/graphql/mutations/test_group_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_group_mutations.py
@@ -48,9 +48,9 @@ def test_groups_add_duplicated(client_query, groups):
 
 
 def test_groups_update(client_query, groups):
-    old_group = _get_groups(client_query)[0]
+    old_group = groups[0]
     new_data = {
-        "id": old_group["id"],
+        "id": str(old_group.id),
         "description": "New description",
         "name": "New Name",
         "website": "https://www.example.com/updated-group",
@@ -78,42 +78,22 @@ def test_groups_update(client_query, groups):
 
 
 def test_groups_delete(client_query, groups):
-    old_group = _get_groups(client_query)[0]
+    old_group = groups[0]
     response = client_query(
         """
         mutation deleteGroup($input: GroupDeleteMutationInput!){
           deleteGroup(input: $input) {
             group {
-              id
               slug
             }
           }
         }
 
         """,
-        variables={"input": {"id": old_group["id"]}},
+        variables={"input": {"id": str(old_group.id)}},
     )
 
     group_result = response.json()["data"]["deleteGroup"]["group"]
 
-    assert group_result["slug"] == old_group["slug"]
+    assert group_result["slug"] == old_group.slug
     assert not Group.objects.filter(slug=group_result["slug"])
-
-
-def _get_groups(client_query):
-    response = client_query(
-        """
-        {
-          groups {
-            edges {
-              node {
-                id
-                slug
-              }
-            }
-          }
-        }
-        """
-    )
-    edges = response.json()["data"]["groups"]["edges"]
-    return [e["node"] for e in edges]

--- a/terraso_backend/tests/graphql/mutations/test_landscape_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_landscape_mutations.py
@@ -48,9 +48,9 @@ def test_landscapes_add_duplicated(client_query, landscapes):
 
 
 def test_landscapes_update(client_query, landscapes):
-    old_landscape = _get_landscapes(client_query)[0]
+    old_landscape = landscapes[0]
     new_data = {
-        "id": old_landscape["id"],
+        "id": str(old_landscape.id),
         "description": "New description",
         "name": "New Name",
         "website": "https://www.example.com/updated-landscape",
@@ -76,42 +76,22 @@ def test_landscapes_update(client_query, landscapes):
 
 
 def test_landscapes_delete(client_query, landscapes):
-    old_landscape = _get_landscapes(client_query)[0]
+    old_landscape = landscapes[0]
     response = client_query(
         """
         mutation deleteLandscape($input: LandscapeDeleteMutationInput!){
           deleteLandscape(input: $input) {
             landscape {
-              id
               slug
             }
           }
         }
 
         """,
-        variables={"input": {"id": old_landscape["id"]}},
+        variables={"input": {"id": str(old_landscape.id)}},
     )
 
     landscape_result = response.json()["data"]["deleteLandscape"]["landscape"]
 
-    assert landscape_result["slug"] == old_landscape["slug"]
+    assert landscape_result["slug"] == old_landscape.slug
     assert not Landscape.objects.filter(slug=landscape_result["slug"])
-
-
-def _get_landscapes(client_query):
-    response = client_query(
-        """
-        {
-          landscapes {
-            edges {
-              node {
-                id
-                slug
-              }
-            }
-          }
-        }
-        """
-    )
-    edges = response.json()["data"]["landscapes"]["edges"]
-    return [e["node"] for e in edges]

--- a/terraso_backend/tests/graphql/mutations/test_user_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_user_mutations.py
@@ -28,9 +28,9 @@ def test_users_add(client_query):
 
 
 def test_users_update(client_query, users):
-    old_user = _get_users(client_query)[0]
+    old_user = users[0]
     new_data = {
-        "id": old_user["id"],
+        "id": str(old_user.id),
         "firstName": "Tina",
         "lastName": "Testing",
         "email": "tinatesting@example.com",
@@ -58,41 +58,21 @@ def test_users_update(client_query, users):
 
 
 def test_users_delete(client_query, users):
-    old_user = _get_users(client_query)[0]
+    old_user = users[0]
     response = client_query(
         """
         mutation deleteUser($input: UserDeleteMutationInput!){
           deleteUser(input: $input) {
             user {
-              id
               email
             }
           }
         }
         """,
-        variables={"input": {"id": old_user["id"]}},
+        variables={"input": {"id": str(old_user.id)}},
     )
 
     user_result = response.json()["data"]["deleteUser"]["user"]
 
-    assert user_result["email"] == old_user["email"]
+    assert user_result["email"] == old_user.email
     assert not User.objects.filter(email=user_result["email"])
-
-
-def _get_users(client_query):
-    response = client_query(
-        """
-        {
-          users {
-            edges {
-              node {
-                id
-                email
-              }
-            }
-          }
-        }
-        """
-    )
-    edges = response.json()["data"]["users"]["edges"]
-    return [e["node"] for e in edges]


### PR DESCRIPTION
This change updates the GraphQL API schemas to use the same database id
(UUID) on model schemas.