### PR TITLE
build: check if docker is running before calling docker-compose up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,8 @@ setup-git-hooks:
 
 pre-commit: lint
 
-run: check_rebuild
-	@docker-compose up
+run:
+	@./scripts/docker.sh
 
 setup: build setup-pre-commit
 

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+DOCKER_ERRORS=$(docker info 2>/dev/null | grep -c ERROR)
+if [ "${DOCKER_ERRORS}" = "0" ]; then
+  docker-compose up
+else
+  echo "Docker is not running. Please start it and try 'make run' again."
+fi


### PR DESCRIPTION
## Description
Check if Docker is running before calling `docker-compose` up. Avoids long, messy errors like so:
```
$ make run
./scripts/rebuild.sh
Checking if we need a docker images rebuild before running this command
docker build --tag=techmatters/terraso_backend --file=Dockerfile .
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
ERRO[0000] Can't add file /Users/paul/.dev/backend/.git/hooks/pre-push.sample to tar: io: read/write on closed pipe 
make[1]: *** [build_base_image] Error 1
make: *** [check_rebuild] Error 2
```