### PR TITLE
feat: permissions to delete / change Group and Landscape

### DIFF
--- a/terraso_backend/apps/core/models/groups.py
+++ b/terraso_backend/apps/core/models/groups.py
@@ -51,6 +51,7 @@ class Group(SlugModel):
     class Meta:
         rules_permissions = {
             "change": perm_rules.allowed_to_change_group,
+            "delete": perm_rules.allowed_to_delete_group,
         }
 
     def save(self, *args, **kwargs):

--- a/terraso_backend/apps/core/models/landscapes.py
+++ b/terraso_backend/apps/core/models/landscapes.py
@@ -1,5 +1,7 @@
 from django.db import models
 
+from apps.core import permission_rules as perm_rules
+
 from .commons import BaseModel, SlugModel
 from .groups import Group
 from .users import User
@@ -33,6 +35,11 @@ class Landscape(SlugModel):
     groups = models.ManyToManyField(Group, through="LandscapeGroup")
 
     field_to_slug = "name"
+
+    class Meta:
+        rules_permissions = {
+            "delete": perm_rules.allowed_to_delete_landscape,
+        }
 
     def get_default_group(self):
         """

--- a/terraso_backend/apps/core/models/landscapes.py
+++ b/terraso_backend/apps/core/models/landscapes.py
@@ -38,6 +38,7 @@ class Landscape(SlugModel):
 
     class Meta:
         rules_permissions = {
+            "change": perm_rules.allowed_to_change_landscape,
             "delete": perm_rules.allowed_to_delete_landscape,
         }
 

--- a/terraso_backend/apps/core/models/users.py
+++ b/terraso_backend/apps/core/models/users.py
@@ -66,6 +66,16 @@ class User(SafeDeleteModel, AbstractUser):
             ),
         )
 
+    def is_landscape_manager(self, landscape_id):
+        return (
+            self.memberships.managers_only()
+            .filter(
+                group__associated_landscapes__is_default_landscape_group=True,
+                group__associated_landscapes__landscape__pk=landscape_id,
+            )
+            .exists()
+        )
+
     def is_group_manager(self, group_id):
         return self.memberships.managers_only().filter(group__pk=group_id).exists()
 

--- a/terraso_backend/apps/core/permission_rules.py
+++ b/terraso_backend/apps/core/permission_rules.py
@@ -7,6 +7,11 @@ def allowed_to_change_group(user, group_id):
 
 
 @rules.predicate
+def allowed_to_delete_landscape(user, landscape_id):
+    return user.is_landscape_manager(landscape_id)
+
+
+@rules.predicate
 def allowed_to_delete_membership(user, membership_id):
     from apps.core.models import Membership
 

--- a/terraso_backend/apps/core/permission_rules.py
+++ b/terraso_backend/apps/core/permission_rules.py
@@ -12,6 +12,11 @@ def allowed_to_delete_group(user, group_id):
 
 
 @rules.predicate
+def allowed_to_change_landscape(user, landscape_id):
+    return user.is_landscape_manager(landscape_id)
+
+
+@rules.predicate
 def allowed_to_delete_landscape(user, landscape_id):
     return user.is_landscape_manager(landscape_id)
 

--- a/terraso_backend/apps/core/permission_rules.py
+++ b/terraso_backend/apps/core/permission_rules.py
@@ -7,6 +7,11 @@ def allowed_to_change_group(user, group_id):
 
 
 @rules.predicate
+def allowed_to_delete_group(user, group_id):
+    return user.is_group_manager(group_id)
+
+
+@rules.predicate
 def allowed_to_delete_landscape(user, landscape_id):
     return user.is_landscape_manager(landscape_id)
 

--- a/terraso_backend/apps/graphql/schema/groups.py
+++ b/terraso_backend/apps/graphql/schema/groups.py
@@ -95,3 +95,15 @@ class GroupDeleteMutation(BaseDeleteMutation):
 
     class Input:
         id = graphene.ID()
+
+    @classmethod
+    def mutate_and_get_payload(cls, root, info, **kwargs):
+        user = info.context.user
+
+        ff_check_permission_on = settings.FEATURE_FLAGS["CHECK_PERMISSIONS"]
+        user_has_delete_permission = user.has_perm(Group.get_perm("delete"), obj=kwargs["id"])
+
+        if ff_check_permission_on and not user_has_delete_permission:
+            raise GraphQLValidationException("User has no permission to delete this data.")
+
+        return super().mutate_and_get_payload(root, info, **kwargs)

--- a/terraso_backend/apps/graphql/schema/landscapes.py
+++ b/terraso_backend/apps/graphql/schema/landscapes.py
@@ -67,6 +67,18 @@ class LandscapeUpdateMutation(BaseWriteMutation):
         website = graphene.String()
         location = graphene.String()
 
+    @classmethod
+    def mutate_and_get_payload(cls, root, info, **kwargs):
+        user = info.context.user
+
+        if not settings.FEATURE_FLAGS["CHECK_PERMISSIONS"]:
+            return super().mutate_and_get_payload(root, info, **kwargs)
+
+        if not user.has_perm(Landscape.get_perm("change"), obj=kwargs["id"]):
+            raise GraphQLValidationException("User has no permission to change the Landscape.")
+
+        return super().mutate_and_get_payload(root, info, **kwargs)
+
 
 class LandscapeDeleteMutation(BaseDeleteMutation):
     landscape = graphene.Field(LandscapeNode)

--- a/terraso_backend/apps/graphql/schema/landscapes.py
+++ b/terraso_backend/apps/graphql/schema/landscapes.py
@@ -1,8 +1,10 @@
 import graphene
+from django.conf import settings
 from graphene import relay
 from graphene_django import DjangoObjectType
 
 from apps.core.models import Landscape
+from apps.graphql.exceptions import GraphQLValidationException
 
 from .commons import BaseDeleteMutation, BaseWriteMutation, TerrasoConnection
 
@@ -73,3 +75,15 @@ class LandscapeDeleteMutation(BaseDeleteMutation):
 
     class Input:
         id = graphene.ID()
+
+    @classmethod
+    def mutate_and_get_payload(cls, root, info, **kwargs):
+        user = info.context.user
+
+        ff_check_permission_on = settings.FEATURE_FLAGS["CHECK_PERMISSIONS"]
+        user_has_delete_permission = user.has_perm(Landscape.get_perm("delete"), obj=kwargs["id"])
+
+        if ff_check_permission_on and not user_has_delete_permission:
+            raise GraphQLValidationException("User has no permission to delete this data.")
+
+        return super().mutate_and_get_payload(root, info, **kwargs)

--- a/terraso_backend/tests/core/models/test_users.py
+++ b/terraso_backend/tests/core/models/test_users.py
@@ -1,7 +1,7 @@
 import pytest
 from mixer.backend.django import mixer
 
-from apps.core.models.users import User
+from apps.core.models import Group, Landscape, LandscapeGroup, User
 
 pytestmark = pytest.mark.django_db
 
@@ -11,3 +11,25 @@ def test_user_string_format_is_its_email():
     user = mixer.blend(User, email=user_email)
 
     assert user_email == str(user)
+
+
+@pytest.mark.parametrize(
+    "is_default_landscape_group, is_expected_to_be_manager",
+    (
+        (True, True),
+        (False, False),
+    ),
+)
+def test_user_is_landscape_manager(is_default_landscape_group, is_expected_to_be_manager):
+    user = mixer.blend(User)
+    group = mixer.blend(Group)
+    landscape = mixer.blend(Landscape)
+    mixer.blend(
+        LandscapeGroup,
+        landscape=landscape,
+        group=group,
+        is_default_landscape_group=is_default_landscape_group,
+    )
+    group.add_manager(user)
+
+    assert user.is_landscape_manager(landscape.id) is is_expected_to_be_manager

--- a/terraso_backend/tests/graphql/conftest.py
+++ b/terraso_backend/tests/graphql/conftest.py
@@ -82,6 +82,14 @@ def groups():
 
 
 @pytest.fixture
+def managed_groups(users, groups):
+    for i in range(len(groups)):
+        groups[i].add_manager(users[i])
+
+    return groups
+
+
+@pytest.fixture
 def subgroups():
     return mixer.cycle(2).blend(Group)
 

--- a/terraso_backend/tests/graphql/conftest.py
+++ b/terraso_backend/tests/graphql/conftest.py
@@ -60,6 +60,23 @@ def landscapes():
 
 
 @pytest.fixture
+def managed_landscapes(users):
+    landscapes = mixer.cycle(2).blend(Landscape)
+
+    for i in range(len(landscapes)):
+        group = mixer.blend(Group)
+        group.add_manager(users[i])
+        mixer.blend(
+            LandscapeGroup,
+            landscape=landscapes[i],
+            group=group,
+            is_default_landscape_group=True,
+        )
+
+    return landscapes
+
+
+@pytest.fixture
 def groups():
     return mixer.cycle(5).blend(Group)
 

--- a/terraso_backend/tests/graphql/mutations/test_landscape_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_landscape_mutations.py
@@ -71,14 +71,17 @@ def test_landscapes_add_duplicated(client_query, landscapes):
     assert "field=name" in error_result["message"]
 
 
-def test_landscapes_update(client_query, landscapes):
-    old_landscape = landscapes[0]
+def test_landscapes_update_by_manager_works(settings, client_query, managed_landscapes):
+    old_landscape = managed_landscapes[0]
     new_data = {
         "id": str(old_landscape.id),
         "description": "New description",
         "name": "New Name",
         "website": "https://www.example.com/updated-landscape",
     }
+
+    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
+
     response = client_query(
         """
         mutation updateLandscape($input: LandscapeUpdateMutationInput!) {
@@ -97,6 +100,39 @@ def test_landscapes_update(client_query, landscapes):
     landscape_result = response.json()["data"]["updateLandscape"]["landscape"]
 
     assert landscape_result == new_data
+
+
+def test_landscapes_update_by_member_fails_due_permission_check(settings, client_query, landscapes):
+    old_landscape = landscapes[0]
+    new_data = {
+        "id": str(old_landscape.id),
+        "description": "New description",
+        "name": "New Name",
+        "website": "https://www.example.com/updated-landscape",
+    }
+
+    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
+
+    response = client_query(
+        """
+        mutation updateLandscape($input: LandscapeUpdateMutationInput!) {
+          updateLandscape(input: $input) {
+            landscape {
+              id
+              name
+              description
+              website
+            }
+          }
+        }
+        """,
+        variables={"input": new_data},
+    )
+
+    response = response.json()
+
+    assert "errors" in response
+    assert "has no permission to change" in response["errors"][0]["message"]
 
 
 def test_landscapes_delete_by_manager(settings, client_query, managed_landscapes):


### PR DESCRIPTION
This change adds:

- Permission checks to delete Landscape;
- Permission checks to update Landscape;
- Permission checks to delete Group;

It implements:
- #69 