### PR TITLE
feat: adds Group Manager creation when Group is created

### DIFF
--- a/terraso_backend/apps/core/models/groups.py
+++ b/terraso_backend/apps/core/models/groups.py
@@ -1,4 +1,4 @@
-from django.db import models
+from django.db import models, transaction
 from django.utils.translation import gettext_lazy as _
 
 from .commons import BaseModel, SlugModel
@@ -44,6 +44,20 @@ class Group(SlugModel):
     members = models.ManyToManyField(User, through="Membership")
 
     field_to_slug = "name"
+
+    def save(self, *args, **kwargs):
+        creating = not bool(self.pk)
+
+        with transaction.atomic():
+            super().save(*args, **kwargs)
+
+            if creating and self.created_by:
+                membership = Membership(
+                    group=self,
+                    user=self.created_by,
+                    user_role=Membership.ROLE_MANAGER,
+                )
+                membership.save()
 
     def __str__(self):
         return self.name

--- a/terraso_backend/apps/core/models/groups.py
+++ b/terraso_backend/apps/core/models/groups.py
@@ -46,9 +46,9 @@ class Group(SlugModel):
     field_to_slug = "name"
 
     def save(self, *args, **kwargs):
-        creating = not bool(self.pk)
-
         with transaction.atomic():
+            creating = not Group.objects.filter(pk=self.pk).exists()
+
             super().save(*args, **kwargs)
 
             if creating and self.created_by:

--- a/terraso_backend/apps/graphql/schema/memberships.py
+++ b/terraso_backend/apps/graphql/schema/memberships.py
@@ -41,9 +41,9 @@ class MembershipWriteMutation(relay.ClientIDMutation):
         if _id:
             membership = Membership.objects.get(pk=_id)
         else:
-            membership = Membership()
-            membership.user = User.objects.get(email=kwargs.pop("user_email"))
-            membership.group = Group.objects.get(slug=kwargs.pop("group_slug"))
+            group = Group.objects.get(slug=kwargs.pop("group_slug"))
+            user = User.objects.get(email=kwargs.pop("user_email"))
+            membership, _ = Membership.objects.get_or_create(user=user, group=group)
 
         membership.user_role = Membership.get_user_role_from_text(kwargs.pop("user_role", None))
 

--- a/terraso_backend/tests/core/models/test_groups.py
+++ b/terraso_backend/tests/core/models/test_groups.py
@@ -68,3 +68,12 @@ def test_membership_is_created_when_group_member_added():
 
     assert group.members.count() == 3
     assert Membership.objects.count() == 3
+
+
+def test_group_creator_becomes_manager():
+    user = mixer.blend(User)
+    group = mixer.blend(Group, pk=None, created_by=user)
+
+    manager_membership = Membership.objects.get(group=group, user=user)
+
+    assert manager_membership.user_role == Membership.ROLE_MANAGER

--- a/terraso_backend/tests/core/models/test_groups.py
+++ b/terraso_backend/tests/core/models/test_groups.py
@@ -72,7 +72,7 @@ def test_membership_is_created_when_group_member_added():
 
 def test_group_creator_becomes_manager():
     user = mixer.blend(User)
-    group = mixer.blend(Group, pk=None, created_by=user)
+    group = mixer.blend(Group, created_by=user)
 
     manager_membership = Membership.objects.get(group=group, user=user)
 

--- a/terraso_backend/tests/graphql/mutations/test_membership_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_membership_mutations.py
@@ -41,9 +41,10 @@ def test_membership_add(client_query, groups, users):
     assert membership["userRole"] == Membership.ROLE_MEMBER.upper()
 
 
-def test_membership_add_duplicated(client_query, memberships):
-    group = memberships[0].group
-    user = memberships[0].user
+def test_membership_adding_duplicated_returns_previously_created(client_query, memberships):
+    membership = memberships[0]
+    group = membership.group
+    user = membership.user
 
     response = client_query(
         """
@@ -69,9 +70,12 @@ def test_membership_add_duplicated(client_query, memberships):
             }
         },
     )
-    error_result = response.json()["errors"][0]
+    membership_response = response.json()["data"]["addMembership"]["membership"]
 
-    assert "Group and User already exists" in error_result["message"]
+    assert membership_response["id"] == str(membership.id)
+    assert membership_response["userRole"] == membership.user_role.upper()
+    assert membership_response["user"]["email"] == user.email
+    assert membership_response["group"]["slug"] == group.slug
 
 
 def test_membership_add_manager(client_query, groups, users):


### PR DESCRIPTION
This change updates the `Group.save()` method to automatically create a
`Membership` as role manager for the group creator.

It also updates the `addMembership` mutation on GraphQL to be
idempotent. It means that, if the same pair of `user` and `group` be
submitted to membership creation more than once, only one membership
will be created.

This change is necessary in a context where the web client is having to
create the Group manager directly because the back-end hadn't this
automatic creation implemented.

Now that the back-end implements the automatic manager creation, we have
to create the conditions to release it without breaking the current
implementation of web client.

So, after this change, we can release the automatic group manager
creation on the API side without the need to sync the web client update.

It depends on:
- #85 