### PR TITLE
fix: allow file names with spaces on shared files

### DIFF
--- a/terraso_backend/apps/shared_data/models.py
+++ b/terraso_backend/apps/shared_data/models.py
@@ -54,7 +54,11 @@ class DataEntry(SlugModel):
 
     @property
     def s3_object_name(self):
-        return "/".join(self.url.split("/")[-2:]) if self.url else ""
+        object_name = "/".join(self.url.split("/")[-2:]) if self.url else ""
+
+        # We want to put back the space character so the sign url works properly
+        object_name = object_name.replace("%20", " ")
+        return object_name
 
     @property
     def signed_url(self):

--- a/terraso_backend/apps/storage/services.py
+++ b/terraso_backend/apps/storage/services.py
@@ -37,7 +37,13 @@ class UploadService:
         return f"{user_id}/{file_name}"
 
     def get_uploaded_file_url(self, path):
-        return f"{self.base_url}/{path}"
+        # We want to replace space chars by the encoded %20 value. It's
+        # necessary for the result URL be a valid URL to be persisted on
+        # URLField, for example. Special characters are ok to be kept.
+        clean_filename = path.split("/")[-1].replace(" ", "%20")
+        object_name_prefix = "/".join(path.split("/")[:-1])
+
+        return f"{self.base_url}/{object_name_prefix}/{clean_filename}"
 
     def _download_from_url(self, url):
         with urllib.request.urlopen(url) as file:


### PR DESCRIPTION
This change updates the generic upload service to S3 to generate URLs
without spaces, using %20 instead. This way the service will generate
valid URLs for URLField from Django.

It also updates the property that gives the S3 object name from a given
`DataEntry` to put back the spaces chars, since this is necessary to the
sign URL process generates valid signed URLs.