### PR TITLE
feat: add simple health check endpoint

### DIFF
--- a/terraso_backend/apps/core/urls.py
+++ b/terraso_backend/apps/core/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from apps.core.views import HealthView
+
+app_name = "apps.core"
+
+urlpatterns = [
+    path("healthz/", HealthView.as_view(), name="healthz"),
+]

--- a/terraso_backend/apps/core/views.py
+++ b/terraso_backend/apps/core/views.py
@@ -1,0 +1,25 @@
+from django.db import DatabaseError
+from django.http import HttpResponse
+from django.views import View
+
+from apps.core.models import Group, Landscape, User
+
+
+class HealthView(View):
+    def get(self, request, *args, **kwargs):
+        try:
+            check_db_access()
+        except DatabaseError:
+            return HttpResponse("Database error fetching DB resources", status=400)
+        except Exception:
+            return HttpResponse("Unexpected error fetching DB resources", status=400)
+
+        return HttpResponse("OK", status=200)
+
+
+def check_db_access():
+    # During the health check we try to do a minor DB access to make sure
+    # main tables can be reached
+    Landscape.objects.count()
+    Group.objects.count()
+    User.objects.count()

--- a/terraso_backend/config/urls.py
+++ b/terraso_backend/config/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     path("graphql/", include("apps.graphql.urls", namespace="terraso_graphql")),
     path("storage/", include("apps.storage.urls", namespace="terraso_storage")),
     path("oauth/", include("oauth2_provider.urls", namespace="oauth2_provider")),
+    path("", include("apps.core.urls", namespace="terraso_core")),
 ]

--- a/terraso_backend/tests/core/test_views.py
+++ b/terraso_backend/tests/core/test_views.py
@@ -1,0 +1,38 @@
+from unittest.mock import patch
+
+import pytest
+from django.db import DatabaseError
+from django.urls import reverse
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def healthz_url():
+    return reverse("terraso_core:healthz")
+
+
+def test_get_health_success(client, healthz_url):
+    response = client.get(healthz_url)
+
+    assert response.status_code == 200
+
+
+@patch("apps.core.views.check_db_access")
+def test_get_health_with_db_error(mocked_check_db_access, client, healthz_url):
+    mocked_check_db_access.side_effect = DatabaseError("Mocked exception!")
+
+    response = client.get(healthz_url)
+
+    assert response.status_code == 400
+    assert "Database error" in response.content.decode()
+
+
+@patch("apps.core.views.check_db_access")
+def test_get_health_with_unexpected_error(mocked_check_db_access, client, healthz_url):
+    mocked_check_db_access.side_effect = Exception("Mocked exception!")
+
+    response = client.get(healthz_url)
+
+    assert response.status_code == 400
+    assert "Unexpected error" in response.content.decode()


### PR DESCRIPTION
This change adds a simple health check endpoint. During the check, the
main database tables are read. If any error be raised, an HTTP 400
response is returned. An HTTP 200 (success) is returned otherwise.

This endpoint will be used by Render to check the status of new deployments[1].

[1] - https://render.com/docs/deploys#health-checks