### PR TITLE
fix: Keep error codes snake cased

### DIFF
--- a/terraso_backend/apps/graphql/exceptions.py
+++ b/terraso_backend/apps/graphql/exceptions.py
@@ -59,6 +59,3 @@ class ErrorContext:
 class ErrorMessage:
     code: str
     context: ErrorContext
-
-    def __post_init__(self):
-        self.code = from_snake_to_camel_case(self.code) if self.code else self.code

--- a/terraso_backend/tests/graphql/mutations/test_group_associations_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_group_associations_mutations.py
@@ -64,7 +64,7 @@ def test_group_associations_add_by_non_parent_manager_fails(client_query, groups
     response = response.json()
 
     assert "errors" in response
-    assert "createNotAllowed" in response["errors"][0]["message"]
+    assert "create_not_allowed" in response["errors"][0]["message"]
 
 
 def test_group_associations_add_duplicated(client_query, users, group_associations):
@@ -124,7 +124,7 @@ def test_group_associations_add_parent_group_not_found(client_query, groups):
     response = response.json()
 
     assert "errors" in response
-    assert "notFound" in response["errors"][0]["message"]
+    assert "not_found" in response["errors"][0]["message"]
 
 
 def test_group_associations_add_child_group_not_found(client_query, groups):
@@ -152,7 +152,7 @@ def test_group_associations_add_child_group_not_found(client_query, groups):
     response = response.json()
 
     assert "errors" in response
-    assert "notFound" in response["errors"][0]["message"]
+    assert "not_found" in response["errors"][0]["message"]
 
 
 def test_group_associations_delete_by_parent_manager(client_query, users, group_associations):
@@ -226,4 +226,4 @@ def test_group_associations_delete_by_non_manager_fail(client_query, group_assoc
     response = response.json()
 
     assert "errors" in response
-    assert "deleteNotAllowed" in response["errors"][0]["message"]
+    assert "delete_not_allowed" in response["errors"][0]["message"]

--- a/terraso_backend/tests/graphql/mutations/test_group_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_group_mutations.py
@@ -132,7 +132,7 @@ def test_groups_update_by_member_fails_due_permission_check(client_query, groups
     response = response.json()
 
     assert "errors" in response
-    assert "updateNotAllowed" in response["errors"][0]["message"]
+    assert "update_not_allowed" in response["errors"][0]["message"]
 
 
 def test_groups_delete_by_manager(client_query, managed_groups):
@@ -178,4 +178,4 @@ def test_groups_delete_by_non_manager(client_query, groups):
     response = response.json()
 
     assert "errors" in response
-    assert "deleteNotAllowed" in response["errors"][0]["message"]
+    assert "delete_not_allowed" in response["errors"][0]["message"]

--- a/terraso_backend/tests/graphql/mutations/test_landscape_groups_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_landscape_groups_mutations.py
@@ -77,7 +77,7 @@ def test_landscape_groups_add_by_non_landscape_manager_not_allowed(
     response = response.json()
 
     assert "errors" in response
-    assert "createNotAllowed" in response["errors"][0]["message"]
+    assert "create_not_allowed" in response["errors"][0]["message"]
 
 
 def test_landscape_groups_add_duplicated(client_query, users, landscape_groups):
@@ -145,7 +145,7 @@ def test_landscape_groups_add_landscape_not_found(client_query, groups):
     response = response.json()
 
     assert "errors" in response
-    assert "notFound" in response["errors"][0]["message"]
+    assert "not_found" in response["errors"][0]["message"]
 
 
 def test_landscape_groups_add_group_not_found(client_query, managed_landscapes):
@@ -178,7 +178,7 @@ def test_landscape_groups_add_group_not_found(client_query, managed_landscapes):
     response = response.json()
 
     assert "errors" in response
-    assert "notFound" in response["errors"][0]["message"]
+    assert "not_found" in response["errors"][0]["message"]
 
 
 def test_landscape_groups_delete_by_group_manager(client_query, users, landscape_groups):
@@ -252,7 +252,7 @@ def test_landscape_groups_delete_by_non_managers_not_allowed(client_query, users
     response = response.json()
 
     assert "errors" in response
-    assert "deleteNotAllowed" in response["errors"][0]["message"]
+    assert "delete_not_allowed" in response["errors"][0]["message"]
 
 
 def test_landscape_groups_delete_not_found(client_query, users):
@@ -272,4 +272,4 @@ def test_landscape_groups_delete_not_found(client_query, users):
     response = response.json()
 
     assert "errors" in response
-    assert "notFound" in response["errors"][0]["message"]
+    assert "not_found" in response["errors"][0]["message"]

--- a/terraso_backend/tests/graphql/mutations/test_landscape_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_landscape_mutations.py
@@ -133,7 +133,7 @@ def test_landscapes_update_by_member_fails_due_permission_check(client_query, la
     response = response.json()
 
     assert "errors" in response
-    assert "updateNotAllowed" in response["errors"][0]["message"]
+    assert "update_not_allowed" in response["errors"][0]["message"]
 
 
 def test_landscapes_delete_by_manager(client_query, managed_landscapes):
@@ -179,4 +179,4 @@ def test_landscapes_delete_by_non_manager(client_query, landscapes):
     response = response.json()
 
     assert "errors" in response
-    assert "deleteNotAllowed" in response["errors"][0]["message"]
+    assert "delete_not_allowed" in response["errors"][0]["message"]

--- a/terraso_backend/tests/graphql/mutations/test_membership_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_membership_mutations.py
@@ -74,7 +74,7 @@ def test_membership_add_group_not_found(client_query, users):
     response = response.json()
 
     assert "errors" in response
-    assert "notFound" in response["errors"][0]["message"]
+    assert "not_found" in response["errors"][0]["message"]
 
 
 def test_membership_add_user_not_found(client_query, groups):
@@ -107,7 +107,7 @@ def test_membership_add_user_not_found(client_query, groups):
     response = response.json()
 
     assert "errors" in response
-    assert "notFound" in response["errors"][0]["message"]
+    assert "not_found" in response["errors"][0]["message"]
 
 
 def test_membership_adding_duplicated_returns_previously_created(client_query, memberships):
@@ -261,7 +261,7 @@ def test_membership_update_role_by_last_manager_fails(client_query, users, membe
     response = response.json()
 
     assert "errors" in response
-    assert "updateNotAllowed" in response["errors"][0]["message"]
+    assert "update_not_allowed" in response["errors"][0]["message"]
 
 
 def test_membership_update_by_non_manager_fail(client_query, memberships):
@@ -289,7 +289,7 @@ def test_membership_update_by_non_manager_fail(client_query, memberships):
     response = response.json()
 
     assert "errors" in response
-    assert "updateNotAllowed" in response["errors"][0]["message"]
+    assert "update_not_allowed" in response["errors"][0]["message"]
 
 
 def test_membership_update_not_found(client_query, memberships):
@@ -313,7 +313,7 @@ def test_membership_update_not_found(client_query, memberships):
     response = response.json()
 
     assert "errors" in response
-    assert "notFound" in response["errors"][0]["message"]
+    assert "not_found" in response["errors"][0]["message"]
 
 
 def test_membership_delete(client_query, users, groups):
@@ -447,7 +447,7 @@ def test_membership_delete_by_any_other_user(client_query, memberships):
     response = response.json()
 
     assert "errors" in response
-    assert "deleteNotAllowed" in response["errors"][0]["message"]
+    assert "delete_not_allowed" in response["errors"][0]["message"]
 
 
 def test_membership_delete_by_last_manager(client_query, memberships, users):
@@ -478,4 +478,4 @@ def test_membership_delete_by_last_manager(client_query, memberships, users):
     response = response.json()
 
     assert "errors" in response
-    assert "deleteNotAllowed" in response["errors"][0]["message"]
+    assert "delete_not_allowed" in response["errors"][0]["message"]

--- a/terraso_backend/tests/graphql/mutations/test_user_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_user_mutations.py
@@ -78,7 +78,7 @@ def test_users_update_by_other_user_fail(client_query, users):
     response = response.json()
 
     assert "errors" in response
-    assert "updateNotAllowed" in response["errors"][0]["message"]
+    assert "update_not_allowed" in response["errors"][0]["message"]
 
 
 def test_users_delete(client_query, users):
@@ -119,7 +119,7 @@ def test_users_delete_by_other_user_fail(client_query, users):
     response = response.json()
 
     assert "errors" in response
-    assert "deleteNotAllowed" in response["errors"][0]["message"]
+    assert "delete_not_allowed" in response["errors"][0]["message"]
 
 
 def test_users_preference_update(client_query, users):
@@ -168,7 +168,7 @@ def test_users_preference_update_by_other_fail(client_query, users):
     response = response.json()
 
     assert "errors" in response
-    assert "updateNotAllowed" in response["errors"][0]["message"]
+    assert "update_not_allowed" in response["errors"][0]["message"]
 
 
 def test_users_preference_delete(client_query, users):
@@ -235,4 +235,4 @@ def test_users_preference_delete_by_other_fail(client_query, users):
     response = response.json()
 
     assert "errors" in response
-    assert "deleteNotAllowed" in response["errors"][0]["message"]
+    assert "delete_not_allowed" in response["errors"][0]["message"]


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Keep error codes snake cased to handle them better on the client side

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
