### PR TITLE
feat: add error codes to validation error responses

### DIFF
--- a/terraso_backend/apps/graphql/exceptions.py
+++ b/terraso_backend/apps/graphql/exceptions.py
@@ -5,8 +5,24 @@ class GraphQLValidationException(Exception):
 
         for field, validation_errors in validation_error.error_dict.items():
             for error in validation_errors:
-                messages.extend([f"field={field}, error={message}" for message in error.messages])
+                messages.append(_format_error_message(field, error.code))
 
-        error_message = ";".join(messages)
+        error_message = "; ".join(messages)
 
         return cls(error_message)
+
+
+class GraphQLNotFoundException(GraphQLValidationException):
+    def __init__(self, message="", field=None):
+        super().__init__(_format_error_message(field, "not_found", extra=message))
+
+
+class GraphQLNotAllowedException(GraphQLValidationException):
+    def __init__(self, message="", field=None, operation="operation"):
+        super().__init__(_format_error_message(field, f"{operation}_not_allowed", extra=message))
+
+
+def _format_error_message(field, error_code, extra=""):
+    if extra:
+        return f"field={field}, error_code={error_code}, message={extra}"
+    return f"field={field}, error_code={error_code}"

--- a/terraso_backend/apps/graphql/exceptions.py
+++ b/terraso_backend/apps/graphql/exceptions.py
@@ -1,28 +1,64 @@
+import json
+from dataclasses import asdict, dataclass
+
+from .formatters import from_snake_to_camel_case
+
+
 class GraphQLValidationException(Exception):
+    def __init__(self, message="", error_messages=None):
+        if error_messages:
+            super().__init__(json.dumps([asdict(e) for e in error_messages]))
+        else:
+            super().__init__(message)
+
     @classmethod
-    def from_validation_error(cls, validation_error):
-        messages = []
+    def from_validation_error(cls, validation_error, model_name=""):
+        error_messages = []
 
         for field, validation_errors in validation_error.error_dict.items():
             for error in validation_errors:
-                messages.append(_format_error_message(field, error.code))
+                error_messages.append(
+                    ErrorMessage(
+                        code=error.code,
+                        context=ErrorContext(model=model_name, field=field),
+                    )
+                )
 
-        error_message = "; ".join(messages)
-
-        return cls(error_message)
+        return cls(error_messages=error_messages)
 
 
 class GraphQLNotFoundException(GraphQLValidationException):
-    def __init__(self, message="", field=None):
-        super().__init__(_format_error_message(field, "not_found", extra=message))
+    def __init__(self, message="", field=None, model_name=None):
+        error_message = ErrorMessage(
+            code="not_found", context=ErrorContext(model=model_name, field=field)
+        )
+        super().__init__(error_messages=[error_message])
 
 
 class GraphQLNotAllowedException(GraphQLValidationException):
-    def __init__(self, message="", field=None, operation="operation"):
-        super().__init__(_format_error_message(field, f"{operation}_not_allowed", extra=message))
+    def __init__(self, message="", field=None, model_name=None, operation="operation"):
+        operation_name = f"{operation}_not_allowed"
+
+        error_message = ErrorMessage(
+            code=operation_name, context=ErrorContext(model=model_name, field=field, extra=message)
+        )
+        super().__init__(error_messages=[error_message])
 
 
-def _format_error_message(field, error_code, extra=""):
-    if extra:
-        return f"field={field}, error_code={error_code}, message={extra}"
-    return f"field={field}, error_code={error_code}"
+@dataclass
+class ErrorContext:
+    model: str
+    field: str
+    extra: str = ""
+
+    def __post_init__(self):
+        self.field = from_snake_to_camel_case(self.field) if self.field else self.field
+
+
+@dataclass
+class ErrorMessage:
+    code: str
+    context: ErrorContext
+
+    def __post_init__(self):
+        self.code = from_snake_to_camel_case(self.code) if self.code else self.code

--- a/terraso_backend/apps/graphql/formatters.py
+++ b/terraso_backend/apps/graphql/formatters.py
@@ -1,0 +1,21 @@
+import re
+
+RE_CAMEL_TO_SNAKE_CASE = re.compile(r"(?<!^)(?=[A-Z])")
+
+
+def from_camel_to_snake_case(camel_case_string):
+    """
+    Transforms camel case to snake case. MyModel becomes my_model.
+    """
+    return RE_CAMEL_TO_SNAKE_CASE.sub("_", camel_case_string).lower()
+
+
+def from_snake_to_camel_case(snake_case_string):
+    """
+    Transforms camel case to snake case. my_field_name becomes myFieldName.
+    """
+    if not snake_case_string:
+        return ""
+
+    words = snake_case_string.split("_")
+    return words[0].lower() + "".join([w.lower().title() for w in words[1:]])

--- a/terraso_backend/apps/graphql/schema/constants.py
+++ b/terraso_backend/apps/graphql/schema/constants.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class MutationTypes(Enum):
+    CREATE = "create"
+    UPDATE = "update"
+    DELETE = "delete"
+
+    def __str__(self):
+        return self.value

--- a/terraso_backend/apps/graphql/schema/group_associations.py
+++ b/terraso_backend/apps/graphql/schema/group_associations.py
@@ -12,6 +12,7 @@ from apps.graphql.exceptions import (
 )
 
 from .commons import BaseDeleteMutation, TerrasoConnection
+from .constants import MutationTypes
 
 
 class GroupAssociationNode(DjangoObjectType):
@@ -65,7 +66,9 @@ class GroupAssociationAddMutation(relay.ClientIDMutation):
         if ff_check_permission_on and not user.has_perm(
             GroupAssociation.get_perm("add"), obj=parent_group.pk
         ):
-            raise GraphQLNotAllowedException(field="group_association", operation="add")
+            raise GraphQLNotAllowedException(
+                field="group_association", operation=MutationTypes.CREATE
+            )
 
         try:
             group_association.full_clean()
@@ -99,6 +102,8 @@ class GroupAssociationDeleteMutation(BaseDeleteMutation):
         if ff_check_permission_on and not user.has_perm(
             GroupAssociation.get_perm("delete"), obj=group_association
         ):
-            raise GraphQLNotAllowedException(field="group_association", operation="delete")
+            raise GraphQLNotAllowedException(
+                field="group_association", operation=MutationTypes.DELETE
+            )
 
         return super().mutate_and_get_payload(root, info, **kwargs)

--- a/terraso_backend/apps/graphql/schema/group_associations.py
+++ b/terraso_backend/apps/graphql/schema/group_associations.py
@@ -50,12 +50,16 @@ class GroupAssociationAddMutation(relay.ClientIDMutation):
         try:
             parent_group = Group.objects.get(slug=kwargs.pop("parent_group_slug"))
         except Group.DoesNotExist:
-            raise GraphQLNotFoundException(field="parent_group")
+            raise GraphQLNotFoundException(
+                field="parent_group", model_name=GroupAssociation.__name__
+            )
 
         try:
             child_group = Group.objects.get(slug=kwargs.pop("child_group_slug"))
         except Group.DoesNotExist:
-            raise GraphQLNotFoundException(field="child_group")
+            raise GraphQLNotFoundException(
+                field="child_group", model_name=GroupAssociation.__name__
+            )
 
         group_association = GroupAssociation()
         group_association.parent_group = parent_group
@@ -67,7 +71,7 @@ class GroupAssociationAddMutation(relay.ClientIDMutation):
             GroupAssociation.get_perm("add"), obj=parent_group.pk
         ):
             raise GraphQLNotAllowedException(
-                field="group_association", operation=MutationTypes.CREATE
+                model_name=GroupAssociation.__name__, operation=MutationTypes.CREATE
             )
 
         try:
@@ -95,7 +99,7 @@ class GroupAssociationDeleteMutation(BaseDeleteMutation):
         try:
             group_association = GroupAssociation.objects.get(pk=kwargs["id"])
         except GroupAssociation.DoesNotExist:
-            raise GraphQLNotFoundException(field="group_association")
+            raise GraphQLNotFoundException(model_name=GroupAssociation.__name__)
 
         ff_check_permission_on = settings.FEATURE_FLAGS["CHECK_PERMISSIONS"]
 
@@ -103,7 +107,7 @@ class GroupAssociationDeleteMutation(BaseDeleteMutation):
             GroupAssociation.get_perm("delete"), obj=group_association
         ):
             raise GraphQLNotAllowedException(
-                field="group_association", operation=MutationTypes.DELETE
+                model_name=GroupAssociation.__name__, operation=MutationTypes.DELETE
             )
 
         return super().mutate_and_get_payload(root, info, **kwargs)

--- a/terraso_backend/apps/graphql/schema/groups.py
+++ b/terraso_backend/apps/graphql/schema/groups.py
@@ -103,7 +103,9 @@ class GroupUpdateMutation(BaseWriteMutation):
             return super().mutate_and_get_payload(root, info, **kwargs)
 
         if not user.has_perm(Group.get_perm("change"), obj=kwargs["id"]):
-            raise GraphQLNotAllowedException(field="group", operation=MutationTypes.UPDATE)
+            raise GraphQLNotAllowedException(
+                model_name=Group.__name__, operation=MutationTypes.UPDATE
+            )
 
         return super().mutate_and_get_payload(root, info, **kwargs)
 
@@ -123,6 +125,8 @@ class GroupDeleteMutation(BaseDeleteMutation):
         user_has_delete_permission = user.has_perm(Group.get_perm("delete"), obj=kwargs["id"])
 
         if ff_check_permission_on and not user_has_delete_permission:
-            raise GraphQLNotAllowedException(field="group", operation=MutationTypes.DELETE)
+            raise GraphQLNotAllowedException(
+                model_name=Group.__name__, operation=MutationTypes.DELETE
+            )
 
         return super().mutate_and_get_payload(root, info, **kwargs)

--- a/terraso_backend/apps/graphql/schema/groups.py
+++ b/terraso_backend/apps/graphql/schema/groups.py
@@ -5,7 +5,7 @@ from graphene import relay
 from graphene_django import DjangoObjectType
 
 from apps.core.models import Group
-from apps.graphql.exceptions import GraphQLValidationException
+from apps.graphql.exceptions import GraphQLNotAllowedException
 
 from .commons import BaseDeleteMutation, BaseWriteMutation, TerrasoConnection
 
@@ -102,7 +102,7 @@ class GroupUpdateMutation(BaseWriteMutation):
             return super().mutate_and_get_payload(root, info, **kwargs)
 
         if not user.has_perm(Group.get_perm("change"), obj=kwargs["id"]):
-            raise GraphQLValidationException("User has no permission to change the Group.")
+            raise GraphQLNotAllowedException(field="group", operation="change")
 
         return super().mutate_and_get_payload(root, info, **kwargs)
 
@@ -120,6 +120,8 @@ class GroupDeleteMutation(BaseDeleteMutation):
 
         ff_check_permission_on = settings.FEATURE_FLAGS["CHECK_PERMISSIONS"]
         user_has_delete_permission = user.has_perm(Group.get_perm("delete"), obj=kwargs["id"])
+
         if ff_check_permission_on and not user_has_delete_permission:
-            raise GraphQLValidationException("User has no permission to delete this data.")
+            raise GraphQLNotAllowedException(field="group", operation="delete")
+
         return super().mutate_and_get_payload(root, info, **kwargs)

--- a/terraso_backend/apps/graphql/schema/groups.py
+++ b/terraso_backend/apps/graphql/schema/groups.py
@@ -8,6 +8,7 @@ from apps.core.models import Group
 from apps.graphql.exceptions import GraphQLNotAllowedException
 
 from .commons import BaseDeleteMutation, BaseWriteMutation, TerrasoConnection
+from .constants import MutationTypes
 
 
 class GroupFilterSet(django_filters.FilterSet):
@@ -102,7 +103,7 @@ class GroupUpdateMutation(BaseWriteMutation):
             return super().mutate_and_get_payload(root, info, **kwargs)
 
         if not user.has_perm(Group.get_perm("change"), obj=kwargs["id"]):
-            raise GraphQLNotAllowedException(field="group", operation="change")
+            raise GraphQLNotAllowedException(field="group", operation=MutationTypes.UPDATE)
 
         return super().mutate_and_get_payload(root, info, **kwargs)
 
@@ -122,6 +123,6 @@ class GroupDeleteMutation(BaseDeleteMutation):
         user_has_delete_permission = user.has_perm(Group.get_perm("delete"), obj=kwargs["id"])
 
         if ff_check_permission_on and not user_has_delete_permission:
-            raise GraphQLNotAllowedException(field="group", operation="delete")
+            raise GraphQLNotAllowedException(field="group", operation=MutationTypes.DELETE)
 
         return super().mutate_and_get_payload(root, info, **kwargs)

--- a/terraso_backend/apps/graphql/schema/landscape_groups.py
+++ b/terraso_backend/apps/graphql/schema/landscape_groups.py
@@ -52,12 +52,12 @@ class LandscapeGroupAddMutation(relay.ClientIDMutation):
         try:
             landscape = Landscape.objects.get(slug=kwargs.pop("landscape_slug"))
         except Landscape.DoesNotExist:
-            raise GraphQLNotFoundException(field="landscape")
+            raise GraphQLNotFoundException(field="landscape", model_name=LandscapeGroup.__name__)
 
         try:
             group = Group.objects.get(slug=kwargs.pop("group_slug"))
         except Group.DoesNotExist:
-            raise GraphQLNotFoundException(field="group")
+            raise GraphQLNotFoundException(field="group", model_name=LandscapeGroup.__name__)
 
         ff_check_permission_on = settings.FEATURE_FLAGS["CHECK_PERMISSIONS"]
 
@@ -65,7 +65,7 @@ class LandscapeGroupAddMutation(relay.ClientIDMutation):
             LandscapeGroup.get_perm("add"), obj=landscape.pk
         ):
             raise GraphQLNotAllowedException(
-                field="landscape_group", operation=MutationTypes.CREATE
+                model_name=LandscapeGroup.__name__, operation=MutationTypes.CREATE
             )
 
         landscape_group = LandscapeGroup()
@@ -96,7 +96,7 @@ class LandscapeGroupDeleteMutation(BaseDeleteMutation):
         try:
             landscape_group = LandscapeGroup.objects.get(pk=kwargs["id"])
         except LandscapeGroup.DoesNotExist:
-            raise GraphQLNotFoundException(field="landscape_group")
+            raise GraphQLNotFoundException(model_name=LandscapeGroup.__name__)
 
         ff_check_permission_on = settings.FEATURE_FLAGS["CHECK_PERMISSIONS"]
 
@@ -104,7 +104,7 @@ class LandscapeGroupDeleteMutation(BaseDeleteMutation):
             LandscapeGroup.get_perm("delete"), obj=landscape_group
         ):
             raise GraphQLNotAllowedException(
-                field="landscape_group", operation=MutationTypes.DELETE
+                model_name=LandscapeGroup.__name__, operation=MutationTypes.DELETE
             )
 
         return super().mutate_and_get_payload(root, info, **kwargs)

--- a/terraso_backend/apps/graphql/schema/landscape_groups.py
+++ b/terraso_backend/apps/graphql/schema/landscape_groups.py
@@ -12,6 +12,7 @@ from apps.graphql.exceptions import (
 )
 
 from .commons import BaseDeleteMutation, TerrasoConnection
+from .constants import MutationTypes
 
 
 class LandscapeGroupNode(DjangoObjectType):
@@ -63,7 +64,9 @@ class LandscapeGroupAddMutation(relay.ClientIDMutation):
         if ff_check_permission_on and not user.has_perm(
             LandscapeGroup.get_perm("add"), obj=landscape.pk
         ):
-            raise GraphQLNotAllowedException(field="landscape_group", operation="create")
+            raise GraphQLNotAllowedException(
+                field="landscape_group", operation=MutationTypes.CREATE
+            )
 
         landscape_group = LandscapeGroup()
         landscape_group.landscape = landscape
@@ -100,6 +103,8 @@ class LandscapeGroupDeleteMutation(BaseDeleteMutation):
         if ff_check_permission_on and not user.has_perm(
             LandscapeGroup.get_perm("delete"), obj=landscape_group
         ):
-            raise GraphQLNotAllowedException(field="landscape_group", operation="delete")
+            raise GraphQLNotAllowedException(
+                field="landscape_group", operation=MutationTypes.DELETE
+            )
 
         return super().mutate_and_get_payload(root, info, **kwargs)

--- a/terraso_backend/apps/graphql/schema/landscapes.py
+++ b/terraso_backend/apps/graphql/schema/landscapes.py
@@ -4,7 +4,7 @@ from graphene import relay
 from graphene_django import DjangoObjectType
 
 from apps.core.models import Landscape
-from apps.graphql.exceptions import GraphQLValidationException
+from apps.graphql.exceptions import GraphQLNotAllowedException
 
 from .commons import BaseDeleteMutation, BaseWriteMutation, TerrasoConnection
 
@@ -75,7 +75,7 @@ class LandscapeUpdateMutation(BaseWriteMutation):
             return super().mutate_and_get_payload(root, info, **kwargs)
 
         if not user.has_perm(Landscape.get_perm("change"), obj=kwargs["id"]):
-            raise GraphQLValidationException("User has no permission to change the Landscape.")
+            raise GraphQLNotAllowedException(field="landscape", operation="change")
 
         return super().mutate_and_get_payload(root, info, **kwargs)
 
@@ -96,6 +96,6 @@ class LandscapeDeleteMutation(BaseDeleteMutation):
         user_has_delete_permission = user.has_perm(Landscape.get_perm("delete"), obj=kwargs["id"])
 
         if ff_check_permission_on and not user_has_delete_permission:
-            raise GraphQLValidationException("User has no permission to delete this data.")
+            raise GraphQLNotAllowedException(field="landscape", operation="delete")
 
         return super().mutate_and_get_payload(root, info, **kwargs)

--- a/terraso_backend/apps/graphql/schema/landscapes.py
+++ b/terraso_backend/apps/graphql/schema/landscapes.py
@@ -76,7 +76,9 @@ class LandscapeUpdateMutation(BaseWriteMutation):
             return super().mutate_and_get_payload(root, info, **kwargs)
 
         if not user.has_perm(Landscape.get_perm("change"), obj=kwargs["id"]):
-            raise GraphQLNotAllowedException(field="landscape", operation=MutationTypes.UPDATE)
+            raise GraphQLNotAllowedException(
+                model_name=Landscape.__name__, operation=MutationTypes.UPDATE
+            )
 
         return super().mutate_and_get_payload(root, info, **kwargs)
 
@@ -97,6 +99,8 @@ class LandscapeDeleteMutation(BaseDeleteMutation):
         user_has_delete_permission = user.has_perm(Landscape.get_perm("delete"), obj=kwargs["id"])
 
         if ff_check_permission_on and not user_has_delete_permission:
-            raise GraphQLNotAllowedException(field="landscape", operation=MutationTypes.DELETE)
+            raise GraphQLNotAllowedException(
+                model_name=Landscape.__name__, operation=MutationTypes.DELETE
+            )
 
         return super().mutate_and_get_payload(root, info, **kwargs)

--- a/terraso_backend/apps/graphql/schema/landscapes.py
+++ b/terraso_backend/apps/graphql/schema/landscapes.py
@@ -7,6 +7,7 @@ from apps.core.models import Landscape
 from apps.graphql.exceptions import GraphQLNotAllowedException
 
 from .commons import BaseDeleteMutation, BaseWriteMutation, TerrasoConnection
+from .constants import MutationTypes
 
 
 class LandscapeNode(DjangoObjectType):
@@ -75,7 +76,7 @@ class LandscapeUpdateMutation(BaseWriteMutation):
             return super().mutate_and_get_payload(root, info, **kwargs)
 
         if not user.has_perm(Landscape.get_perm("change"), obj=kwargs["id"]):
-            raise GraphQLNotAllowedException(field="landscape", operation="change")
+            raise GraphQLNotAllowedException(field="landscape", operation=MutationTypes.UPDATE)
 
         return super().mutate_and_get_payload(root, info, **kwargs)
 
@@ -96,6 +97,6 @@ class LandscapeDeleteMutation(BaseDeleteMutation):
         user_has_delete_permission = user.has_perm(Landscape.get_perm("delete"), obj=kwargs["id"])
 
         if ff_check_permission_on and not user_has_delete_permission:
-            raise GraphQLNotAllowedException(field="landscape", operation="delete")
+            raise GraphQLNotAllowedException(field="landscape", operation=MutationTypes.DELETE)
 
         return super().mutate_and_get_payload(root, info, **kwargs)

--- a/terraso_backend/apps/graphql/schema/memberships.py
+++ b/terraso_backend/apps/graphql/schema/memberships.py
@@ -12,6 +12,7 @@ from apps.graphql.exceptions import (
 )
 
 from .commons import BaseDeleteMutation, TerrasoConnection
+from .constants import MutationTypes
 
 
 class MembershipNode(DjangoObjectType):
@@ -89,11 +90,11 @@ class MembershipUpdateMutation(relay.ClientIDMutation):
             return cls(membership=membership)
 
         if not user.has_perm(Membership.get_perm("change"), obj=membership.group.id):
-            raise GraphQLNotAllowedException(field="membership", operation="change")
+            raise GraphQLNotAllowedException(field="membership", operation=MutationTypes.UPDATE)
 
         if not rules.test_rule("allowed_group_managers_count", user, kwargs["id"]):
             raise GraphQLNotAllowedException(
-                field="membership", operation="change", message="manager_count"
+                field="membership", operation=MutationTypes.UPDATE, message="manager_count"
             )
 
         membership.user_role = Membership.get_user_role_from_text(user_role)
@@ -118,11 +119,11 @@ class MembershipDeleteMutation(BaseDeleteMutation):
             return super().mutate_and_get_payload(root, info, **kwargs)
 
         if not user.has_perm(Membership.get_perm("delete"), obj=kwargs["id"]):
-            raise GraphQLNotAllowedException(field="membership", operation="delete")
+            raise GraphQLNotAllowedException(field="membership", operation=MutationTypes.DELETE)
 
         if not rules.test_rule("allowed_group_managers_count", user, kwargs["id"]):
             raise GraphQLNotAllowedException(
-                field="membership", operation="change", message="manager_count"
+                field="membership", operation=MutationTypes.DELETE, message="manager_count"
             )
 
         return super().mutate_and_get_payload(root, info, **kwargs)

--- a/terraso_backend/apps/graphql/schema/users.py
+++ b/terraso_backend/apps/graphql/schema/users.py
@@ -6,6 +6,7 @@ from apps.core.models import User
 from apps.graphql.exceptions import GraphQLNotAllowedException
 
 from .commons import BaseDeleteMutation, TerrasoConnection
+from .constants import MutationTypes
 
 
 class UserNode(DjangoObjectType):
@@ -59,7 +60,7 @@ class UserUpdateMutation(relay.ClientIDMutation):
         _id = kwargs.pop("id")
 
         if str(request_user.id) != _id:
-            raise GraphQLNotAllowedException(field="user", operation="change")
+            raise GraphQLNotAllowedException(field="user", operation=MutationTypes.UPDATE)
 
         user = User.objects.get(pk=_id)
         new_password = kwargs.pop("password", None)
@@ -88,6 +89,6 @@ class UserDeleteMutation(BaseDeleteMutation):
         _id = kwargs.get("id")
 
         if str(request_user.id) != _id:
-            raise GraphQLNotAllowedException(field="user", operation="delete")
+            raise GraphQLNotAllowedException(field="user", operation=MutationTypes.DELETE)
 
         return super().mutate_and_get_payload(root, info, **kwargs)

--- a/terraso_backend/apps/graphql/schema/users.py
+++ b/terraso_backend/apps/graphql/schema/users.py
@@ -3,7 +3,7 @@ from graphene import relay
 from graphene_django import DjangoObjectType
 
 from apps.core.models import User
-from apps.graphql.exceptions import GraphQLValidationException
+from apps.graphql.exceptions import GraphQLNotAllowedException
 
 from .commons import BaseDeleteMutation, TerrasoConnection
 
@@ -59,9 +59,7 @@ class UserUpdateMutation(relay.ClientIDMutation):
         _id = kwargs.pop("id")
 
         if str(request_user.id) != _id:
-            raise GraphQLValidationException(
-                f"User {request_user.id} has no permission to change data for user {_id}."
-            )
+            raise GraphQLNotAllowedException(field="user", operation="change")
 
         user = User.objects.get(pk=_id)
         new_password = kwargs.pop("password", None)
@@ -90,8 +88,6 @@ class UserDeleteMutation(BaseDeleteMutation):
         _id = kwargs.get("id")
 
         if str(request_user.id) != _id:
-            raise GraphQLValidationException(
-                f"User {request_user.id} has no permission to delete user {_id}."
-            )
+            raise GraphQLNotAllowedException(field="user", operation="delete")
 
         return super().mutate_and_get_payload(root, info, **kwargs)

--- a/terraso_backend/apps/graphql/schema/users.py
+++ b/terraso_backend/apps/graphql/schema/users.py
@@ -60,7 +60,9 @@ class UserUpdateMutation(relay.ClientIDMutation):
         _id = kwargs.pop("id")
 
         if str(request_user.id) != _id:
-            raise GraphQLNotAllowedException(field="user", operation=MutationTypes.UPDATE)
+            raise GraphQLNotAllowedException(
+                model_name=User.__name__, operation=MutationTypes.UPDATE
+            )
 
         user = User.objects.get(pk=_id)
         new_password = kwargs.pop("password", None)
@@ -89,6 +91,8 @@ class UserDeleteMutation(BaseDeleteMutation):
         _id = kwargs.get("id")
 
         if str(request_user.id) != _id:
-            raise GraphQLNotAllowedException(field="user", operation=MutationTypes.DELETE)
+            raise GraphQLNotAllowedException(
+                model_name=User.__name__, operation=MutationTypes.DELETE
+            )
 
         return super().mutate_and_get_payload(root, info, **kwargs)

--- a/terraso_backend/tests/graphql/mutations/test_group_associations_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_group_associations_mutations.py
@@ -68,7 +68,7 @@ def test_group_associations_add_by_non_parent_manager_fails(settings, client_que
     response = response.json()
 
     assert "errors" in response
-    assert "no permission" in response["errors"][0]["message"]
+    assert "not_allowed" in response["errors"][0]["message"]
 
 
 def test_group_associations_add_duplicated(settings, client_query, users, group_associations):
@@ -132,7 +132,7 @@ def test_group_associations_add_parent_group_not_found(settings, client_query, g
     response = response.json()
 
     assert "errors" in response
-    assert "Parent Group not found" in response["errors"][0]["message"]
+    assert "not_found" in response["errors"][0]["message"]
 
 
 def test_group_associations_add_child_group_not_found(settings, client_query, groups):
@@ -162,7 +162,7 @@ def test_group_associations_add_child_group_not_found(settings, client_query, gr
     response = response.json()
 
     assert "errors" in response
-    assert "Child Group not found" in response["errors"][0]["message"]
+    assert "not_found" in response["errors"][0]["message"]
 
 
 def test_group_associations_delete_by_parent_manager(
@@ -246,4 +246,4 @@ def test_group_associations_delete_by_non_manager_fail(settings, client_query, g
     response = response.json()
 
     assert "errors" in response
-    assert "no permission" in response["errors"][0]["message"]
+    assert "not_allowed" in response["errors"][0]["message"]

--- a/terraso_backend/tests/graphql/mutations/test_group_associations_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_group_associations_mutations.py
@@ -68,7 +68,7 @@ def test_group_associations_add_by_non_parent_manager_fails(settings, client_que
     response = response.json()
 
     assert "errors" in response
-    assert "not_allowed" in response["errors"][0]["message"]
+    assert "createNotAllowed" in response["errors"][0]["message"]
 
 
 def test_group_associations_add_duplicated(settings, client_query, users, group_associations):
@@ -132,7 +132,7 @@ def test_group_associations_add_parent_group_not_found(settings, client_query, g
     response = response.json()
 
     assert "errors" in response
-    assert "not_found" in response["errors"][0]["message"]
+    assert "notFound" in response["errors"][0]["message"]
 
 
 def test_group_associations_add_child_group_not_found(settings, client_query, groups):
@@ -162,7 +162,7 @@ def test_group_associations_add_child_group_not_found(settings, client_query, gr
     response = response.json()
 
     assert "errors" in response
-    assert "not_found" in response["errors"][0]["message"]
+    assert "notFound" in response["errors"][0]["message"]
 
 
 def test_group_associations_delete_by_parent_manager(
@@ -246,4 +246,4 @@ def test_group_associations_delete_by_non_manager_fail(settings, client_query, g
     response = response.json()
 
     assert "errors" in response
-    assert "not_allowed" in response["errors"][0]["message"]
+    assert "deleteNotAllowed" in response["errors"][0]["message"]

--- a/terraso_backend/tests/graphql/mutations/test_group_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_group_mutations.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from apps.core.models import Group
@@ -69,7 +71,10 @@ def test_groups_add_duplicated(client_query, groups):
     error_result = response.json()["errors"][0]
 
     assert error_result
-    assert "field=name" in error_result["message"]
+
+    error_message = json.loads(error_result["message"])[0]
+    assert error_message["code"] == "unique"
+    assert error_message["context"]["field"] == "name"
 
 
 def test_groups_update_by_manager_works(client_query, groups, users):
@@ -129,7 +134,7 @@ def test_groups_update_by_member_fails_due_permission_check(settings, client_que
     response = response.json()
 
     assert "errors" in response
-    assert "not_allowed" in response["errors"][0]["message"]
+    assert "updateNotAllowed" in response["errors"][0]["message"]
 
 
 def test_groups_delete_by_manager(settings, client_query, managed_groups):
@@ -179,4 +184,4 @@ def test_groups_delete_by_non_manager(settings, client_query, groups):
     response = response.json()
 
     assert "errors" in response
-    assert "not_allowed" in response["errors"][0]["message"]
+    assert "deleteNotAllowed" in response["errors"][0]["message"]

--- a/terraso_backend/tests/graphql/mutations/test_group_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_group_mutations.py
@@ -129,7 +129,7 @@ def test_groups_update_by_member_fails_due_permission_check(settings, client_que
     response = response.json()
 
     assert "errors" in response
-    assert "has no permission to change" in response["errors"][0]["message"]
+    assert "not_allowed" in response["errors"][0]["message"]
 
 
 def test_groups_delete_by_manager(settings, client_query, managed_groups):
@@ -178,5 +178,5 @@ def test_groups_delete_by_non_manager(settings, client_query, groups):
 
     response = response.json()
 
-    assert "has no permission" in response["errors"][0]["message"]
     assert "errors" in response
+    assert "not_allowed" in response["errors"][0]["message"]

--- a/terraso_backend/tests/graphql/mutations/test_landscape_groups_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_landscape_groups_mutations.py
@@ -82,7 +82,7 @@ def test_landscape_groups_add_by_non_landscape_manager_not_allowed(
     response = response.json()
 
     assert "errors" in response
-    assert "no permission" in response["errors"][0]["message"]
+    assert "not_allowed" in response["errors"][0]["message"]
 
 
 def test_landscape_groups_add_duplicated(settings, client_query, users, landscape_groups):
@@ -153,7 +153,7 @@ def test_landscape_groups_add_landscape_not_found(settings, client_query, groups
     response = response.json()
 
     assert "errors" in response
-    assert "Landscape not found" in response["errors"][0]["message"]
+    assert "not_found" in response["errors"][0]["message"]
 
 
 def test_landscape_groups_add_group_not_found(settings, client_query, managed_landscapes):
@@ -187,7 +187,7 @@ def test_landscape_groups_add_group_not_found(settings, client_query, managed_la
     response = response.json()
 
     assert "errors" in response
-    assert "Group not found" in response["errors"][0]["message"]
+    assert "not_found" in response["errors"][0]["message"]
 
 
 def test_landscape_groups_delete_by_group_manager(settings, client_query, users, landscape_groups):
@@ -271,7 +271,7 @@ def test_landscape_groups_delete_by_non_managers_not_allowed(
     response = response.json()
 
     assert "errors" in response
-    assert "no permission" in response["errors"][0]["message"]
+    assert "not_allowed" in response["errors"][0]["message"]
 
 
 def test_landscape_groups_delete_not_found(settings, client_query, users):
@@ -293,4 +293,4 @@ def test_landscape_groups_delete_not_found(settings, client_query, users):
     response = response.json()
 
     assert "errors" in response
-    assert "Landscape Group not found" in response["errors"][0]["message"]
+    assert "not_found" in response["errors"][0]["message"]

--- a/terraso_backend/tests/graphql/mutations/test_landscape_groups_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_landscape_groups_mutations.py
@@ -82,7 +82,7 @@ def test_landscape_groups_add_by_non_landscape_manager_not_allowed(
     response = response.json()
 
     assert "errors" in response
-    assert "not_allowed" in response["errors"][0]["message"]
+    assert "createNotAllowed" in response["errors"][0]["message"]
 
 
 def test_landscape_groups_add_duplicated(settings, client_query, users, landscape_groups):
@@ -153,7 +153,7 @@ def test_landscape_groups_add_landscape_not_found(settings, client_query, groups
     response = response.json()
 
     assert "errors" in response
-    assert "not_found" in response["errors"][0]["message"]
+    assert "notFound" in response["errors"][0]["message"]
 
 
 def test_landscape_groups_add_group_not_found(settings, client_query, managed_landscapes):
@@ -187,7 +187,7 @@ def test_landscape_groups_add_group_not_found(settings, client_query, managed_la
     response = response.json()
 
     assert "errors" in response
-    assert "not_found" in response["errors"][0]["message"]
+    assert "notFound" in response["errors"][0]["message"]
 
 
 def test_landscape_groups_delete_by_group_manager(settings, client_query, users, landscape_groups):
@@ -271,7 +271,7 @@ def test_landscape_groups_delete_by_non_managers_not_allowed(
     response = response.json()
 
     assert "errors" in response
-    assert "not_allowed" in response["errors"][0]["message"]
+    assert "deleteNotAllowed" in response["errors"][0]["message"]
 
 
 def test_landscape_groups_delete_not_found(settings, client_query, users):
@@ -293,4 +293,4 @@ def test_landscape_groups_delete_not_found(settings, client_query, users):
     response = response.json()
 
     assert "errors" in response
-    assert "not_found" in response["errors"][0]["message"]
+    assert "notFound" in response["errors"][0]["message"]

--- a/terraso_backend/tests/graphql/mutations/test_landscape_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_landscape_mutations.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from apps.core.models import Landscape
@@ -68,7 +70,10 @@ def test_landscapes_add_duplicated(client_query, landscapes):
     error_result = response.json()["errors"][0]
 
     assert error_result
-    assert "field=name" in error_result["message"]
+
+    error_message = json.loads(error_result["message"])[0]
+    assert error_message["code"] == "unique"
+    assert error_message["context"]["field"] == "name"
 
 
 def test_landscapes_update_by_manager_works(settings, client_query, managed_landscapes):
@@ -132,7 +137,7 @@ def test_landscapes_update_by_member_fails_due_permission_check(settings, client
     response = response.json()
 
     assert "errors" in response
-    assert "not_allowed" in response["errors"][0]["message"]
+    assert "updateNotAllowed" in response["errors"][0]["message"]
 
 
 def test_landscapes_delete_by_manager(settings, client_query, managed_landscapes):
@@ -182,4 +187,4 @@ def test_landscapes_delete_by_non_manager(settings, client_query, landscapes):
     response = response.json()
 
     assert "errors" in response
-    assert "not_allowed" in response["errors"][0]["message"]
+    assert "deleteNotAllowed" in response["errors"][0]["message"]

--- a/terraso_backend/tests/graphql/mutations/test_landscape_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_landscape_mutations.py
@@ -132,7 +132,7 @@ def test_landscapes_update_by_member_fails_due_permission_check(settings, client
     response = response.json()
 
     assert "errors" in response
-    assert "has no permission to change" in response["errors"][0]["message"]
+    assert "not_allowed" in response["errors"][0]["message"]
 
 
 def test_landscapes_delete_by_manager(settings, client_query, managed_landscapes):
@@ -182,4 +182,4 @@ def test_landscapes_delete_by_non_manager(settings, client_query, landscapes):
     response = response.json()
 
     assert "errors" in response
-    assert "has no permission" in response["errors"][0]["message"]
+    assert "not_allowed" in response["errors"][0]["message"]

--- a/terraso_backend/tests/graphql/mutations/test_membership_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_membership_mutations.py
@@ -74,7 +74,7 @@ def test_membership_add_group_not_found(client_query, users):
     response = response.json()
 
     assert "errors" in response
-    assert "Group not found" in response["errors"][0]["message"]
+    assert "notFound" in response["errors"][0]["message"]
 
 
 def test_membership_add_user_not_found(client_query, groups):
@@ -107,7 +107,7 @@ def test_membership_add_user_not_found(client_query, groups):
     response = response.json()
 
     assert "errors" in response
-    assert "User not found" in response["errors"][0]["message"]
+    assert "notFound" in response["errors"][0]["message"]
 
 
 def test_membership_adding_duplicated_returns_previously_created(client_query, memberships):
@@ -265,7 +265,7 @@ def test_membership_update_role_by_last_manager_fails(settings, client_query, us
     response = response.json()
 
     assert "errors" in response
-    assert "not_allowed" in response["errors"][0]["message"]
+    assert "updateNotAllowed" in response["errors"][0]["message"]
 
 
 def test_membership_update_by_non_manager_fail(settings, client_query, memberships):
@@ -295,7 +295,7 @@ def test_membership_update_by_non_manager_fail(settings, client_query, membershi
     response = response.json()
 
     assert "errors" in response
-    assert "not_allowed" in response["errors"][0]["message"]
+    assert "updateNotAllowed" in response["errors"][0]["message"]
 
 
 def test_membership_update_not_found(client_query, memberships):
@@ -319,7 +319,7 @@ def test_membership_update_not_found(client_query, memberships):
     response = response.json()
 
     assert "errors" in response
-    assert "not_found" in response["errors"][0]["message"]
+    assert "notFound" in response["errors"][0]["message"]
 
 
 def test_membership_delete(settings, client_query, users, groups):
@@ -461,7 +461,7 @@ def test_membership_delete_by_any_other_user(settings, client_query, memberships
     response = response.json()
 
     assert "errors" in response
-    assert "not_allowed" in response["errors"][0]["message"]
+    assert "deleteNotAllowed" in response["errors"][0]["message"]
 
 
 def test_membership_delete_by_last_manager(settings, client_query, memberships, users):
@@ -494,4 +494,4 @@ def test_membership_delete_by_last_manager(settings, client_query, memberships, 
     response = response.json()
 
     assert "errors" in response
-    assert "not_allowed" in response["errors"][0]["message"]
+    assert "deleteNotAllowed" in response["errors"][0]["message"]

--- a/terraso_backend/tests/graphql/mutations/test_membership_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_membership_mutations.py
@@ -265,7 +265,7 @@ def test_membership_update_role_by_last_manager_fails(settings, client_query, us
     response = response.json()
 
     assert "errors" in response
-    assert "at least one manager" in response["errors"][0]["message"]
+    assert "not_allowed" in response["errors"][0]["message"]
 
 
 def test_membership_update_by_non_manager_fail(settings, client_query, memberships):
@@ -295,7 +295,7 @@ def test_membership_update_by_non_manager_fail(settings, client_query, membershi
     response = response.json()
 
     assert "errors" in response
-    assert "no permission" in response["errors"][0]["message"]
+    assert "not_allowed" in response["errors"][0]["message"]
 
 
 def test_membership_update_not_found(client_query, memberships):
@@ -319,7 +319,7 @@ def test_membership_update_not_found(client_query, memberships):
     response = response.json()
 
     assert "errors" in response
-    assert "not found" in response["errors"][0]["message"]
+    assert "not_found" in response["errors"][0]["message"]
 
 
 def test_membership_delete(settings, client_query, users, groups):
@@ -461,7 +461,7 @@ def test_membership_delete_by_any_other_user(settings, client_query, memberships
     response = response.json()
 
     assert "errors" in response
-    assert "has no permission to delete" in response["errors"][0]["message"]
+    assert "not_allowed" in response["errors"][0]["message"]
 
 
 def test_membership_delete_by_last_manager(settings, client_query, memberships, users):
@@ -494,4 +494,4 @@ def test_membership_delete_by_last_manager(settings, client_query, memberships, 
     response = response.json()
 
     assert "errors" in response
-    assert "at least one manager" in response["errors"][0]["message"]
+    assert "not_allowed" in response["errors"][0]["message"]

--- a/terraso_backend/tests/graphql/mutations/test_user_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_user_mutations.py
@@ -78,7 +78,7 @@ def test_users_update_by_other_user_fail(client_query, users):
     response = response.json()
 
     assert "errors" in response
-    assert "no permission" in response["errors"][0]["message"]
+    assert "not_allowed" in response["errors"][0]["message"]
 
 
 def test_users_delete(client_query, users):
@@ -119,4 +119,4 @@ def test_users_delete_by_other_user_fail(client_query, users):
     response = response.json()
 
     assert "errors" in response
-    assert "no permission" in response["errors"][0]["message"]
+    assert "not_allowed" in response["errors"][0]["message"]

--- a/terraso_backend/tests/graphql/mutations/test_user_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_user_mutations.py
@@ -78,7 +78,7 @@ def test_users_update_by_other_user_fail(client_query, users):
     response = response.json()
 
     assert "errors" in response
-    assert "not_allowed" in response["errors"][0]["message"]
+    assert "updateNotAllowed" in response["errors"][0]["message"]
 
 
 def test_users_delete(client_query, users):
@@ -119,4 +119,4 @@ def test_users_delete_by_other_user_fail(client_query, users):
     response = response.json()
 
     assert "errors" in response
-    assert "not_allowed" in response["errors"][0]["message"]
+    assert "deleteNotAllowed" in response["errors"][0]["message"]

--- a/terraso_backend/tests/graphql/test_formatters.py
+++ b/terraso_backend/tests/graphql/test_formatters.py
@@ -1,0 +1,28 @@
+import pytest
+
+from apps.graphql.formatters import from_camel_to_snake_case, from_snake_to_camel_case
+
+
+@pytest.mark.parametrize(
+    "camel_case, snake_case",
+    (
+        ("field", "field"),
+        ("fieldName", "field_name"),
+        ("multiPartFieldName", "multi_part_field_name"),
+    ),
+)
+def test_camel_to_snake(camel_case, snake_case):
+    assert from_camel_to_snake_case(camel_case) == snake_case
+
+
+@pytest.mark.parametrize(
+    "snake_case, camel_case",
+    (
+        ("field", "field"),
+        ("field_name", "fieldName"),
+        ("multi_part_field_name", "multiPartFieldName"),
+        ("uNusuAl_FiEld_nAMe", "unusualFieldName"),
+    ),
+)
+def test_snake_to_camel(snake_case, camel_case):
+    assert from_snake_to_camel_case(snake_case) == camel_case


### PR DESCRIPTION
This change updates how the validation messages are built. It now makes
the message be a serialized JSON in order to add more contextual data to
the message. This is an attempt to make possible the i18n of validation
messages by the clients.

This is an example of validation error message using the new schema:

```
'message': '[{
    "code": "updateNotAllowed",
    "context": {"model": null, "field": "membership"}
}]'
```

If the validation happens in a specific field, the context `field`
attribute will have the related field name. Otherwise, it will be null. 

```
'message': '[{
    "code": "notFound",
    "context": {"model": "Membership", "field": "group", "extra": ""}
}]'
```

In some specific cases, an error message might have a complement to the
error code. Like in a situation where a `Membership` cannot be updated
because the user is the last manager in that group:

```
'message': '[{
    "code": "updateNotAllowed",
    "context": {"model": "Membership", "field": null, "extra": "manager_count"}
}]'
```

In cases where more than one field have validation errors, then the
message will have more than one object:

```
'message': '[
    {"code": "blank", "context": {"model": "Landscape", "field": "name"}},
    {"code": "invalid", "context": {"model": "Landscape", "field": "website"}
}]'
```

To make this structure work, more specific exceptions were added to the
GraphQL app with the proper handler to format the error message. Also,
all mutations were already updated to work with the new schema.