### PR TITLE
chore: removes check permissions feature flag

### DIFF
--- a/terraso_backend/apps/graphql/schema/group_associations.py
+++ b/terraso_backend/apps/graphql/schema/group_associations.py
@@ -1,6 +1,5 @@
 import graphene
 import structlog
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from graphene import relay
 from graphene_django import DjangoObjectType
@@ -79,11 +78,7 @@ class GroupAssociationAddMutation(relay.ClientIDMutation):
         group_association.parent_group = parent_group
         group_association.child_group = child_group
 
-        ff_check_permission_on = settings.FEATURE_FLAGS["CHECK_PERMISSIONS"]
-
-        if ff_check_permission_on and not user.has_perm(
-            GroupAssociation.get_perm("add"), obj=parent_group.pk
-        ):
+        if not user.has_perm(GroupAssociation.get_perm("add"), obj=parent_group.pk):
             logger.info(
                 "Attempt to create a Group Association, but user has no permission",
                 extra={"user_id": user.pk},
@@ -129,11 +124,7 @@ class GroupAssociationDeleteMutation(BaseDeleteMutation):
             )
             raise GraphQLNotFoundException(model_name=GroupAssociation.__name__)
 
-        ff_check_permission_on = settings.FEATURE_FLAGS["CHECK_PERMISSIONS"]
-
-        if ff_check_permission_on and not user.has_perm(
-            GroupAssociation.get_perm("delete"), obj=group_association
-        ):
+        if not user.has_perm(GroupAssociation.get_perm("delete"), obj=group_association):
             logger.info(
                 "Attempt to delete a Group Association, but user has no permission",
                 extra={"user_id": user.pk, "group_association": group_association_id},

--- a/terraso_backend/apps/graphql/schema/landscape_groups.py
+++ b/terraso_backend/apps/graphql/schema/landscape_groups.py
@@ -1,6 +1,5 @@
 import graphene
 import structlog
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from graphene import relay
 from graphene_django import DjangoObjectType
@@ -71,11 +70,7 @@ class LandscapeGroupAddMutation(relay.ClientIDMutation):
             )
             raise GraphQLNotFoundException(field="group", model_name=LandscapeGroup.__name__)
 
-        ff_check_permission_on = settings.FEATURE_FLAGS["CHECK_PERMISSIONS"]
-
-        if ff_check_permission_on and not user.has_perm(
-            LandscapeGroup.get_perm("add"), obj=landscape.pk
-        ):
+        if not user.has_perm(LandscapeGroup.get_perm("add"), obj=landscape.pk):
             logger.info(
                 "Attempt to add a Landscape Group, but user has no permission",
                 extra={
@@ -128,11 +123,7 @@ class LandscapeGroupDeleteMutation(BaseDeleteMutation):
             )
             raise GraphQLNotFoundException(model_name=LandscapeGroup.__name__)
 
-        ff_check_permission_on = settings.FEATURE_FLAGS["CHECK_PERMISSIONS"]
-
-        if ff_check_permission_on and not user.has_perm(
-            LandscapeGroup.get_perm("delete"), obj=landscape_group
-        ):
+        if not user.has_perm(LandscapeGroup.get_perm("delete"), obj=landscape_group):
             logger.info(
                 "Attempt to delete a Landscape Group, but user has no permission",
                 extra={"user_id": user.pk, "landscape_group_id": landscape_group_id},

--- a/terraso_backend/apps/graphql/schema/landscapes.py
+++ b/terraso_backend/apps/graphql/schema/landscapes.py
@@ -1,6 +1,5 @@
 import graphene
 import structlog
-from django.conf import settings
 from graphene import relay
 from graphene_django import DjangoObjectType
 
@@ -77,9 +76,6 @@ class LandscapeUpdateMutation(BaseWriteMutation):
         user = info.context.user
         landscape_id = kwargs["id"]
 
-        if not settings.FEATURE_FLAGS["CHECK_PERMISSIONS"]:
-            return super().mutate_and_get_payload(root, info, **kwargs)
-
         if not user.has_perm(Landscape.get_perm("change"), obj=landscape_id):
             logger.info(
                 "Attempt to update a Landscape, but user has no permission",
@@ -105,10 +101,7 @@ class LandscapeDeleteMutation(BaseDeleteMutation):
         user = info.context.user
         landscape_id = kwargs["id"]
 
-        ff_check_permission_on = settings.FEATURE_FLAGS["CHECK_PERMISSIONS"]
-        user_has_delete_permission = user.has_perm(Landscape.get_perm("delete"), obj=landscape_id)
-
-        if ff_check_permission_on and not user_has_delete_permission:
+        if not user.has_perm(Landscape.get_perm("delete"), obj=landscape_id):
             logger.info(
                 "Attempt to delete a Landscape, but user has no permission",
                 extra={"user_id": user.pk, "landscape_id": landscape_id},

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -174,10 +174,6 @@ GRAPHENE = {
     "SCHEMA": "apps.graphql.schema.schema",
 }
 
-FEATURE_FLAGS = {
-    "CHECK_PERMISSIONS": config("FF_CHECK_PERMISSIONS", default=False, cast=config.boolean)
-}
-
 WEB_CLIENT_URL = config("WEB_CLIENT_ENDPOINT", default="")
 AUTH_COOKIE_DOMAIN = config("AUTH_COOKIE_DOMAIN", default="")
 CORS_ORIGIN_WHITELIST = config("CORS_ORIGIN_WHITELIST", default=[], cast=config.list)

--- a/terraso_backend/tests/graphql/mutations/test_group_associations_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_group_associations_mutations.py
@@ -5,14 +5,12 @@ from apps.core.models import GroupAssociation
 pytestmark = pytest.mark.django_db
 
 
-def test_group_associations_add_by_parent_manager(settings, client_query, users, groups):
+def test_group_associations_add_by_parent_manager(client_query, users, groups):
     user = users[0]
     parent_group = groups[0]
     child_group = groups[1]
 
     parent_group.add_manager(user)
-
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
 
     response = client_query(
         """
@@ -40,11 +38,9 @@ def test_group_associations_add_by_parent_manager(settings, client_query, users,
     assert group_association["childGroup"]["slug"] == child_group.slug
 
 
-def test_group_associations_add_by_non_parent_manager_fails(settings, client_query, groups):
+def test_group_associations_add_by_non_parent_manager_fails(client_query, groups):
     parent_group = groups[0]
     child_group = groups[1]
-
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
 
     response = client_query(
         """
@@ -71,14 +67,12 @@ def test_group_associations_add_by_non_parent_manager_fails(settings, client_que
     assert "createNotAllowed" in response["errors"][0]["message"]
 
 
-def test_group_associations_add_duplicated(settings, client_query, users, group_associations):
+def test_group_associations_add_duplicated(client_query, users, group_associations):
     user = users[0]
     parent_group = group_associations[0].parent_group
     child_group = group_associations[0].child_group
 
     parent_group.add_manager(user)
-
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
 
     response = client_query(
         """
@@ -105,10 +99,8 @@ def test_group_associations_add_duplicated(settings, client_query, users, group_
     assert "duplicate key value" in error_result["message"]
 
 
-def test_group_associations_add_parent_group_not_found(settings, client_query, groups):
+def test_group_associations_add_parent_group_not_found(client_query, groups):
     child_group = groups[1]
-
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
 
     response = client_query(
         """
@@ -135,10 +127,8 @@ def test_group_associations_add_parent_group_not_found(settings, client_query, g
     assert "notFound" in response["errors"][0]["message"]
 
 
-def test_group_associations_add_child_group_not_found(settings, client_query, groups):
+def test_group_associations_add_child_group_not_found(client_query, groups):
     parent_group = groups[0]
-
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
 
     response = client_query(
         """
@@ -165,15 +155,11 @@ def test_group_associations_add_child_group_not_found(settings, client_query, gr
     assert "notFound" in response["errors"][0]["message"]
 
 
-def test_group_associations_delete_by_parent_manager(
-    settings, client_query, users, group_associations
-):
+def test_group_associations_delete_by_parent_manager(client_query, users, group_associations):
     user = users[0]
     old_group_association = group_associations[0]
     old_group_association.parent_group.add_manager(user)
 
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
-
     response = client_query(
         """
         mutation deleteGroupAssociation($input: GroupAssociationDeleteMutationInput!){
@@ -195,15 +181,11 @@ def test_group_associations_delete_by_parent_manager(
     )
 
 
-def test_group_associations_delete_by_child_manager(
-    settings, client_query, users, group_associations
-):
+def test_group_associations_delete_by_child_manager(client_query, users, group_associations):
     user = users[0]
     old_group_association = group_associations[0]
     old_group_association.child_group.add_manager(user)
 
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
-
     response = client_query(
         """
         mutation deleteGroupAssociation($input: GroupAssociationDeleteMutationInput!){
@@ -225,10 +207,8 @@ def test_group_associations_delete_by_child_manager(
     )
 
 
-def test_group_associations_delete_by_non_manager_fail(settings, client_query, group_associations):
+def test_group_associations_delete_by_non_manager_fail(client_query, group_associations):
     old_group_association = group_associations[0]
-
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
 
     response = client_query(
         """

--- a/terraso_backend/tests/graphql/mutations/test_group_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_group_mutations.py
@@ -110,14 +110,12 @@ def test_groups_update_by_manager_works(client_query, groups, users):
     assert group_result == new_data
 
 
-def test_groups_update_by_member_fails_due_permission_check(settings, client_query, groups):
+def test_groups_update_by_member_fails_due_permission_check(client_query, groups):
     old_group = groups[0]
     new_data = {
         "id": str(old_group.id),
         "description": "New description",
     }
-
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
 
     response = client_query(
         """
@@ -137,10 +135,8 @@ def test_groups_update_by_member_fails_due_permission_check(settings, client_que
     assert "updateNotAllowed" in response["errors"][0]["message"]
 
 
-def test_groups_delete_by_manager(settings, client_query, managed_groups):
+def test_groups_delete_by_manager(client_query, managed_groups):
     old_group = managed_groups[0]
-
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
 
     response = client_query(
         """
@@ -162,10 +158,8 @@ def test_groups_delete_by_manager(settings, client_query, managed_groups):
     assert not Group.objects.filter(slug=group_result["slug"])
 
 
-def test_groups_delete_by_non_manager(settings, client_query, groups):
+def test_groups_delete_by_non_manager(client_query, groups):
     old_group = groups[0]
-
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
 
     response = client_query(
         """

--- a/terraso_backend/tests/graphql/mutations/test_landscape_groups_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_landscape_groups_mutations.py
@@ -8,12 +8,9 @@ from apps.core.models import Group, LandscapeGroup
 pytestmark = pytest.mark.django_db
 
 
-def test_landscape_groups_add_by_landscape_manager(
-    settings, client_query, managed_landscapes, groups
-):
+def test_landscape_groups_add_by_landscape_manager(client_query, managed_landscapes, groups):
     landscape = managed_landscapes[0]
     group = groups[0]
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
 
     response = client_query(
         """
@@ -48,12 +45,10 @@ def test_landscape_groups_add_by_landscape_manager(
 
 
 def test_landscape_groups_add_by_non_landscape_manager_not_allowed(
-    settings, client_query, landscapes, groups
+    client_query, landscapes, groups
 ):
     landscape = landscapes[0]
     group = groups[0]
-
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
 
     response = client_query(
         """
@@ -85,13 +80,11 @@ def test_landscape_groups_add_by_non_landscape_manager_not_allowed(
     assert "createNotAllowed" in response["errors"][0]["message"]
 
 
-def test_landscape_groups_add_duplicated(settings, client_query, users, landscape_groups):
+def test_landscape_groups_add_duplicated(client_query, users, landscape_groups):
     user = users[0]
     landscape = landscape_groups[0].landscape
     group = landscape_groups[0].group
     group.add_manager(user)
-
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
 
     response = client_query(
         """
@@ -122,9 +115,8 @@ def test_landscape_groups_add_duplicated(settings, client_query, users, landscap
     assert "duplicate key" in error_result["message"]
 
 
-def test_landscape_groups_add_landscape_not_found(settings, client_query, groups):
+def test_landscape_groups_add_landscape_not_found(client_query, groups):
     group = groups[0]
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
 
     response = client_query(
         """
@@ -156,9 +148,8 @@ def test_landscape_groups_add_landscape_not_found(settings, client_query, groups
     assert "notFound" in response["errors"][0]["message"]
 
 
-def test_landscape_groups_add_group_not_found(settings, client_query, managed_landscapes):
+def test_landscape_groups_add_group_not_found(client_query, managed_landscapes):
     landscape = managed_landscapes[0]
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
 
     response = client_query(
         """
@@ -190,13 +181,11 @@ def test_landscape_groups_add_group_not_found(settings, client_query, managed_la
     assert "notFound" in response["errors"][0]["message"]
 
 
-def test_landscape_groups_delete_by_group_manager(settings, client_query, users, landscape_groups):
+def test_landscape_groups_delete_by_group_manager(client_query, users, landscape_groups):
     user = users[0]
     _, old_landscape_group = landscape_groups
     old_landscape_group.group.add_manager(user)
 
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
-
     response = client_query(
         """
         mutation deleteLandscapeGroup($input: LandscapeGroupDeleteMutationInput!){
@@ -218,15 +207,11 @@ def test_landscape_groups_delete_by_group_manager(settings, client_query, users,
     )
 
 
-def test_landscape_groups_delete_by_landscape_manager(
-    settings, client_query, users, managed_landscapes
-):
+def test_landscape_groups_delete_by_landscape_manager(client_query, users, managed_landscapes):
     landscape = managed_landscapes[0]
     group = mixer.blend(Group)
     old_landscape_group = mixer.blend(LandscapeGroup, landscape=landscape, group=group)
 
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
-
     response = client_query(
         """
         mutation deleteLandscapeGroup($input: LandscapeGroupDeleteMutationInput!){
@@ -248,12 +233,8 @@ def test_landscape_groups_delete_by_landscape_manager(
     )
 
 
-def test_landscape_groups_delete_by_non_managers_not_allowed(
-    settings, client_query, users, landscape_groups
-):
+def test_landscape_groups_delete_by_non_managers_not_allowed(client_query, users, landscape_groups):
     _, old_landscape_group = landscape_groups
-
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
 
     response = client_query(
         """
@@ -274,9 +255,7 @@ def test_landscape_groups_delete_by_non_managers_not_allowed(
     assert "deleteNotAllowed" in response["errors"][0]["message"]
 
 
-def test_landscape_groups_delete_not_found(settings, client_query, users):
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
-
+def test_landscape_groups_delete_not_found(client_query, users):
     response = client_query(
         """
         mutation deleteLandscapeGroup($input: LandscapeGroupDeleteMutationInput!){

--- a/terraso_backend/tests/graphql/mutations/test_landscape_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_landscape_mutations.py
@@ -76,7 +76,7 @@ def test_landscapes_add_duplicated(client_query, landscapes):
     assert error_message["context"]["field"] == "name"
 
 
-def test_landscapes_update_by_manager_works(settings, client_query, managed_landscapes):
+def test_landscapes_update_by_manager_works(client_query, managed_landscapes):
     old_landscape = managed_landscapes[0]
     new_data = {
         "id": str(old_landscape.id),
@@ -84,8 +84,6 @@ def test_landscapes_update_by_manager_works(settings, client_query, managed_land
         "name": "New Name",
         "website": "https://www.example.com/updated-landscape",
     }
-
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
 
     response = client_query(
         """
@@ -107,7 +105,7 @@ def test_landscapes_update_by_manager_works(settings, client_query, managed_land
     assert landscape_result == new_data
 
 
-def test_landscapes_update_by_member_fails_due_permission_check(settings, client_query, landscapes):
+def test_landscapes_update_by_member_fails_due_permission_check(client_query, landscapes):
     old_landscape = landscapes[0]
     new_data = {
         "id": str(old_landscape.id),
@@ -115,8 +113,6 @@ def test_landscapes_update_by_member_fails_due_permission_check(settings, client
         "name": "New Name",
         "website": "https://www.example.com/updated-landscape",
     }
-
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
 
     response = client_query(
         """
@@ -140,10 +136,8 @@ def test_landscapes_update_by_member_fails_due_permission_check(settings, client
     assert "updateNotAllowed" in response["errors"][0]["message"]
 
 
-def test_landscapes_delete_by_manager(settings, client_query, managed_landscapes):
+def test_landscapes_delete_by_manager(client_query, managed_landscapes):
     old_landscape = managed_landscapes[0]
-
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
 
     response = client_query(
         """
@@ -165,10 +159,8 @@ def test_landscapes_delete_by_manager(settings, client_query, managed_landscapes
     assert not Landscape.objects.filter(slug=landscape_result["slug"])
 
 
-def test_landscapes_delete_by_non_manager(settings, client_query, landscapes):
+def test_landscapes_delete_by_non_manager(client_query, landscapes):
     old_landscape = landscapes[0]
-
-    settings.FEATURE_FLAGS["CHECK_PERMISSIONS"] = True
 
     response = client_query(
         """


### PR DESCRIPTION
The `CHECK_PERMISSIONS` feature flag was created to be used only until
web client implement behavior changes based on user's role. Now, we can
always run permissions check. So, the feature flag is being removed.

Fix: #125 
