### PR TITLE
fix: doesn't allow last manager to become a member

### DIFF
--- a/terraso_backend/apps/graphql/schema/memberships.py
+++ b/terraso_backend/apps/graphql/schema/memberships.py
@@ -89,6 +89,9 @@ class MembershipUpdateMutation(MembershipWriteMutation):
         if not user.has_perm(Membership.get_perm("change"), obj=membership.group.id):
             raise GraphQLValidationException("User has no permission to change Membership.")
 
+        if not rules.test_rule("allowed_group_managers_count", user, kwargs["id"]):
+            raise GraphQLValidationException("A Group needs to have at least one manager.")
+
         return super().mutate_and_get_payload(root, info, **kwargs)
 
 

--- a/terraso_backend/tests/graphql/mutations/test_membership_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_membership_mutations.py
@@ -120,9 +120,11 @@ def test_membership_add_manager(client_query, groups, users):
 
 def test_membership_update(settings, client_query, users, memberships):
     user = users[0]
+    other_manager = users[1]
     old_membership = memberships[0]
 
     old_membership.group.add_manager(user)
+    old_membership.group.add_manager(other_manager)
 
     assert old_membership.user_role != Membership.ROLE_MANAGER.upper()
 
@@ -148,7 +150,7 @@ def test_membership_update(settings, client_query, users, memberships):
         variables={
             "input": {
                 "id": str(old_membership.id),
-                "userRole": Membership.ROLE_MANAGER,
+                "userRole": Membership.ROLE_MEMBER,
             }
         },
     )
@@ -157,7 +159,7 @@ def test_membership_update(settings, client_query, users, memberships):
     assert membership["id"]
     assert membership["user"]["email"] == old_membership.user.email
     assert membership["group"]["slug"] == old_membership.group.slug
-    assert membership["userRole"] == Membership.ROLE_MANAGER.upper()
+    assert membership["userRole"] == Membership.ROLE_MEMBER.upper()
 
 
 def test_membership_update_role_by_last_manager_fails(settings, client_query, users, memberships):

--- a/terraso_backend/tests/graphql/mutations/test_membership_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_membership_mutations.py
@@ -160,6 +160,46 @@ def test_membership_update(settings, client_query, users, memberships):
     assert membership["userRole"] == Membership.ROLE_MANAGER.upper()
 
 
+def test_membership_update_role_by_last_manager_fails(settings, client_query, users, memberships):
+    user = users[0]
+    old_membership = memberships[0]
+
+    old_membership.group.add_manager(user)
+
+    assert old_membership.user_role != Membership.ROLE_MANAGER.upper()
+
+    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
+
+    response = client_query(
+        """
+        mutation updateMembership($input: MembershipUpdateMutationInput!){
+          updateMembership(input: $input) {
+            membership {
+              id
+              userRole
+              user {
+                email
+              }
+              group {
+                slug
+              }
+            }
+          }
+        }
+        """,
+        variables={
+            "input": {
+                "id": str(old_membership.id),
+                "userRole": Membership.ROLE_MEMBER,
+            }
+        },
+    )
+    response = response.json()
+
+    assert "errors" in response
+    assert "at least one manager" in response["errors"][0]["message"]
+
+
 def test_membership_update_by_non_manager_fail(settings, client_query, memberships):
     old_membership = memberships[0]
     old_membership.user_role = Membership.ROLE_MEMBER


### PR DESCRIPTION
This change updates the permissions checks on Membership update mutation
to don't allow the last Group Manager to become a Member.