### PR TITLE
feat: add state parameter to authorize URL API

### DIFF
--- a/terraso_backend/apps/auth/providers.py
+++ b/terraso_backend/apps/auth/providers.py
@@ -27,7 +27,10 @@ class GoogleProvider:
             "client_id": cls.CLIENT_ID,
         }
 
-        return self.GOOGLE_OAUTH_BASE_URL + urllib.parse.urlencode(params)
+        if state:
+            params["state"] = state
+
+        return cls.GOOGLE_OAUTH_BASE_URL + urllib.parse.urlencode(params)
 
     def fetch_auth_tokens(self, authorization_code):
         request_data = {
@@ -60,7 +63,10 @@ class AppleProvider:
             "client_id": cls.CLIENT_ID,
         }
 
-        return self.OAUTH_BASE_URL + urllib.parse.urlencode(params, quote_via=urllib.parse.quote)
+        if state:
+            params["state"] = state
+
+        return cls.OAUTH_BASE_URL + urllib.parse.urlencode(params, quote_via=urllib.parse.quote)
 
     def fetch_auth_tokens(self, authorization_code):
         request_data = {

--- a/terraso_backend/apps/auth/providers.py
+++ b/terraso_backend/apps/auth/providers.py
@@ -17,14 +17,14 @@ class GoogleProvider:
     REDIRECT_URI = settings.GOOGLE_AUTH_REDIRECT_URI
 
     @classmethod
-    def login_url(self):
+    def login_url(cls, state=None):
         params = {
             "scope": "openid email profile",
             "access_type": "offline",
             "include_granted_scopes": "true",
             "response_type": "code",
-            "redirect_uri": self.REDIRECT_URI,
-            "client_id": self.CLIENT_ID,
+            "redirect_uri": cls.REDIRECT_URI,
+            "client_id": cls.CLIENT_ID,
         }
 
         return self.GOOGLE_OAUTH_BASE_URL + urllib.parse.urlencode(params)
@@ -51,13 +51,13 @@ class AppleProvider:
     JWT_AUD = "https://appleid.apple.com"
 
     @classmethod
-    def login_url(self):
+    def login_url(cls, state=None):
         params = {
             "scope": "name email openid",
             "response_type": "code",
             "response_mode": "form_post",
-            "redirect_uri": self.REDIRECT_URI,
-            "client_id": self.CLIENT_ID,
+            "redirect_uri": cls.REDIRECT_URI,
+            "client_id": cls.CLIENT_ID,
         }
 
         return self.OAUTH_BASE_URL + urllib.parse.urlencode(params, quote_via=urllib.parse.quote)


### PR DESCRIPTION
This change adds the `state` parameter to the `{provider}/authorize`
API. This endpoint returns the proper provider URL to redirect the user to
authentication. Now, this API accepts a `state` parameter that will be
used to redirect back user to the client. Example:

If the authorize URL for Google be request like:
```
/auth/google/authorize?state=groups/new
```

After a successful authentication, the user will be redirected to
`{web_client_endpoint}/groups/new`.