### PR TITLE
fix: get one node by id on GraphQL API

### DIFF
--- a/terraso_backend/apps/graphql/schema/__init__.py
+++ b/terraso_backend/apps/graphql/schema/__init__.py
@@ -1,7 +1,7 @@
 import graphene
-from graphene import relay
 from graphene_django.filter import DjangoFilterConnectionField
 
+from .commons import TerrasoRelayNode
 from .group_associations import (
     GroupAssociationAddMutation,
     GroupAssociationDeleteMutation,
@@ -35,13 +35,13 @@ from .users import UserAddMutation, UserDeleteMutation, UserNode, UserUpdateMuta
 
 
 class Query(graphene.ObjectType):
-    group = relay.Node.Field(GroupNode)
-    landscape = relay.Node.Field(LandscapeNode)
-    landscape_group = relay.Node.Field(LandscapeNode)
-    user = relay.Node.Field(UserNode)
-    landscape_group = relay.Node.Field(LandscapeGroupNode)
-    membership = relay.Node.Field(MembershipNode)
-    group_association = relay.Node.Field(GroupAssociationNode)
+    group = TerrasoRelayNode.Field(GroupNode)
+    landscape = TerrasoRelayNode.Field(LandscapeNode)
+    landscape_group = TerrasoRelayNode.Field(LandscapeNode)
+    user = TerrasoRelayNode.Field(UserNode)
+    landscape_group = TerrasoRelayNode.Field(LandscapeGroupNode)
+    membership = TerrasoRelayNode.Field(MembershipNode)
+    group_association = TerrasoRelayNode.Field(GroupAssociationNode)
     groups = DjangoFilterConnectionField(GroupNode)
     landscapes = DjangoFilterConnectionField(LandscapeNode)
     landscape_groups = DjangoFilterConnectionField(LandscapeGroupNode)

--- a/terraso_backend/apps/graphql/schema/commons.py
+++ b/terraso_backend/apps/graphql/schema/commons.py
@@ -16,6 +16,12 @@ def from_camel_to_snake_case(model_class):
     return RE_CAMEL_TO_SNAKE_CASE.sub("_", model_class_name).lower()
 
 
+class TerrasoRelayNode(relay.Node):
+    @staticmethod
+    def get_node_from_global_id(info, global_id, only_type=None):
+        return info.return_type.graphene_type._meta.model.objects.get(pk=global_id)
+
+
 class BaseWriteMutation(relay.ClientIDMutation):
     model_class = None
 

--- a/terraso_backend/tests/graphql/test_core_request.py
+++ b/terraso_backend/tests/graphql/test_core_request.py
@@ -22,6 +22,25 @@ def test_landscapes_query(client_query, landscapes):
         assert landscape.slug in landscapes_result
 
 
+def test_landscape_get_one_by_id(client_query, landscapes):
+    landscape = landscapes[0]
+    query = (
+        """
+        {landscape(id: "%s") {
+            id
+            slug
+          }
+        }
+        """
+        % landscape.id
+    )
+    response = client_query(query)
+    landscape_result = response.json()["data"]["landscape"]
+
+    assert landscape_result["id"] == str(landscape.id)
+    assert landscape_result["slug"] == landscape.slug
+
+
 def test_landscape_groups_query(client_query, landscape_groups):
     response = client_query(
         """
@@ -54,6 +73,23 @@ def test_landscape_groups_query(client_query, landscape_groups):
     assert landscapes_and_groups_expected == landscapes_and_groups_returned
 
 
+def test_landscape_group_get_one_by_id(client_query, landscape_groups):
+    landscape_group = landscape_groups[0]
+    query = (
+        """
+        {landscapeGroup(id: "%s") {
+          id
+        }}
+        """
+        % landscape_group.id
+    )
+    response = client_query(query)
+
+    landscape_group_response = response.json()["data"]["landscapeGroup"]
+
+    assert landscape_group_response["id"] == str(landscape_group.id)
+
+
 def test_groups_query(client_query, groups):
     response = client_query(
         """
@@ -71,6 +107,24 @@ def test_groups_query(client_query, groups):
 
     for group in groups:
         assert group.slug in groups_result
+
+
+def test_group_get_by_one_by_id(client_query, groups):
+    group = groups[0]
+    query = (
+        """
+        {group(id: "%s") {
+          id
+          slug
+        }}
+        """
+        % group.id
+    )
+    response = client_query(query)
+    group_result = response.json()["data"]["group"]
+
+    assert group_result["id"] == str(group.id)
+    assert group_result["slug"] == group.slug
 
 
 def test_group_associations_query(client_query, group_associations):
@@ -104,6 +158,23 @@ def test_group_associations_query(client_query, group_associations):
     assert associations_expected == associations_returned
 
 
+def test_group_association_get_one_by_id(client_query, group_associations):
+    group_association = group_associations[0]
+    query = (
+        """
+        {groupAssociation(id: "%s") {
+          id
+        }}
+        """
+        % group_association.id
+    )
+    response = client_query(query)
+
+    group_association_result = response.json()["data"]["groupAssociation"]
+
+    assert group_association_result["id"] == str(group_association.id)
+
+
 def test_memberships_query(client_query, memberships):
     response = client_query(
         """
@@ -132,6 +203,22 @@ def test_memberships_query(client_query, memberships):
     assert memberships_expected == memberships_returned
 
 
+def test_membership_get_one_by_id(client_query, memberships):
+    membership = memberships[0]
+    query = (
+        """
+        {membership(id: "%s") {
+          id
+        }}
+        """
+        % membership.id
+    )
+    response = client_query(query)
+    membership_result = response.json()["data"]["membership"]
+
+    assert membership_result["id"] == str(membership.id)
+
+
 def test_users_query(client_query, users):
     response = client_query(
         """
@@ -151,3 +238,22 @@ def test_users_query(client_query, users):
         user_node = next(item for item in users_result_nodes if item["email"] == user.email)
         assert user_node
         assert user.profile_image == user_node["profileImage"]
+
+
+def test_user_get_one_by_id(client_query, users):
+    user = users[0]
+    query = (
+        """
+        {user(id: "%s") {
+          id
+          email
+          profileImage
+        }}
+        """
+        % user.id
+    )
+    response = client_query(query)
+    user_result = response.json()["data"]["user"]
+    assert user_result["id"] == str(user.id)
+    assert user_result["email"] == user.email
+    assert user_result["profileImage"] == user.profile_image

--- a/terraso_backend/tests/graphql/test_core_request.py
+++ b/terraso_backend/tests/graphql/test_core_request.py
@@ -6,15 +6,13 @@ pytestmark = pytest.mark.django_db
 def test_landscapes_query(client_query, landscapes):
     response = client_query(
         """
-        query {
-            landscapes {
-                edges {
-                    node {
-                        slug
-                    }
-                }
+        {landscapes {
+          edges {
+            node {
+              slug
             }
-        }
+          }
+        }}
         """
     )
     edges = response.json()["data"]["landscapes"]["edges"]
@@ -59,15 +57,13 @@ def test_landscape_groups_query(client_query, landscape_groups):
 def test_groups_query(client_query, groups):
     response = client_query(
         """
-        query {
-            groups {
-                edges {
-                    node {
-                        slug
-                    }
-                }
+        {groups {
+          edges {
+            node {
+              slug
             }
-        }
+          }
+        }}
         """
     )
     edges = response.json()["data"]["groups"]["edges"]
@@ -139,16 +135,14 @@ def test_memberships_query(client_query, memberships):
 def test_users_query(client_query, users):
     response = client_query(
         """
-        query {
-            users {
-                edges {
-                    node {
-                        email
-                        profileImage
-                    }
-                }
+        {users {
+          edges {
+            node {
+              email
+              profileImage
             }
-        }
+          }
+        }}
         """
     )
     edges = response.json()["data"]["users"]["edges"]


### PR DESCRIPTION
This change fixes a bug inserted by the change that updated the GraphQL
API global ID for nodes to use model PK (Primary key). After that
change, that overridden default relay global ID, it wasn't possible any
more get one specific node by its ID.

What this change does is to create a custom relay Node that knows how to
search for a specific model from global ID, using its PK.