### PR TITLE
feat: adds Landscape area polygon to update mutation

### DIFF
--- a/terraso_backend/apps/graphql/schema/landscapes.py
+++ b/terraso_backend/apps/graphql/schema/landscapes.py
@@ -70,6 +70,7 @@ class LandscapeUpdateMutation(BaseWriteMutation):
         description = graphene.String()
         website = graphene.String()
         location = graphene.String()
+        area_polygon = graphene.JSONString()
 
     @classmethod
     def mutate_and_get_payload(cls, root, info, **kwargs):


### PR DESCRIPTION
This change adds the `area_polygon` Landscape's attribute to the
update mutation schema.