### PR TITLE
chore: sets JSON log formatter to console log

### DIFF
--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -125,6 +125,10 @@ LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": {
+        "json_formatter": {
+            "()": structlog.stdlib.ProcessorFormatter,
+            "processor": structlog.processors.JSONRenderer(),
+        },
         "plain_console": {
             "()": structlog.stdlib.ProcessorFormatter,
             "processor": structlog.dev.ConsoleRenderer(),
@@ -133,7 +137,7 @@ LOGGING = {
     "handlers": {
         "console": {
             "class": "logging.StreamHandler",
-            "formatter": "plain_console",
+            "formatter": "json_formatter",
         },
     },
     "loggers": {


### PR DESCRIPTION
This change sets the JSON log formatter to the console logger. This way
we can have the log parsed on log management platforms.

This is part of:
- #78 