### PR TITLE
feat: removes LandscapeGroupUpdateMutation

### DIFF
--- a/terraso_backend/apps/graphql/schema/__init__.py
+++ b/terraso_backend/apps/graphql/schema/__init__.py
@@ -17,7 +17,6 @@ from .landscape_groups import (
     LandscapeGroupAddMutation,
     LandscapeGroupDeleteMutation,
     LandscapeGroupNode,
-    LandscapeGroupUpdateMutation,
 )
 from .landscapes import (
     LandscapeAddMutation,
@@ -60,7 +59,6 @@ class Mutations(graphene.ObjectType):
     add_membership = MembershipAddMutation.Field()
     update_group = GroupUpdateMutation.Field()
     update_landscape = LandscapeUpdateMutation.Field()
-    update_landscape_group = LandscapeGroupUpdateMutation.Field()
     update_membership = MembershipUpdateMutation.Field()
     update_user = UserUpdateMutation.Field()
     delete_group = GroupDeleteMutation.Field()

--- a/terraso_backend/apps/graphql/schema/landscape_groups.py
+++ b/terraso_backend/apps/graphql/schema/landscape_groups.py
@@ -26,8 +26,12 @@ class LandscapeGroupNode(DjangoObjectType):
         connection_class = TerrasoConnection
 
 
-class LandscapeGroupWriteMutation(relay.ClientIDMutation):
+class LandscapeGroupAddMutation(relay.ClientIDMutation):
     landscape_group = graphene.Field(LandscapeGroupNode)
+
+    class Input:
+        landscape_slug = graphene.String(required=True)
+        group_slug = graphene.String(required=True)
 
     @classmethod
     def mutate_and_get_payload(cls, root, info, **kwargs):
@@ -37,27 +41,9 @@ class LandscapeGroupWriteMutation(relay.ClientIDMutation):
         called both when adding and updating Landscape Groups. The `kwargs`
         receives a dictionary with all inputs informed.
         """
-        _id = kwargs.pop("id", None)
-
-        if _id:
-            landscape_group = LandscapeGroup.objects.get(pk=_id)
-            new_landscape = kwargs.pop("landscape_slug", None)
-            new_group = kwargs.pop("group_slug", None)
-
-            if new_landscape:
-                landscape_group.landscape = Landscape.objects.get(slug=new_landscape)
-
-            if new_group:
-                landscape_group.group = Group.objects.get(slug=new_group)
-        else:
-            landscape_group = LandscapeGroup()
-            landscape_group.is_dafault_landscape_group = False
-            landscape_group.landscape = Landscape.objects.get(slug=kwargs.pop("landscape_slug"))
-            landscape_group.group = Group.objects.get(slug=kwargs.pop("group_slug"))
-
-        default_group = kwargs.pop("is_default_landscape_group", None)
-        if default_group is not None:
-            landscape_group.is_default_landscape_group = default_group
+        landscape_group = LandscapeGroup()
+        landscape_group.landscape = Landscape.objects.get(slug=kwargs.pop("landscape_slug"))
+        landscape_group.group = Group.objects.get(slug=kwargs.pop("group_slug"))
 
         try:
             landscape_group.full_clean()
@@ -67,21 +53,6 @@ class LandscapeGroupWriteMutation(relay.ClientIDMutation):
         landscape_group.save()
 
         return cls(landscape_group=landscape_group)
-
-
-class LandscapeGroupAddMutation(LandscapeGroupWriteMutation):
-    class Input:
-        landscape_slug = graphene.String(required=True)
-        group_slug = graphene.String(required=True)
-        is_default_landscape_group = graphene.Boolean(required=False, default=False)
-
-
-class LandscapeGroupUpdateMutation(LandscapeGroupWriteMutation):
-    class Input:
-        id = graphene.ID(required=True)
-        landscape_slug = graphene.String()
-        group_slug = graphene.String()
-        is_default_landscape_group = graphene.Boolean(required=False, default=False)
 
 
 class LandscapeGroupDeleteMutation(BaseDeleteMutation):

--- a/terraso_backend/tests/graphql/mutations/test_landscape_groups_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_landscape_groups_mutations.py
@@ -5,8 +5,7 @@ from apps.core.models import LandscapeGroup
 pytestmark = pytest.mark.django_db
 
 
-@pytest.mark.parametrize("is_default_group", (True, False))
-def test_landscape_groups_add(client_query, landscapes, groups, is_default_group):
+def test_landscape_groups_add(client_query, landscapes, groups):
     landscape = landscapes[0]
     group = groups[0]
 
@@ -31,7 +30,6 @@ def test_landscape_groups_add(client_query, landscapes, groups, is_default_group
             "input": {
                 "landscapeSlug": landscape.slug,
                 "groupSlug": group.slug,
-                "isDefaultLandscapeGroup": is_default_group,
             }
         },
     )
@@ -40,7 +38,7 @@ def test_landscape_groups_add(client_query, landscapes, groups, is_default_group
     assert landscape_group["id"]
     assert landscape_group["landscape"]["name"] == landscape.name
     assert landscape_group["group"]["name"] == group.name
-    assert landscape_group["isDefaultLandscapeGroup"] is is_default_group
+    assert not landscape_group["isDefaultLandscapeGroup"]
 
 
 def test_landscape_groups_add_duplicated(client_query, landscape_groups):
@@ -100,68 +98,6 @@ def test_landscape_groups_add_without_default(client_query, landscapes, groups):
     landscape_group = response.json()["data"]["addLandscapeGroup"]["landscapeGroup"]
 
     assert not landscape_group["isDefaultLandscapeGroup"]
-
-
-def test_landscape_groups_update_is_default_group(client_query, landscape_groups):
-    old_landscape_group = landscape_groups[0]
-    old_is_default = old_landscape_group.is_default_landscape_group
-
-    response = client_query(
-        """
-        mutation updateLandscapeGroup($input: LandscapeGroupUpdateMutationInput!){
-          updateLandscapeGroup(input: $input) {
-            landscapeGroup {
-              id
-              isDefaultLandscapeGroup
-            }
-          }
-        }
-        """,
-        variables={
-            "input": {
-                "id": str(old_landscape_group.id),
-                "isDefaultLandscapeGroup": not old_is_default,
-            }
-        },
-    )
-    landscape_group = response.json()["data"]["updateLandscapeGroup"]["landscapeGroup"]
-
-    assert landscape_group["id"] == str(old_landscape_group.id)
-    assert landscape_group["isDefaultLandscapeGroup"] is not old_is_default
-
-
-def test_landscape_groups_update_landscape_and_group(
-    client_query, landscapes, groups, landscape_groups
-):
-    old_landscape_group = landscape_groups[0]
-    new_landscape = landscapes[-1]
-    new_group = groups[-1]
-
-    response = client_query(
-        """
-        mutation updateLandscapeGroup($input: LandscapeGroupUpdateMutationInput!){
-          updateLandscapeGroup(input: $input) {
-            landscapeGroup {
-              id
-              landscape { slug }
-              group { slug }
-            }
-          }
-        }
-        """,
-        variables={
-            "input": {
-                "id": str(old_landscape_group.id),
-                "landscapeSlug": new_landscape.slug,
-                "groupSlug": new_group.slug,
-            }
-        },
-    )
-    landscape_group = response.json()["data"]["updateLandscapeGroup"]["landscapeGroup"]
-
-    assert landscape_group["id"] == str(old_landscape_group.id)
-    assert landscape_group["landscape"]["slug"] == new_landscape.slug
-    assert landscape_group["group"]["slug"] == new_group.slug
 
 
 def test_landscape_groups_delete(client_query, landscape_groups):


### PR DESCRIPTION
Landscape Group (the relationship model between Landscape and Group)
isn't expected to be updated. The only attribute this entity has is the
`is_default_landscape_group` that is a more internal attribute and won't
be updated.