### PR TITLE
chore: adds settings to serve static files from CDN

### DIFF
--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -29,13 +29,14 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "corsheaders",
     "graphene_django",
     "rules",
+    "storages",
     "safedelete",
     "apps.core",
     "apps.graphql",
     "apps.auth",
-    "corsheaders",
 ]
 
 MIDDLEWARE = [

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -108,6 +108,13 @@ USE_TZ = True
 MEDIA_URL = "/media/"
 STATIC_URL = "/static/"
 
+if not DEBUG:
+    CDN_STATIC_DOMAIN = config("CDN_STATIC_DOMAIN")
+    AWS_S3_CUSTOM_DOMAIN = CDN_STATIC_DOMAIN
+    AWS_STORAGE_BUCKET_NAME = CDN_STATIC_DOMAIN
+    STATIC_URL = f"{CDN_STATIC_DOMAIN}/"
+    STATICFILES_STORAGE = "storages.backends.s3boto3.S3StaticStorage"
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -18,6 +18,10 @@ PROJECT_DIR = os.path.dirname(os.path.abspath(BASE_DIR))
 DEBUG = config("DEBUG", default=False, cast=config.boolean)
 
 ALLOWED_HOSTS = config("ALLOWED_HOSTS", default="*", cast=config.list)
+CSRF_TRUSTED_ORIGINS = config(
+    "CSRF_TRUSTED_ORIGINS", default="https://*.terraso.org", cast=config.list
+)
+
 SECRET_KEY = config("SECRET_KEY")
 
 SILENCED_SYSTEM_CHECKS = ["auth.W004"]


### PR DESCRIPTION
This change adds the settings to the application serve the static files
from S3 (through Cloudflare).

This is part of:
- #25 