### PR TITLE
chore: silence system auth.W004 warning

### DIFF
--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -12,6 +12,8 @@ DEBUG = config("DEBUG", default=False, cast=config.boolean)
 ALLOWED_HOSTS = config("ALLOWED_HOSTS", default="*", cast=config.list)
 SECRET_KEY = config("SECRET_KEY")
 
+SILENCED_SYSTEM_CHECKS = ["auth.W004"]
+
 INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",


### PR DESCRIPTION
The auth.W004 warning says that user username field is not unique. This
change silence this warning because we have a unique constraint in
place, but considering only non deleted objects.