### PR TITLE
feat: add permissions to GroupAssociation mutations

### DIFF
--- a/terraso_backend/apps/core/models/groups.py
+++ b/terraso_backend/apps/core/models/groups.py
@@ -94,6 +94,10 @@ class GroupAssociation(BaseModel):
     )
 
     class Meta:
+        rules_permissions = {
+            "add": perm_rules.allowed_to_add_group_association,
+            "delete": perm_rules.allowed_to_delete_group_association,
+        }
         constraints = (
             models.UniqueConstraint(
                 fields=("parent_group", "child_group"),

--- a/terraso_backend/apps/core/permission_rules.py
+++ b/terraso_backend/apps/core/permission_rules.py
@@ -12,6 +12,18 @@ def allowed_to_delete_group(user, group_id):
 
 
 @rules.predicate
+def allowed_to_add_group_association(user, parent_group_id):
+    return user.is_group_manager(parent_group_id)
+
+
+@rules.predicate
+def allowed_to_delete_group_association(user, group_association):
+    return user.is_group_manager(group_association.parent_group.pk) or user.is_group_manager(
+        group_association.child_group.pk
+    )
+
+
+@rules.predicate
 def allowed_to_change_landscape(user, landscape_id):
     return user.is_landscape_manager(landscape_id)
 

--- a/terraso_backend/apps/graphql/schema/group_associations.py
+++ b/terraso_backend/apps/graphql/schema/group_associations.py
@@ -1,4 +1,5 @@
 import graphene
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from graphene import relay
 from graphene_django import DjangoObjectType
@@ -10,7 +11,7 @@ from .commons import BaseDeleteMutation, TerrasoConnection
 
 
 class GroupAssociationNode(DjangoObjectType):
-    id = graphene.ID(source='pk', required=True)
+    id = graphene.ID(source="pk", required=True)
 
     class Meta:
         model = GroupAssociation
@@ -39,6 +40,8 @@ class GroupAssociationAddMutation(relay.ClientIDMutation):
         This method will be called when adding Group Associations. The `kwargs`
         receives a dictionary with all inputs informed.
         """
+        user = info.context.user
+
         try:
             parent_group = Group.objects.get(slug=kwargs.pop("parent_group_slug"))
         except Group.DoesNotExist:
@@ -52,6 +55,13 @@ class GroupAssociationAddMutation(relay.ClientIDMutation):
         group_association = GroupAssociation()
         group_association.parent_group = parent_group
         group_association.child_group = child_group
+
+        ff_check_permission_on = settings.FEATURE_FLAGS["CHECK_PERMISSIONS"]
+
+        if ff_check_permission_on and not user.has_perm(
+            GroupAssociation.get_perm("add"), obj=parent_group.pk
+        ):
+            raise GraphQLValidationException("User has no permission to add this data.")
 
         try:
             group_association.full_clean()
@@ -70,3 +80,21 @@ class GroupAssociationDeleteMutation(BaseDeleteMutation):
 
     class Input:
         id = graphene.ID()
+
+    @classmethod
+    def mutate_and_get_payload(cls, root, info, **kwargs):
+        user = info.context.user
+
+        try:
+            group_association = GroupAssociation.objects.get(pk=kwargs["id"])
+        except GroupAssociation.DoesNotExist:
+            raise GraphQLValidationException("Group Association not found.")
+
+        ff_check_permission_on = settings.FEATURE_FLAGS["CHECK_PERMISSIONS"]
+
+        if ff_check_permission_on and not user.has_perm(
+            GroupAssociation.get_perm("delete"), obj=group_association
+        ):
+            raise GraphQLValidationException("User has no permission to delete this data.")
+
+        return super().mutate_and_get_payload(root, info, **kwargs)

--- a/terraso_backend/apps/graphql/schema/group_associations.py
+++ b/terraso_backend/apps/graphql/schema/group_associations.py
@@ -39,9 +39,19 @@ class GroupAssociationAddMutation(relay.ClientIDMutation):
         This method will be called when adding Group Associations. The `kwargs`
         receives a dictionary with all inputs informed.
         """
+        try:
+            parent_group = Group.objects.get(slug=kwargs.pop("parent_group_slug"))
+        except Group.DoesNotExist:
+            raise GraphQLValidationException("Parent Group not found.")
+
+        try:
+            child_group = Group.objects.get(slug=kwargs.pop("child_group_slug"))
+        except Group.DoesNotExist:
+            raise GraphQLValidationException("Child Group not found.")
+
         group_association = GroupAssociation()
-        group_association.parent_group = Group.objects.get(slug=kwargs.pop("parent_group_slug"))
-        group_association.child_group = Group.objects.get(slug=kwargs.pop("child_group_slug"))
+        group_association.parent_group = parent_group
+        group_association.child_group = child_group
 
         try:
             group_association.full_clean()

--- a/terraso_backend/tests/graphql/mutations/test_group_associations_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_group_associations_mutations.py
@@ -5,9 +5,14 @@ from apps.core.models import GroupAssociation
 pytestmark = pytest.mark.django_db
 
 
-def test_group_associations_add(client_query, groups):
+def test_group_associations_add_by_parent_manager(settings, client_query, users, groups):
+    user = users[0]
     parent_group = groups[0]
     child_group = groups[1]
+
+    parent_group.add_manager(user)
+
+    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
 
     response = client_query(
         """
@@ -35,9 +40,45 @@ def test_group_associations_add(client_query, groups):
     assert group_association["childGroup"]["slug"] == child_group.slug
 
 
-def test_group_associations_add_duplicated(client_query, group_associations):
+def test_group_associations_add_by_non_parent_manager_fails(settings, client_query, groups):
+    parent_group = groups[0]
+    child_group = groups[1]
+
+    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
+
+    response = client_query(
+        """
+        mutation addGroupAssociation($input: GroupAssociationAddMutationInput!){
+          addGroupAssociation(input: $input) {
+            groupAssociation {
+              id
+              parentGroup { slug }
+              childGroup { slug }
+            }
+          }
+        }
+        """,
+        variables={
+            "input": {
+                "parentGroupSlug": parent_group.slug,
+                "childGroupSlug": child_group.slug,
+            }
+        },
+    )
+    response = response.json()
+
+    assert "errors" in response
+    assert "no permission" in response["errors"][0]["message"]
+
+
+def test_group_associations_add_duplicated(settings, client_query, users, group_associations):
+    user = users[0]
     parent_group = group_associations[0].parent_group
     child_group = group_associations[0].child_group
+
+    parent_group.add_manager(user)
+
+    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
 
     response = client_query(
         """
@@ -64,8 +105,10 @@ def test_group_associations_add_duplicated(client_query, group_associations):
     assert "duplicate key value" in error_result["message"]
 
 
-def test_group_associations_add_parent_group_not_found(client_query, groups):
+def test_group_associations_add_parent_group_not_found(settings, client_query, groups):
     child_group = groups[1]
+
+    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
 
     response = client_query(
         """
@@ -92,8 +135,10 @@ def test_group_associations_add_parent_group_not_found(client_query, groups):
     assert "Parent Group not found" in response["errors"][0]["message"]
 
 
-def test_group_associations_add_child_group_not_found(client_query, groups):
+def test_group_associations_add_child_group_not_found(settings, client_query, groups):
     parent_group = groups[0]
+
+    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
 
     response = client_query(
         """
@@ -120,8 +165,15 @@ def test_group_associations_add_child_group_not_found(client_query, groups):
     assert "Child Group not found" in response["errors"][0]["message"]
 
 
-def test_group_associations_delete(client_query, group_associations):
+def test_group_associations_delete_by_parent_manager(
+    settings, client_query, users, group_associations
+):
+    user = users[0]
     old_group_association = group_associations[0]
+    old_group_association.parent_group.add_manager(user)
+
+    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
+
     response = client_query(
         """
         mutation deleteGroupAssociation($input: GroupAssociationDeleteMutationInput!){
@@ -141,3 +193,57 @@ def test_group_associations_delete(client_query, group_associations):
         parent_group__slug=group_association["parentGroup"]["slug"],
         child_group__slug=group_association["childGroup"]["slug"],
     )
+
+
+def test_group_associations_delete_by_child_manager(
+    settings, client_query, users, group_associations
+):
+    user = users[0]
+    old_group_association = group_associations[0]
+    old_group_association.child_group.add_manager(user)
+
+    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
+
+    response = client_query(
+        """
+        mutation deleteGroupAssociation($input: GroupAssociationDeleteMutationInput!){
+          deleteGroupAssociation(input: $input) {
+            groupAssociation {
+              parentGroup { slug }
+              childGroup { slug }
+            }
+          }
+        }
+        """,
+        variables={"input": {"id": str(old_group_association.id)}},
+    )
+    group_association = response.json()["data"]["deleteGroupAssociation"]["groupAssociation"]
+
+    assert not GroupAssociation.objects.filter(
+        parent_group__slug=group_association["parentGroup"]["slug"],
+        child_group__slug=group_association["childGroup"]["slug"],
+    )
+
+
+def test_group_associations_delete_by_non_manager_fail(settings, client_query, group_associations):
+    old_group_association = group_associations[0]
+
+    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
+
+    response = client_query(
+        """
+        mutation deleteGroupAssociation($input: GroupAssociationDeleteMutationInput!){
+          deleteGroupAssociation(input: $input) {
+            groupAssociation {
+              parentGroup { slug }
+              childGroup { slug }
+            }
+          }
+        }
+        """,
+        variables={"input": {"id": str(old_group_association.id)}},
+    )
+    response = response.json()
+
+    assert "errors" in response
+    assert "no permission" in response["errors"][0]["message"]

--- a/terraso_backend/tests/graphql/mutations/test_group_associations_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_group_associations_mutations.py
@@ -64,6 +64,62 @@ def test_group_associations_add_duplicated(client_query, group_associations):
     assert "duplicate key value" in error_result["message"]
 
 
+def test_group_associations_add_parent_group_not_found(client_query, groups):
+    child_group = groups[1]
+
+    response = client_query(
+        """
+        mutation addGroupAssociation($input: GroupAssociationAddMutationInput!){
+          addGroupAssociation(input: $input) {
+            groupAssociation {
+              id
+              parentGroup { slug }
+              childGroup { slug }
+            }
+          }
+        }
+        """,
+        variables={
+            "input": {
+                "parentGroupSlug": "non-existing-group",
+                "childGroupSlug": child_group.slug,
+            }
+        },
+    )
+    response = response.json()
+
+    assert "errors" in response
+    assert "Parent Group not found" in response["errors"][0]["message"]
+
+
+def test_group_associations_add_child_group_not_found(client_query, groups):
+    parent_group = groups[0]
+
+    response = client_query(
+        """
+        mutation addGroupAssociation($input: GroupAssociationAddMutationInput!){
+          addGroupAssociation(input: $input) {
+            groupAssociation {
+              id
+              parentGroup { slug }
+              childGroup { slug }
+            }
+          }
+        }
+        """,
+        variables={
+            "input": {
+                "parentGroupSlug": parent_group.slug,
+                "childGroupSlug": "non-existing-group",
+            }
+        },
+    )
+    response = response.json()
+
+    assert "errors" in response
+    assert "Child Group not found" in response["errors"][0]["message"]
+
+
 def test_group_associations_delete(client_query, group_associations):
     old_group_association = group_associations[0]
     response = client_query(


### PR DESCRIPTION
This change adds the proper permission checks to the Group Association
add and delete mutations.

`GroupAssociation` is the relationship entity between two `Groups`.

This is part of:
- #75 