### PR TITLE
feat: adds permission checks to mutate Landscape Group

### DIFF
--- a/terraso_backend/apps/core/models/landscapes.py
+++ b/terraso_backend/apps/core/models/landscapes.py
@@ -76,6 +76,9 @@ class LandscapeGroup(BaseModel):
     is_default_landscape_group = models.BooleanField(blank=True, default=False)
 
     class Meta:
+        rules_permissions = {
+            "add": perm_rules.allowed_to_add_landscape_group,
+        }
         constraints = (
             models.UniqueConstraint(
                 fields=("group", "landscape"),

--- a/terraso_backend/apps/core/models/landscapes.py
+++ b/terraso_backend/apps/core/models/landscapes.py
@@ -78,6 +78,7 @@ class LandscapeGroup(BaseModel):
     class Meta:
         rules_permissions = {
             "add": perm_rules.allowed_to_add_landscape_group,
+            "delete": perm_rules.allowed_to_delete_landscape_group,
         }
         constraints = (
             models.UniqueConstraint(

--- a/terraso_backend/apps/core/permission_rules.py
+++ b/terraso_backend/apps/core/permission_rules.py
@@ -22,6 +22,11 @@ def allowed_to_delete_landscape(user, landscape_id):
 
 
 @rules.predicate
+def allowed_to_add_landscape_group(user, landscape_id):
+    return user.is_landscape_manager(landscape_id)
+
+
+@rules.predicate
 def allowed_to_delete_membership(user, membership_id):
     from apps.core.models import Membership
 

--- a/terraso_backend/apps/core/permission_rules.py
+++ b/terraso_backend/apps/core/permission_rules.py
@@ -27,6 +27,13 @@ def allowed_to_add_landscape_group(user, landscape_id):
 
 
 @rules.predicate
+def allowed_to_delete_landscape_group(user, landscape_group):
+    return user.is_landscape_manager(landscape_group.landscape.id) or user.is_group_manager(
+        landscape_group.group.id
+    )
+
+
+@rules.predicate
 def allowed_to_delete_membership(user, membership_id):
     from apps.core.models import Membership
 

--- a/terraso_backend/apps/graphql/schema/landscape_groups.py
+++ b/terraso_backend/apps/graphql/schema/landscape_groups.py
@@ -47,9 +47,9 @@ class LandscapeGroupAddMutation(relay.ClientIDMutation):
         group = Group.objects.get(slug=kwargs.pop("group_slug"))
 
         ff_check_permission_on = settings.FEATURE_FLAGS["CHECK_PERMISSIONS"]
-        user_has_delete_permission = user.has_perm(LandscapeGroup.get_perm("add"), obj=landscape.pk)
+        user_has_add_permission = user.has_perm(LandscapeGroup.get_perm("add"), obj=landscape.pk)
 
-        if ff_check_permission_on and not user_has_delete_permission:
+        if ff_check_permission_on and not user_has_add_permission:
             raise GraphQLValidationException("User has no permission to create this data.")
 
         landscape_group = LandscapeGroup()
@@ -73,3 +73,18 @@ class LandscapeGroupDeleteMutation(BaseDeleteMutation):
 
     class Input:
         id = graphene.ID()
+
+    @classmethod
+    def mutate_and_get_payload(cls, root, info, **kwargs):
+        user = info.context.user
+        landscape_group = LandscapeGroup.objects.get(pk=kwargs["id"])
+
+        ff_check_permission_on = settings.FEATURE_FLAGS["CHECK_PERMISSIONS"]
+        user_has_delete_permission = user.has_perm(
+            LandscapeGroup.get_perm("delete"), obj=landscape_group
+        )
+
+        if ff_check_permission_on and not user_has_delete_permission:
+            raise GraphQLValidationException("User has no permission to delete this data.")
+
+        return super().mutate_and_get_payload(root, info, **kwargs)


### PR DESCRIPTION
This change adds permission check to allow only Landscape managers to
add Landscape Group. It means only a Landscape Manager can create a new
association to a Group.

It also adds permission check to allow only the Landscape or Group
manager to delete a Landscape Group relationship.

This is part of:
- #75 