### PR TITLE
fix: duplicated slug message returned by the API

### DIFF
--- a/terraso_backend/tests/graphql/mutations/test_group_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_group_mutations.py
@@ -77,6 +77,29 @@ def test_groups_add_duplicated(client_query, groups):
     assert error_message["context"]["field"] == "name"
 
 
+def test_groups_add_duplicated_by_slug(client_query, groups):
+    group_name = groups[0].name
+    response = client_query(
+        """
+        mutation addGroup($input: GroupAddMutationInput!){
+          addGroup(input: $input) {
+            group {
+              id
+              name
+            }
+          }
+        }
+        """,
+        variables={"input": {"name": group_name.upper()}},
+    )
+    error_result = response.json()["errors"][0]
+    assert error_result
+
+    error_message = json.loads(error_result["message"])[0]
+    assert error_message["code"] == "unique"
+    assert error_message["context"]["field"] == "All"
+
+
 def test_groups_update_by_manager_works(client_query, groups, users):
     old_group = groups[0]
     # Makes sure user is group manager before update

--- a/terraso_backend/tests/graphql/mutations/test_landscape_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_landscape_mutations.py
@@ -76,6 +76,30 @@ def test_landscapes_add_duplicated(client_query, landscapes):
     assert error_message["context"]["field"] == "name"
 
 
+def test_landscapes_add_duplicated_by_slug(client_query, landscapes):
+    landscape_name = landscapes[0].name
+    response = client_query(
+        """
+        mutation addLandscape($input: LandscapeAddMutationInput!){
+          addLandscape(input: $input) {
+            landscape {
+              id
+              name
+            }
+          }
+        }
+        """,
+        variables={"input": {"name": landscape_name.upper()}},
+    )
+    error_result = response.json()["errors"][0]
+
+    assert error_result
+
+    error_message = json.loads(error_result["message"])[0]
+    assert error_message["code"] == "unique"
+    assert error_message["context"]["field"] == "All"
+
+
 def test_landscapes_update_by_manager_works(client_query, managed_landscapes):
     old_landscape = managed_landscapes[0]
     new_data = {


### PR DESCRIPTION
This change fixes the response message for duplicated slug scenarios
when using the generic write mutation. As a good collateral effect, this
change already handle any integrity error that might happen.

The slug unique constraint only runs over non-deleted registers. This
constraint is created directly on DB. So, when performing a save
operation, this unique constraint will only be assessed on DB level, not
on application level. The DB error message is the message being returned
by the API at the moment.

This change handles the `IntegrityError` when calling `save()` and build
an appropriate `ValidationError` to be returned by the API.

Example of the result message:
```
{
    "message": '[{
        "code": "unique",
        "context": {"model": "Group", "field": "All", "extra": ""}
    }]', 
    ...
}
```

fix: #147 