### PR TITLE
feat: add permission to change Membership

### DIFF
--- a/terraso_backend/apps/core/models/groups.py
+++ b/terraso_backend/apps/core/models/groups.py
@@ -142,6 +142,7 @@ class Membership(BaseModel):
         )
         rules_permissions = {
             "delete": perm_rules.allowed_to_delete_membership,
+            "change": perm_rules.allowed_to_change_membership,
         }
 
     @classmethod

--- a/terraso_backend/apps/core/permission_rules.py
+++ b/terraso_backend/apps/core/permission_rules.py
@@ -34,6 +34,11 @@ def allowed_to_delete_landscape_group(user, landscape_group):
 
 
 @rules.predicate
+def allowed_to_change_membership(user, membership_group_id):
+    return user.is_group_manager(membership_group_id)
+
+
+@rules.predicate
 def allowed_to_delete_membership(user, membership_id):
     from apps.core.models import Membership
 


### PR DESCRIPTION
This change adds the proper permission check to change a Membership.
Since the only attribute to be updated in a Membership object is the
user role, only the Membership group manager is allowed to make this
mutation.
