### PR TITLE
fix: user names being updated on every sign in

### DIFF
--- a/terraso_backend/apps/auth/services.py
+++ b/terraso_backend/apps/auth/services.py
@@ -40,9 +40,12 @@ class AccountService:
         return self._persist_user(tokens.open_id.email, first_name=first_name, last_name=last_name)
 
     def _persist_user(self, email, first_name="", last_name="", profile_image_url=None):
-        profile_image_service = ProfileImageService()
-        user, _ = User.objects.get_or_create(email=email)
+        user, created = User.objects.get_or_create(email=email)
 
+        if not created:
+            return user
+
+        profile_image_service = ProfileImageService()
         update_name = first_name or last_name
 
         if first_name:

--- a/terraso_backend/tests/auth/test_services.py
+++ b/terraso_backend/tests/auth/test_services.py
@@ -2,12 +2,22 @@ from unittest import mock
 
 import pytest
 from httpx import Response
+from mixer.backend.django import mixer
 from moto import mock_s3
 
 from apps.auth.providers import AppleProvider, GoogleProvider
 from apps.auth.services import AccountService
+from apps.core.models import User
 
 pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def user():
+    first_name, last_name = "User", "Testing"
+    return mixer.blend(
+        User, first_name=first_name, last_name=last_name, email="testingterraso@example.com"
+    )
 
 
 @mock_s3
@@ -27,6 +37,19 @@ def test_sign_up_with_google_creates_user(mock_upload, respx_mock, access_tokens
     mock_upload.assert_called_once()
 
 
+def test_sign_in_with_google_doesnt_update_user_names(respx_mock, access_tokens_google, user):
+    respx_mock.post(GoogleProvider.GOOGLE_TOKEN_URI).mock(
+        return_value=Response(200, json=access_tokens_google)
+    )
+    service = AccountService()
+
+    user_result = service.sign_up_with_google("authorization_code")
+
+    assert user_result.email == user.email
+    assert user_result.last_name == user.last_name
+    assert user_result.first_name == user.first_name
+
+
 @mock_s3
 def test_sign_up_with_apple_creates_user(respx_mock, access_tokens_apple):
     respx_mock.post(AppleProvider.TOKEN_URI).mock(
@@ -43,7 +66,23 @@ def test_sign_up_with_apple_creates_user(respx_mock, access_tokens_apple):
     mock_secret.assert_called_once()
 
     assert user
-
     assert user.email == "testingterraso@example.com"
     assert user.first_name == "Testing"
     assert user.last_name == "Terraso"
+
+
+def test_sign_in_with_apple_doesnt_update_user_names(respx_mock, access_tokens_apple, user):
+    respx_mock.post(AppleProvider.TOKEN_URI).mock(
+        return_value=Response(200, json=access_tokens_apple)
+    )
+    service = AccountService()
+
+    with mock.patch("apps.auth.providers.AppleProvider._build_client_secret") as mock_secret:
+        mock_secret.return_value = "mocked-secret-value"
+        user_result = service.sign_up_with_apple(
+            "authorization_code", first_name="Testing", last_name="Terraso"
+        )
+
+    assert user_result.email == user.email
+    assert user_result.first_name == user.first_name
+    assert user_result.last_name == user.last_name


### PR DESCRIPTION
This change updates the Account Service to make sure the user name is
only set when user is created. If the user signing in was already
created on database, then their names will be left as is. This is
important because users might have had updated their names on Terraso
platform after the sign-up process.
