### PR TITLE
feat: create the GraphQL API of shared data app

### DIFF
--- a/terraso_backend/apps/graphql/schema/__init__.py
+++ b/terraso_backend/apps/graphql/schema/__init__.py
@@ -30,6 +30,7 @@ from .memberships import (
     MembershipNode,
     MembershipUpdateMutation,
 )
+from .shared_data import DataEntryDeleteMutation, DataEntryNode, DataEntryUpdateMutation
 from .users import (
     UserAddMutation,
     UserDeleteMutation,
@@ -55,6 +56,8 @@ class Query(graphene.ObjectType):
     landscape_groups = DjangoFilterConnectionField(LandscapeGroupNode)
     memberships = DjangoFilterConnectionField(MembershipNode)
     group_associations = DjangoFilterConnectionField(GroupAssociationNode)
+    data_entry = TerrasoRelayNode.Field(DataEntryNode)
+    data_entries = DjangoFilterConnectionField(DataEntryNode)
 
 
 class Mutations(graphene.ObjectType):
@@ -76,6 +79,8 @@ class Mutations(graphene.ObjectType):
     delete_membership = MembershipDeleteMutation.Field()
     update_user_preference = UserPreferenceUpdate.Field()
     delete_user_preference = UserPreferenceDelete.Field()
+    update_data_entry = DataEntryUpdateMutation.Field()
+    delete_data_entry = DataEntryDeleteMutation.Field()
 
 
 schema = graphene.Schema(query=Query, mutation=Mutations)

--- a/terraso_backend/apps/graphql/schema/shared_data.py
+++ b/terraso_backend/apps/graphql/schema/shared_data.py
@@ -55,7 +55,7 @@ class DataEntryUpdateMutation(BaseWriteMutation):
 
         if not user.has_perm(DataEntry.get_perm("change"), obj=data_entry):
             logger.info(
-                "Attempt to update a DataEntry, but user has no permission",
+                "Attempt to update a DataEntry, but user lacks permission",
                 extra={"user_id": user.pk, "data_entry_id": str(data_entry.pk)},
             )
             raise GraphQLNotAllowedException(
@@ -80,7 +80,7 @@ class DataEntryDeleteMutation(BaseDeleteMutation):
 
         if not user.has_perm(DataEntry.get_perm("delete"), obj=data_entry):
             logger.info(
-                "Attempt to delete a DataEntry, but user has no permission",
+                "Attempt to delete a DataEntry, but user lacks permission",
                 extra={"user_id": user.pk, "data_entry_id": str(data_entry.pk)},
             )
             raise GraphQLNotAllowedException(

--- a/terraso_backend/apps/graphql/schema/shared_data.py
+++ b/terraso_backend/apps/graphql/schema/shared_data.py
@@ -22,6 +22,8 @@ class DataEntryNode(DjangoObjectType):
             "description": ["icontains"],
             "slug": ["exact", "icontains"],
             "url": ["icontains"],
+            "groups__slug": ["icontains"],
+            "groups__id": ["exact"],
         }
         fields = (
             "name",

--- a/terraso_backend/apps/graphql/schema/shared_data.py
+++ b/terraso_backend/apps/graphql/schema/shared_data.py
@@ -1,0 +1,87 @@
+import graphene
+import structlog
+from graphene import relay
+from graphene_django import DjangoObjectType
+
+from apps.graphql.exceptions import GraphQLNotAllowedException
+from apps.shared_data.models import DataEntry
+
+from .commons import BaseDeleteMutation, BaseWriteMutation, TerrasoConnection
+from .constants import MutationTypes
+
+logger = structlog.get_logger(__name__)
+
+
+class DataEntryNode(DjangoObjectType):
+    id = graphene.ID(source="pk", required=True)
+
+    class Meta:
+        model = DataEntry
+        filter_fields = {
+            "name": ["icontains"],
+            "description": ["icontains"],
+            "slug": ["exact", "icontains"],
+            "url": ["icontains"],
+        }
+        fields = (
+            "name",
+            "slug",
+            "description",
+            "resource_type",
+            "url",
+            "created_by",
+            "groups",
+        )
+        interfaces = (relay.Node,)
+        connection_class = TerrasoConnection
+
+
+class DataEntryUpdateMutation(BaseWriteMutation):
+    data_entry = graphene.Field(DataEntryNode)
+
+    model_class = DataEntry
+
+    class Input:
+        id = graphene.ID(required=True)
+        name = graphene.String()
+        description = graphene.String()
+
+    @classmethod
+    def mutate_and_get_payload(cls, root, info, **kwargs):
+        user = info.context.user
+        data_entry = DataEntry.objects.get(pk=kwargs["id"])
+
+        if not user.has_perm(DataEntry.get_perm("change"), obj=data_entry):
+            logger.info(
+                "Attempt to update a DataEntry, but user has no permission",
+                extra={"user_id": user.pk, "data_entry_id": str(data_entry.pk)},
+            )
+            raise GraphQLNotAllowedException(
+                model_name=DataEntry.__name__, operation=MutationTypes.UPDATE
+            )
+
+        return super().mutate_and_get_payload(root, info, **kwargs)
+
+
+class DataEntryDeleteMutation(BaseDeleteMutation):
+    data_entry = graphene.Field(DataEntryNode)
+
+    model_class = DataEntry
+
+    class Input:
+        id = graphene.ID()
+
+    @classmethod
+    def mutate_and_get_payload(cls, root, info, **kwargs):
+        user = info.context.user
+        data_entry = DataEntry.objects.get(pk=kwargs["id"])
+
+        if not user.has_perm(DataEntry.get_perm("delete"), obj=data_entry):
+            logger.info(
+                "Attempt to delete a DataEntry, but user has no permission",
+                extra={"user_id": user.pk, "data_entry_id": str(data_entry.pk)},
+            )
+            raise GraphQLNotAllowedException(
+                model_name=DataEntry.__name__, operation=MutationTypes.DELETE
+            )
+        return super().mutate_and_get_payload(root, info, **kwargs)

--- a/terraso_backend/apps/shared_data/admin.py
+++ b/terraso_backend/apps/shared_data/admin.py
@@ -1,0 +1,8 @@
+from django.contrib import admin
+
+from .models import DataEntry
+
+
+@admin.register(DataEntry)
+class DataEntryAdmin(admin.ModelAdmin):
+    list_display = ("name", "slug", "url", "resource_type", "created_by")

--- a/terraso_backend/apps/shared_data/models.py
+++ b/terraso_backend/apps/shared_data/models.py
@@ -43,6 +43,7 @@ class DataEntry(SlugModel):
     field_to_slug = "name"
 
     class Meta(SlugModel.Meta):
+        verbose_name_plural = "Data Entries"
         rules_permissions = {
             "change": perm_rules.allowed_to_change_data_entry,
             "delete": perm_rules.allowed_to_delete_data_entry,

--- a/terraso_backend/tests/graphql/conftest.py
+++ b/terraso_backend/tests/graphql/conftest.py
@@ -15,6 +15,7 @@ from apps.core.models import (
     Membership,
     User,
 )
+from apps.shared_data.models import DataEntry
 
 pytestmark = pytest.mark.django_db
 
@@ -146,3 +147,9 @@ def make_core_db_records(
     group_associations, landscapes, landscape_groups, memberships, groups, subgroups, users
 ):
     return
+
+
+@pytest.fixture
+def data_entries(users):
+    creator = users[0]
+    return mixer.cycle(5).blend(DataEntry, created_by=creator)

--- a/terraso_backend/tests/graphql/mutations/test_shared_data_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_shared_data_mutations.py
@@ -6,7 +6,7 @@ pytestmark = pytest.mark.django_db
 
 
 def test_data_entry_update_by_creator_works(client_query, data_entries):
-    # Fixtures make sure that the user on client query is the data entry creator
+    # The data entries' owner is the same user on client query
     old_data_entry = data_entries[0]
 
     new_data = {

--- a/terraso_backend/tests/graphql/mutations/test_shared_data_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_shared_data_mutations.py
@@ -1,0 +1,117 @@
+import pytest
+
+from apps.shared_data.models import DataEntry
+
+pytestmark = pytest.mark.django_db
+
+
+def test_data_entry_update_by_creator_works(client_query, data_entries):
+    # Fixtures make sure that the user on client query is the data entry creator
+    old_data_entry = data_entries[0]
+
+    new_data = {
+        "id": str(old_data_entry.id),
+        "description": "New description",
+        "name": "New Name",
+    }
+    response = client_query(
+        """
+        mutation updateDataEntry($input: DataEntryUpdateMutationInput!) {
+          updateDataEntry(input: $input) {
+            dataEntry {
+              id
+              name
+              description
+            }
+          }
+        }
+        """,
+        variables={"input": new_data},
+    )
+    group_result = response.json()["data"]["updateDataEntry"]["dataEntry"]
+
+    assert group_result == new_data
+
+
+def test_data_entry_update_by_non_creator_fails_due_permission_check(
+    client_query, data_entries, users
+):
+    old_data_entry = data_entries[0]
+
+    # Let's force old data creator be different from client query user
+    old_data_entry.created_by = users[2]
+    old_data_entry.save()
+
+    new_data = {
+        "id": str(old_data_entry.id),
+        "description": "New description",
+    }
+
+    response = client_query(
+        """
+        mutation updateDataEntry($input: DataEntryUpdateMutationInput!) {
+          updateDataEntry(input: $input) {
+            dataEntry {
+              id
+            }
+          }
+        }
+        """,
+        variables={"input": new_data},
+    )
+    response = response.json()
+
+    assert "errors" in response
+    assert "update_not_allowed" in response["errors"][0]["message"]
+
+
+def test_data_entry_delete_by_creator_works(client_query, data_entries):
+    old_data_entry = data_entries[0]
+
+    response = client_query(
+        """
+        mutation deleteDataEntry($input: DataEntryDeleteMutationInput!){
+          deleteDataEntry(input: $input) {
+            dataEntry {
+              slug
+            }
+          }
+        }
+
+        """,
+        variables={"input": {"id": str(old_data_entry.id)}},
+    )
+
+    data_entry_result = response.json()["data"]["deleteDataEntry"]["dataEntry"]
+
+    assert data_entry_result["slug"] == old_data_entry.slug
+    assert not DataEntry.objects.filter(slug=data_entry_result["slug"])
+
+
+def test_data_entry_delete_by_non_creator_fails_due_permission_check(
+    client_query, data_entries, users
+):
+    old_data_entry = data_entries[0]
+
+    # Let's force old data creator be different from client query user
+    old_data_entry.created_by = users[2]
+    old_data_entry.save()
+
+    response = client_query(
+        """
+        mutation deleteDataEntry($input: DataEntryDeleteMutationInput!){
+          deleteDataEntry(input: $input) {
+            dataEntry {
+              slug
+            }
+          }
+        }
+
+        """,
+        variables={"input": {"id": str(old_data_entry.id)}},
+    )
+
+    response = response.json()
+
+    assert "errors" in response
+    assert "delete_not_allowed" in response["errors"][0]["message"]

--- a/terraso_backend/tests/graphql/test_shared_data.py
+++ b/terraso_backend/tests/graphql/test_shared_data.py
@@ -1,0 +1,59 @@
+import pytest
+
+pytestmark = pytest.mark.django_db
+
+
+def test_data_entries_query(client_query, data_entries):
+    response = client_query(
+        """
+        {dataEntries {
+          edges {
+            node {
+              slug
+            }
+          }
+        }}
+        """
+    )
+
+    edges = response.json()["data"]["dataEntries"]["edges"]
+    entries_result = [edge["node"]["slug"] for edge in edges]
+
+    for data_entry in data_entries:
+        assert data_entry.slug in entries_result
+
+
+def test_data_entry_get_one_by_id(client_query, data_entries):
+    data_entry = data_entries[0]
+    query = (
+        """
+        {dataEntry(id: "%s") {
+          id
+          slug
+        }}
+        """
+        % data_entry.id
+    )
+    response = client_query(query)
+    data_entry_result = response.json()["data"]["dataEntry"]
+
+    assert data_entry_result["id"] == str(data_entry.id)
+    assert data_entry_result["slug"] == data_entry.slug
+
+
+def test_data_entries_query_has_total_count(client_query, data_entries):
+    response = client_query(
+        """
+        {dataEntries {
+          totalCount
+          edges {
+            node {
+              slug
+            }
+          }
+        }}
+        """
+    )
+    total_count = response.json()["data"]["dataEntries"]["totalCount"]
+
+    assert total_count == len(data_entries)

--- a/terraso_backend/tests/graphql/test_shared_data.py
+++ b/terraso_backend/tests/graphql/test_shared_data.py
@@ -57,3 +57,107 @@ def test_data_entries_query_has_total_count(client_query, data_entries):
     total_count = response.json()["data"]["dataEntries"]["totalCount"]
 
     assert total_count == len(data_entries)
+
+
+def test_data_entries_filter_by_group_slug_filters_successfuly(client_query, data_entries, groups):
+    data_entry_a = data_entries[0]
+    data_entry_b = data_entries[1]
+
+    data_entry_a.groups.add(*groups)
+    data_entry_b.groups.add(*groups)
+
+    group_filter = groups[0]
+
+    response = client_query(
+        """
+        {dataEntries(groups_Slug_Icontains: "%s") {
+          edges {
+            node {
+              id
+            }
+          }
+        }}
+        """
+        % group_filter.slug
+    )
+
+    edges = response.json()["data"]["dataEntries"]["edges"]
+    data_entries_result = [edge["node"]["id"] for edge in edges]
+
+    assert len(data_entries_result) == 2
+    assert str(data_entry_a.id) in data_entries_result
+    assert str(data_entry_b.id) in data_entries_result
+
+
+def test_data_entries_filter_by_group_id_filters_successfuly(client_query, data_entries, groups):
+    data_entry_a = data_entries[0]
+    data_entry_b = data_entries[1]
+
+    data_entry_a.groups.add(*groups)
+    data_entry_b.groups.add(*groups)
+
+    group_filter = groups[0]
+
+    response = client_query(
+        """
+        {dataEntries(groups_Id: "%s") {
+          edges {
+            node {
+              id
+            }
+          }
+        }}
+        """
+        % group_filter.id
+    )
+
+    edges = response.json()["data"]["dataEntries"]["edges"]
+    data_entries_result = [edge["node"]["id"] for edge in edges]
+
+    assert len(data_entries_result) == 2
+    assert str(data_entry_a.id) in data_entries_result
+    assert str(data_entry_b.id) in data_entries_result
+
+
+def test_data_entries_filter_by_group_slug_returns_empty_if_no_associations(
+    client_query, data_entries, groups
+):
+    # All data entries aren't associated to any group, the result must be empty
+    group_filter = groups[0]
+
+    response = client_query(
+        """
+        {dataEntries(groups_Slug_Icontains: "%s") {
+          edges {
+            node {
+              id
+            }
+          }
+        }}
+        """
+        % group_filter.slug
+    )
+
+    assert not response.json()["data"]["dataEntries"]["edges"]
+
+
+def test_data_entries_filter_by_group_id_returns_empty_if_no_associations(
+    client_query, data_entries, groups
+):
+    # All data entries aren't associated to any group, the result must be empty
+    group_filter = groups[0]
+
+    response = client_query(
+        """
+        {dataEntries(groups_Id: "%s") {
+          edges {
+            node {
+              id
+            }
+          }
+        }}
+        """
+        % group_filter.id
+    )
+
+    assert not response.json()["data"]["dataEntries"]["edges"]


### PR DESCRIPTION
This change creates the GraphQL API for the Shared Data Files app with the
operations to read, update and delete `DataEntry`.