### PR TITLE
feat: allows only Group Manager update Group data

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,14 +4,14 @@
 #
 #    make lock-dev
 #
-anyio==3.4.0 \
-    --hash=sha256:24adc69309fb5779bc1e06158e143e0b6d2c56b302a3ac3de3083c705a6ed39d \
-    --hash=sha256:2855a9423524abcdd652d942f8932fda1735210f77a6b392eafd9ff34d3fe020
+anyio==3.5.0 \
+    --hash=sha256:a0aeffe2fb1fdf374a8e4b471444f0f3ac4fb9f5a5b542b48824475e0042a5a6 \
+    --hash=sha256:b5fa16c5ff93fa1046f2eeb5bbff2dad4d3514d6cda61d02816dba34fa8c3c2e
     # via httpcore
-appnope==0.1.2 \
-    --hash=sha256:93aa393e9d6c54c5cd570ccadd8edad61ea0c4b9ea7a01409020c9aa019eb442 \
-    --hash=sha256:dd83cd4b5b460958838f6eb3000c660b1f9caf2a5b1de4264e941512f603258a
-    # via ipython
+asttokens==2.0.5 \
+    --hash=sha256:0844691e88552595a6f4a4281a9f7f79b8dd45ca4ccea82e5e05b4bbdb76705c \
+    --hash=sha256:9a54c114f02c7a9480d56550932546a3f1fe71d8a02f1bc7ccd0ee3ee35cf4d5
+    # via stack-data
 attrs==21.4.0 \
     --hash=sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4 \
     --hash=sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd
@@ -23,14 +23,16 @@ backcall==0.2.0 \
 black==21.12b0 \
     --hash=sha256:77b80f693a569e2e527958459634f18df9b0ba2625ba4e0c2d5da5be42e6f2b3 \
     --hash=sha256:a615e69ae185e08fdd73e4715e260e2479c861b5740057fde6e8b4e3b7dd589f
-    # via -r requirements/dev.in
-boto3==1.20.30 \
-    --hash=sha256:7fbdf85db66e8f3ee38958994bb3957e9dc9b79b6ee064180278442cc87694eb \
-    --hash=sha256:e50827ccb217cadf61744fad3c0e4c7455bbbd6ed447868d04914cc5c8e6a978
+    # via
+    #   -r requirements/dev.in
+    #   ipython
+boto3==1.20.37 \
+    --hash=sha256:0e2f8aa8ee71f144d8afbe9ff7d0bb40525b94535e0695bdb200687970c9f452 \
+    --hash=sha256:55c7004af4296648ee497417dfc454d9c39770c265f67e28e1c5f10e11f3b644
     # via moto
-botocore==1.23.30 \
-    --hash=sha256:30c6566e68e680116a1949dd3a490a1f50ddaf9c195b1c85bada9d8af4163ad0 \
-    --hash=sha256:c6a60cffe095296b78ff03adae0fdf2875210a74531a0d1f68206091203573fe
+botocore==1.23.37 \
+    --hash=sha256:9ea3eb6e507684900418ad100e5accd1d98979d41c49bacf15f970f0d72f75d4 \
+    --hash=sha256:f3077f1ca19e6ab6b7a84c61e01e136a97c7732078a8d806908aee44f1042f5f
     # via
     #   boto3
     #   moto
@@ -175,12 +177,16 @@ cryptography==36.0.1 \
     --hash=sha256:ebc15b1c22e55c4d5566e3ca4db8689470a0ca2babef8e3a9ee057a8b82ce4b1 \
     --hash=sha256:ec63da4e7e4a5f924b90af42eddf20b698a70e58d86a72d943857c4c6045b3ee
     # via moto
-decorator==5.1.0 \
-    --hash=sha256:7b12e7c3c6ab203a29e157335e9122cb03de9ab7264b137594103fd4a683b374 \
-    --hash=sha256:e59913af105b9860aa2c8d3272d9de5a56a4e608db9a2f167a8480b323d529a7
+decorator==5.1.1 \
+    --hash=sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330 \
+    --hash=sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186
     # via
     #   ipdb
     #   ipython
+executing==0.8.2 \
+    --hash=sha256:32fc6077b103bd19e6494a72682d66d5763cf20a106d5aa7c5ccbea4e47b0df7 \
+    --hash=sha256:c23bf42e9a7b9b212f185b1b2c3c91feb895963378887bb10e64a2e612ec0023
+    # via stack-data
 faker==11.3.0 \
     --hash=sha256:61f97034cea252b8426d81810afab2f3c27b584f2b4313400a0cc83a9b013ded \
     --hash=sha256:adbe567e64da6a1097feacab699000e1ad16e17a6592a8f0ae1ee0b7fbf19887
@@ -197,9 +203,9 @@ h11==0.12.0 \
     --hash=sha256:36a3cb8c0a032f56e2da7084577878a035d3b61d104230d4bd49c0c6b555a9c6 \
     --hash=sha256:47222cb6067e4a307d535814917cd98fd0a57b6788ce715755fa2b6c28b56042
     # via httpcore
-httpcore==0.14.4 \
-    --hash=sha256:9410fe352bea732311f2b2bee0555c8cc5e62b9a73b9d3272fe125a2aa6eb28e \
-    --hash=sha256:d4305811f604d3c2e22869147392f134796976ff946c96a8cfba87f4e0171d83
+httpcore==0.14.5 \
+    --hash=sha256:2621ee769d0236574df51b305c5f4c69ca8f0c7b215221ad247b1ee42a9a9de1 \
+    --hash=sha256:435ab519628a6e2393f67812dea3ca5c6ad23b457412cd119295d9f906d96a2b
     # via httpx
 httpx==0.21.3 \
     --hash=sha256:7a3eb67ef0b8abbd6d9402248ef2f84a76080fa1c839f8662e6eb385640e445a \
@@ -219,9 +225,9 @@ iniconfig==1.1.1 \
 ipdb==0.13.9 \
     --hash=sha256:951bd9a64731c444fd907a5ce268543020086a697f6be08f7cc2c9a752a278c5
     # via -r requirements/dev.in
-ipython==7.31.0 \
-    --hash=sha256:346c74db7312c41fa566d3be45d2e759a528dcc2994fe48aac1a03a70cd668a3 \
-    --hash=sha256:4c4234cdcc6b8f87c5b5c7af9899aa696ac5cfcf0e9f6d0688018bbee5c73bce
+ipython==8.0.0 \
+    --hash=sha256:004a0d05aeecd32adec4841b6e2586d5ca35785b1477db4d8333a39333e0ce98 \
+    --hash=sha256:5b58cf977635abad74d76be49dbb2e97fddd825fb8503083d55496aa1160b854
     # via ipdb
 isort==5.10.1 \
     --hash=sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7 \
@@ -326,9 +332,9 @@ mixer==7.2.0 \
     --hash=sha256:7cc84aecea63144a12dd295ee6d407cd02298d1698e4794193e0776568788a78 \
     --hash=sha256:d5d6466bd6227f9d3c5002b443f01ca13f4cd8dc3bd5f7715f0788dc9632975f
     # via -r requirements/dev.in
-moto==2.3.0 \
-    --hash=sha256:0a1913f8cfe1ea8a14bf7807de1e34df9731818dca70c91f3f42015c2d7a102c \
-    --hash=sha256:0d6a179622bb9d0cd8141bb33d78882039ce7400aca3a8c07ad6d00076b60c62
+moto==2.3.2 \
+    --hash=sha256:0c29f5813d4db69b2f99c5538909a5aba0ba1cb91a74c19eddd9bfdc39ed2ff3 \
+    --hash=sha256:eaaed229742adbd1387383d113350ecd9222fc1e8f5611a9395a058c1eee4377
     # via -r requirements/dev.in
 mypy-extensions==0.4.3 \
     --hash=sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d \
@@ -370,6 +376,10 @@ ptyprocess==0.7.0 \
     --hash=sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35 \
     --hash=sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220
     # via pexpect
+pure-eval==0.2.1 \
+    --hash=sha256:0f04483b16c9429532d2c0ddc96e2b3bb6b2dc37a2bfb0e986248dbfd0b78873 \
+    --hash=sha256:94eeb505a88721bec7bb21a4ac49758b8b1a01530da1a70d4ffc1d9937689d71
+    # via stack-data
 py==1.11.0 \
     --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719 \
     --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378
@@ -427,13 +437,13 @@ requests==2.27.1 \
     # via
     #   moto
     #   responses
-responses==0.16.0 \
-    --hash=sha256:a2e3aca2a8277e61257cd3b1c154b1dd0d782b1ae3d38b7fa37cbe3feb531791 \
-    --hash=sha256:f358ef75e8bf431b0aa203cc62625c3a1c80a600dbe9de91b944bf4e9c600b92
+responses==0.17.0 \
+    --hash=sha256:e4fc472fb7374fb8f84fcefa51c515ca4351f198852b4eb7fc88223780b472ea \
+    --hash=sha256:ec675e080d06bf8d1fb5e5a68a1e5cd0df46b09c78230315f650af5e4036bec7
     # via moto
-respx==0.19.0 \
-    --hash=sha256:1ac1cc99bf892ffd3e33108ae43d71d8309a58ac226965f4bd81ec055600f265 \
-    --hash=sha256:4a09e15803c7450d45303520ec528794c9fd77b05984263bc83b78aabbb39413
+respx==0.19.1 \
+    --hash=sha256:4b13ba2aa4fc619ad5523786bacb4a565fab4ba3d02582b12f23942aa5a9bdf6 \
+    --hash=sha256:df26cf743f4c48bb38f134a3b0ec7384d5350671264c1c28bbddf41658d6f01a
     # via -r requirements/dev.in
 rfc3986[idna2008]==1.5.0 \
     --hash=sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835 \
@@ -447,6 +457,7 @@ six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via
+    #   asttokens
     #   python-dateutil
     #   responses
 sniffio==1.2.0 \
@@ -456,6 +467,10 @@ sniffio==1.2.0 \
     #   anyio
     #   httpcore
     #   httpx
+stack-data==0.1.4 \
+    --hash=sha256:02cc0683cbc445ae4ca8c4e3a0e58cb1df59f252efb0aa016b34804a707cf9bc \
+    --hash=sha256:7769ed2482ce0030e00175dd1bf4ef1e873603b6ab61cd3da443b410e64e9477
+    # via ipython
 text-unidecode==1.3 \
     --hash=sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8 \
     --hash=sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93
@@ -482,9 +497,9 @@ typing-extensions==4.0.1 \
     --hash=sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e \
     --hash=sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b
     # via black
-urllib3==1.26.7 \
-    --hash=sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece \
-    --hash=sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844
+urllib3==1.26.8 \
+    --hash=sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed \
+    --hash=sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c
     # via
     #   botocore
     #   requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,21 +8,21 @@ aniso8601==7.0.0 \
     --hash=sha256:513d2b6637b7853806ae79ffaca6f3e8754bdd547048f5ccc1420aec4b714f1e \
     --hash=sha256:d10a4bf949f619f719b227ef5386e31f49a2b6d453004b21f02661ccc8670c7b
     # via graphene
-anyio==3.4.0 \
-    --hash=sha256:24adc69309fb5779bc1e06158e143e0b6d2c56b302a3ac3de3083c705a6ed39d \
-    --hash=sha256:2855a9423524abcdd652d942f8932fda1735210f77a6b392eafd9ff34d3fe020
+anyio==3.5.0 \
+    --hash=sha256:a0aeffe2fb1fdf374a8e4b471444f0f3ac4fb9f5a5b542b48824475e0042a5a6 \
+    --hash=sha256:b5fa16c5ff93fa1046f2eeb5bbff2dad4d3514d6cda61d02816dba34fa8c3c2e
     # via httpcore
 asgiref==3.4.1 \
     --hash=sha256:4ef1ab46b484e3c706329cedeff284a5d40824200638503f5768edb6de7d58e9 \
     --hash=sha256:ffc141aa908e6f175673e7b1b3b7af4fdb0ecb738fc5c8b88f69f055c2415214
     # via django
-boto3==1.20.28 \
-    --hash=sha256:85287c742626baf0f0a1d5a2636db9483f95c9c1c9685599c3d5ae24ec24ace2 \
-    --hash=sha256:e7b8ef830b8f8770311d076cc89af35164b03bdf79683ea3a52b50c5f92be6d0
+boto3==1.20.37 \
+    --hash=sha256:0e2f8aa8ee71f144d8afbe9ff7d0bb40525b94535e0695bdb200687970c9f452 \
+    --hash=sha256:55c7004af4296648ee497417dfc454d9c39770c265f67e28e1c5f10e11f3b644
     # via -r requirements/base.in
-botocore==1.23.28 \
-    --hash=sha256:3a6e589486d1a269ea9c970da73f88e82fdfa6cb2ab4bb2a4b3010610adbde46 \
-    --hash=sha256:d04b0839de63929d7326e14a4680e7c46e7d32b2870c1031088bae5ba2850896
+botocore==1.23.37 \
+    --hash=sha256:9ea3eb6e507684900418ad100e5accd1d98979d41c49bacf15f970f0d72f75d4 \
+    --hash=sha256:f3077f1ca19e6ab6b7a84c61e01e136a97c7732078a8d806908aee44f1042f5f
     # via
     #   boto3
     #   s3transfer
@@ -123,9 +123,9 @@ django==3.2.11 \
     #   django-filter
     #   django-storages
     #   graphene-django
-django-cors-headers==3.10.1 \
-    --hash=sha256:1390b5846e9835b0911e2574409788af87cd9154246aafbdc8ec546c93698fe6 \
-    --hash=sha256:b5a874b492bcad99f544bb76ef679472259eb41ee5644ca62d1a94ddb26b7f6e
+django-cors-headers==3.11.0 \
+    --hash=sha256:a22be2befd4069c4fc174f11cf067351df5c061a3a5f94a01650b4e928b0372b \
+    --hash=sha256:eb98389bf7a2afc5d374806af4a9149697e3a6955b5a2dc2bf049f7d33647456
     # via -r requirements/base.in
 django-filter==21.1 \
     --hash=sha256:632a251fa8f1aadb4b8cceff932bb52fe2f826dd7dfe7f3eac40e5c463d6836e \
@@ -162,13 +162,13 @@ h11==0.12.0 \
     --hash=sha256:36a3cb8c0a032f56e2da7084577878a035d3b61d104230d4bd49c0c6b555a9c6 \
     --hash=sha256:47222cb6067e4a307d535814917cd98fd0a57b6788ce715755fa2b6c28b56042
     # via httpcore
-httpcore==0.14.4 \
-    --hash=sha256:9410fe352bea732311f2b2bee0555c8cc5e62b9a73b9d3272fe125a2aa6eb28e \
-    --hash=sha256:d4305811f604d3c2e22869147392f134796976ff946c96a8cfba87f4e0171d83
+httpcore==0.14.5 \
+    --hash=sha256:2621ee769d0236574df51b305c5f4c69ca8f0c7b215221ad247b1ee42a9a9de1 \
+    --hash=sha256:435ab519628a6e2393f67812dea3ca5c6ad23b457412cd119295d9f906d96a2b
     # via httpx
-httpx==0.21.2 \
-    --hash=sha256:6d88b1208f0996ee99c7a1e38fcfbdc66891c8fc583673337152681ac23585f6 \
-    --hash=sha256:c7c71345faa8983a094bbd24b5b5cc6f4bd274aadcb072a25b312cb209167aef
+httpx==0.21.3 \
+    --hash=sha256:7a3eb67ef0b8abbd6d9402248ef2f84a76080fa1c839f8662e6eb385640e445a \
+    --hash=sha256:df9a0fd43fa79dbab411d83eb1ea6f7a525c96ad92e60c2d7f40388971b25777
     # via -r requirements/base.in
 idna==3.3 \
     --hash=sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff \
@@ -224,6 +224,10 @@ rfc3986[idna2008]==1.5.0 \
     --hash=sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835 \
     --hash=sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97
     # via httpx
+rules==3.1 \
+    --hash=sha256:3293ef232d8ed86ec59dd1d993a745168ebee908a1f0ffb332ed0f3065b8ee57 \
+    --hash=sha256:b5e7d7b83dfab8895e901406f533325eccd96b2a38cc0362860c9b895aaad32f
+    # via -r requirements/base.in
 rx==1.6.1 \
     --hash=sha256:13a1d8d9e252625c173dc795471e614eadfe1cf40ffc684e08b8fff0d9748c23 \
     --hash=sha256:7357592bc7e881a95e0c2013b73326f704953301ab551fbc8133a6fadab84105
@@ -262,9 +266,9 @@ text-unidecode==1.3 \
     --hash=sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8 \
     --hash=sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93
     # via graphene-django
-urllib3==1.26.7 \
-    --hash=sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece \
-    --hash=sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844
+urllib3==1.26.8 \
+    --hash=sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed \
+    --hash=sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c
     # via botocore
 
 # WARNING: The following packages were not pinned, but pip requires them to be

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -9,4 +9,5 @@ dj-database-url
 prettyconf
 psycopg2
 pyjwt[crypto]
+rules
 boto3

--- a/terraso_backend/apps/core/models/commons.py
+++ b/terraso_backend/apps/core/models/commons.py
@@ -2,9 +2,10 @@ import uuid
 
 from django.db import models
 from django.utils.text import slugify
+from rules.contrib.models import RulesModelBase, RulesModelMixin
 
 
-class BaseModel(models.Model):
+class BaseModel(RulesModelMixin, models.Model, metaclass=RulesModelBase):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/terraso_backend/apps/core/models/groups.py
+++ b/terraso_backend/apps/core/models/groups.py
@@ -49,7 +49,7 @@ class Group(SlugModel):
 
     class Meta:
         rules_permissions = {
-            "change": perm_rules.is_group_manager,
+            "change": perm_rules.allowed_to_change_group,
         }
 
     def save(self, *args, **kwargs):

--- a/terraso_backend/apps/core/models/groups.py
+++ b/terraso_backend/apps/core/models/groups.py
@@ -100,7 +100,7 @@ class GroupAssociation(BaseModel):
         )
 
 
-class MembershipManager(models.Manager):
+class MembershipObjectsManager(models.Manager):
     def managers_only(self):
         return self.filter(user_role=Membership.ROLE_MANAGER)
 
@@ -127,7 +127,7 @@ class Membership(BaseModel):
 
     user_role = models.CharField(max_length=64, choices=ROLES, blank=True, default=ROLE_MEMBER)
 
-    objects = MembershipManager()
+    objects = MembershipObjectsManager()
 
     class Meta:
         constraints = (

--- a/terraso_backend/apps/core/models/groups.py
+++ b/terraso_backend/apps/core/models/groups.py
@@ -101,7 +101,7 @@ class GroupAssociation(BaseModel):
 
 
 class MembershipManager(models.Manager):
-    def manager_only(self):
+    def managers_only(self):
         return self.filter(user_role=Membership.ROLE_MANAGER)
 
 

--- a/terraso_backend/apps/core/models/groups.py
+++ b/terraso_backend/apps/core/models/groups.py
@@ -59,6 +59,11 @@ class Group(SlugModel):
                 )
                 membership.save()
 
+    def add_manager(self, user):
+        self.memberships.update_or_create(
+            group=self, user=user, defaults={"user_role": Membership.ROLE_MANAGER}
+        )
+
     def __str__(self):
         return self.name
 
@@ -88,6 +93,11 @@ class GroupAssociation(BaseModel):
         )
 
 
+class MembershipManager(models.Manager):
+    def manager_only(self):
+        return self.filter(user_role=Membership.ROLE_MANAGER)
+
+
 class Membership(BaseModel):
     """
     This model represents the association between a User and a Group on
@@ -109,6 +119,8 @@ class Membership(BaseModel):
     user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="memberships")
 
     user_role = models.CharField(max_length=64, choices=ROLES, blank=True, default=ROLE_MEMBER)
+
+    objects = MembershipManager()
 
     class Meta:
         constraints = (

--- a/terraso_backend/apps/core/models/groups.py
+++ b/terraso_backend/apps/core/models/groups.py
@@ -1,6 +1,8 @@
 from django.db import models, transaction
 from django.utils.translation import gettext_lazy as _
 
+from apps.core import permission_rules as perm_rules
+
 from .commons import BaseModel, SlugModel
 from .users import User
 
@@ -44,6 +46,11 @@ class Group(SlugModel):
     members = models.ManyToManyField(User, through="Membership")
 
     field_to_slug = "name"
+
+    class Meta:
+        rules_permissions = {
+            "change": perm_rules.is_group_manager,
+        }
 
     def save(self, *args, **kwargs):
         with transaction.atomic():

--- a/terraso_backend/apps/core/models/users.py
+++ b/terraso_backend/apps/core/models/users.py
@@ -59,7 +59,7 @@ class User(AbstractUser):
         ordering = ["-created_at"]
 
     def is_group_manager(self, group_id):
-        return self.memberships.manager_only().filter(group__pk=group_id).exists()
+        return self.memberships.managers_only().filter(group__pk=group_id).exists()
 
     def __str__(self):
         return self.email

--- a/terraso_backend/apps/core/models/users.py
+++ b/terraso_backend/apps/core/models/users.py
@@ -58,5 +58,8 @@ class User(AbstractUser):
         get_latest_by = "created_at"
         ordering = ["-created_at"]
 
+    def is_group_manager(self, group_id):
+        return self.memberships.manager_only().filter(group__pk=group_id).exists()
+
     def __str__(self):
         return self.email

--- a/terraso_backend/apps/core/permission_rules.py
+++ b/terraso_backend/apps/core/permission_rules.py
@@ -2,5 +2,5 @@ import rules
 
 
 @rules.predicate
-def is_group_manager(user, group_id):
+def allowed_to_change_group(user, group_id):
     return user.is_group_manager(group_id)

--- a/terraso_backend/apps/core/permission_rules.py
+++ b/terraso_backend/apps/core/permission_rules.py
@@ -1,0 +1,6 @@
+import rules
+
+
+@rules.predicate
+def is_group_manager(user, group_id):
+    return user.is_group_manager(group_id)

--- a/terraso_backend/apps/graphql/schema/groups.py
+++ b/terraso_backend/apps/graphql/schema/groups.py
@@ -3,6 +3,7 @@ from graphene import relay
 from graphene_django import DjangoObjectType
 
 from apps.core.models import Group
+from apps.graphql.exceptions import GraphQLValidationException
 
 from .commons import BaseDeleteMutation, BaseWriteMutation, TerrasoConnection
 
@@ -73,6 +74,15 @@ class GroupUpdateMutation(BaseWriteMutation):
         description = graphene.String()
         website = graphene.String()
         email = graphene.String()
+
+    @classmethod
+    def mutate_and_get_payload(cls, root, info, **kwargs):
+        user = info.context.user
+
+        if not user.has_perm(Group.get_perm("change"), obj=kwargs["id"]):
+            raise GraphQLValidationException("User has no permission to change the Group.")
+
+        return super().mutate_and_get_payload(root, info, **kwargs)
 
 
 class GroupDeleteMutation(BaseDeleteMutation):

--- a/terraso_backend/apps/graphql/schema/groups.py
+++ b/terraso_backend/apps/graphql/schema/groups.py
@@ -1,4 +1,5 @@
 import graphene
+from django.conf import settings
 from graphene import relay
 from graphene_django import DjangoObjectType
 
@@ -78,6 +79,9 @@ class GroupUpdateMutation(BaseWriteMutation):
     @classmethod
     def mutate_and_get_payload(cls, root, info, **kwargs):
         user = info.context.user
+
+        if not settings.FEATURE_FLAGS["CHECK_PERMISSIONS"]:
+            return super().mutate_and_get_payload(root, info, **kwargs)
 
         if not user.has_perm(Group.get_perm("change"), obj=kwargs["id"]):
             raise GraphQLValidationException("User has no permission to change the Group.")

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -20,6 +20,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "graphene_django",
+    "rules",
     "apps.core",
     "apps.graphql",
     "apps.auth",
@@ -61,6 +62,11 @@ default_dburl = "sqlite:///" + os.path.join(BASE_DIR, "db.sqlite3")
 DATABASES = {
     "default": config("DATABASE_URL", default=default_dburl, cast=parse_db_url),
 }
+
+AUTHENTICATION_BACKENDS = (
+    "rules.permissions.ObjectPermissionBackend",
+    "django.contrib.auth.backends.ModelBackend",
+)
 
 AUTH_USER_MODEL = "core.User"
 

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -120,6 +120,10 @@ GRAPHENE = {
     "SCHEMA": "apps.graphql.schema.schema",
 }
 
+FEATURE_FLAGS = {
+    "CHECK_PERMISSIONS": config("FF_CHECK_PERMISSIONS", default=False, cast=config.boolean)
+}
+
 WEB_CLIENT_URL = config("WEB_CLIENT_ENDPOINT", default="")
 AUTH_COOKIE_DOMAIN = config("AUTH_COOKIE_DOMAIN", default="")
 CORS_ORIGIN_WHITELIST = config("CORS_ORIGIN_WHITELIST", default=[], cast=config.list)

--- a/terraso_backend/tests/core/models/test_groups.py
+++ b/terraso_backend/tests/core/models/test_groups.py
@@ -29,6 +29,34 @@ def test_group_slug_is_updatable():
     assert group.name == "New name"
 
 
+def test_group_add_manager():
+    group = mixer.blend(Group)
+    user = mixer.blend(User)
+
+    group.add_manager(user)
+
+    assert Membership.objects.filter(
+        user=user, group=group, user_role=Membership.ROLE_MANAGER
+    ).exists()
+
+
+def test_group_add_manager_updates_previous_membership():
+    group = mixer.blend(Group)
+    user = mixer.blend(User)
+    old_membership = mixer.blend(
+        Membership, user=user, group=group, user_role=Membership.ROLE_MEMBER
+    )
+
+    group.add_manager(user)
+
+    updated_membership = Membership.objects.get(
+        user=user, group=group, user_role=Membership.ROLE_MANAGER
+    )
+
+    assert old_membership.id == updated_membership.id
+    assert updated_membership.user_role == Membership.ROLE_MANAGER
+
+
 def test_group_can_have_group_associations():
     group = mixer.blend(Group)
     subgroup = mixer.blend(Group)

--- a/terraso_backend/tests/graphql/mutations/test_group_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_group_mutations.py
@@ -105,12 +105,15 @@ def test_groups_update_by_manager_works(client_query, groups, users):
     assert group_result == new_data
 
 
-def test_groups_update_by_member_fails_due_permission_check(client_query, groups):
+def test_groups_update_by_member_fails_due_permission_check(settings, client_query, groups):
     old_group = groups[0]
     new_data = {
         "id": str(old_group.id),
         "description": "New description",
     }
+
+    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
+
     response = client_query(
         """
         mutation updateGroup($input: GroupUpdateMutationInput!) {


### PR DESCRIPTION
This change adds permissions check to allow only Users with Group
Manager role to update Group data.

The permissions check works based on `django-rules`[1] lib.

One of the core concepts of `django-rules` are the `predicates`.
Predicates are simple _callables_ that returns a boolean value as a
permission result. The way it was set on the project, all our predicates
should be defined only on `apps.core.permission_rules`.

The base models were updated to integrate with `django-rules` and to
make possible to associate the predicates directly on model definition
(Meta class). This way is somehow explicit which permissions are related
to each model and to which model operation (create, update, delete).

On any place where we need to check for permission before an operation,
we can do it calling an instruction similar to this base one:
`User.has_perm(Model.get_perm('...'), obj=model)`. This is going to call
the proper predicate associated to the model permission.

It's important to note that predicates (and permissions) can be created
regardless the models. Which means that the same foundation might be
used to other permissions checks that not necessarily involves CRUD
model operations. More details can be found on linked lib README.

This is part of:
- #70 

[1] - https://github.com/dfunckt/django-rules
