### PR TITLE
fix: duplicated Data Entries on API response

### DIFF
--- a/terraso_backend/apps/graphql/schema/shared_data.py
+++ b/terraso_backend/apps/graphql/schema/shared_data.py
@@ -3,6 +3,7 @@ import structlog
 from graphene import relay
 from graphene_django import DjangoObjectType
 
+from apps.core.models import Membership
 from apps.graphql.exceptions import GraphQLNotAllowedException
 from apps.shared_data.models import DataEntry
 
@@ -41,7 +42,10 @@ class DataEntryNode(DjangoObjectType):
 
     @classmethod
     def get_queryset(cls, queryset, info):
-        return queryset.filter(groups__members=info.context.user)
+        user_groups_ids = Membership.objects.filter(user=info.context.user).values_list(
+            "group", flat=True
+        )
+        return queryset.filter(groups__in=user_groups_ids)
 
     def resolve_url(self, info):
         return self.signed_url


### PR DESCRIPTION
To answer only `DataEntry` from groups that the current user is
member of, a specific filter is being done on GraphQL `DataEntryNode`.
Until this change, the query was relying on built-in Django look-ups for
the joins. However, it was including soft-deleted registers (Membership
records) because of not so good integration between Django's look-ups
and the `django-safedelete` lib. This was causing the `DataEntry`
duplication in some groups.

To fix that issue, the query was updated to be more explicit and done in
two steps:

1. Get all ID from `Groups` that the current user is a member of. Since this
   is a simple query, the soft-deleted is well respected.
2. With the list of group IDs, filter the `DataEntry` query. This will
   also respect the soft-delete underlying conditions