### PR TITLE
feat: restrict DataEntry list to group members only

### DIFF
--- a/terraso_backend/apps/graphql/schema/shared_data.py
+++ b/terraso_backend/apps/graphql/schema/shared_data.py
@@ -39,6 +39,10 @@ class DataEntryNode(DjangoObjectType):
         interfaces = (relay.Node,)
         connection_class = TerrasoConnection
 
+    @classmethod
+    def get_queryset(cls, queryset, info):
+        return queryset.filter(groups__members=info.context.user)
+
     def resolve_url(self, info):
         return self.signed_url
 

--- a/terraso_backend/tests/graphql/conftest.py
+++ b/terraso_backend/tests/graphql/conftest.py
@@ -150,6 +150,26 @@ def make_core_db_records(
 
 
 @pytest.fixture
-def data_entries(users):
+def data_entry_current_user(users, groups):
     creator = users[0]
-    return mixer.cycle(5).blend(DataEntry, created_by=creator, size=100)
+    creator_group = groups[0]
+    creator_group.members.add(creator)
+    return mixer.blend(DataEntry, slug=None, created_by=creator, size=100, groups=creator_group)
+
+
+@pytest.fixture
+def data_entry_other_user(users, groups):
+    creator = users[1]
+    creator_group = groups[1]
+    creator_group.members.add(creator)
+    return mixer.blend(DataEntry, slug=None, created_by=creator, size=100, groups=creator_group)
+
+
+@pytest.fixture
+def data_entries(users, groups):
+    creator = users[0]
+    creator_group = groups[0]
+    creator_group.members.add(creator)
+    return mixer.cycle(5).blend(
+        DataEntry, slug=None, created_by=creator, size=100, groups=creator_group
+    )


### PR DESCRIPTION
This change makes the GraphQL query for `DataEntry` return only those
registers associated to the Groups from the logged user.