### PR TITLE
refactor: creates an abstract upload service

### DIFF
--- a/terraso_backend/apps/storage/services.py
+++ b/terraso_backend/apps/storage/services.py
@@ -6,24 +6,38 @@ from django.core.files.base import ContentFile
 from .s3 import ProfileImageStorage
 
 
-class ProfileImageService:
-    profile_image_storage = ProfileImageStorage()
+class UploadService:
+    @property
+    def storage(self):
+        raise NotImplementedError()
+
+    @property
+    def base_url(self):
+        raise NotImplementedError()
 
     def upload_url(self, user_id, url):
-        image = self._download_image_from_url(url)
-        return self.upload_file(user_id, ContentFile(image))
+        file = self._download_from_url(url)
+        return self.upload_file(user_id, ContentFile(file))
 
-    def upload_file(self, user_id, image):
-        path = self._get_image_path(user_id)
-        self.profile_image_storage.save(path, image)
-        return self._get_image_url(path)
+    def upload_file(self, user_id, file):
+        path = self.get_path_on_storage(user_id)
+        self.storage.save(path, file)
+        return self.get_uploaded_file_url(path)
 
-    def _get_image_path(self, user_id):
-        return "{}/profile-image".format(user_id)
+    def get_path_on_storage(self, user_id):
+        return f"{user_id}/"
 
-    def _get_image_url(self, path):
-        return "{}/{}".format(settings.PROFILE_IMAGES_BASE_URL, path)
+    def get_uploaded_file_url(self, path):
+        return "{}/{}".format(self.base_url, path)
 
-    def _download_image_from_url(self, url):
+    def _download_from_url(self, url):
         with urllib.request.urlopen(url) as file:
             return file.read()
+
+
+class ProfileImageService(UploadService):
+    storage = ProfileImageStorage()
+    base_url = settings.PROFILE_IMAGES_BASE_URL
+
+    def get_path_on_storage(self, user_id):
+        return "{}/profile-image".format(user_id)


### PR DESCRIPTION
This change creates an abstract upload service based on the current
profile image service. This way, new services that make upload can be
created based on the abstract one having simpler specialized
implementation. No internal API changes were made in this change.

This is part of work for:
- #154 
- #152 