### PR TITLE
fix: User model delete cascade configuration

### DIFF
--- a/terraso_backend/apps/core/models/users.py
+++ b/terraso_backend/apps/core/models/users.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.contrib.auth.models import AbstractUser, BaseUserManager
 from django.db import models
-from safedelete.models import SafeDeleteManager, SafeDeleteModel
+from safedelete.models import SOFT_DELETE_CASCADE, SafeDeleteManager, SafeDeleteModel
 
 
 class UserManager(SafeDeleteManager, BaseUserManager):
@@ -41,6 +41,8 @@ class UserManager(SafeDeleteManager, BaseUserManager):
 
 class User(SafeDeleteModel, AbstractUser):
     """This model represents a User on Terraso platform."""
+
+    _safedelete_policy = SOFT_DELETE_CASCADE
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     created_at = models.DateTimeField(auto_now_add=True)

--- a/terraso_backend/tests/core/models/test_groups.py
+++ b/terraso_backend/tests/core/models/test_groups.py
@@ -88,16 +88,6 @@ def test_group_associations_are_asymmetrical():
     assert group.associations_as_child.count() == 0
 
 
-def test_membership_is_created_when_group_member_added():
-    group = mixer.blend(Group, name="This is My Name", slug=None)
-    users = mixer.cycle(3).blend(User)
-
-    group.members.add(*users)
-
-    assert group.members.count() == 3
-    assert Membership.objects.count() == 3
-
-
 def test_group_creator_becomes_manager():
     user = mixer.blend(User)
     group = mixer.blend(Group, created_by=user)

--- a/terraso_backend/tests/core/models/test_membership.py
+++ b/terraso_backend/tests/core/models/test_membership.py
@@ -1,0 +1,32 @@
+import pytest
+from mixer.backend.django import mixer
+
+from apps.core.models import Group, Membership, User
+
+pytestmark = pytest.mark.django_db
+
+
+def test_membership_is_created_when_group_member_added():
+    group = mixer.blend(Group, name="This is My Name", slug=None)
+    users = mixer.cycle(3).blend(User)
+
+    group.members.add(*users)
+
+    assert group.members.count() == 3
+    assert Membership.objects.count() == 3
+
+
+def test_membership_is_deleted_when_user_is_deleted():
+    user = mixer.blend(User)
+    group = mixer.blend(Group)
+
+    group.members.add(user)
+
+    membership = Membership.objects.get(user=user, group=group)
+
+    assert membership
+
+    user.delete()
+
+    assert not User.objects.filter(id=user.id).exists()
+    assert not Membership.objects.filter(user=user, group=group).exists()


### PR DESCRIPTION
This change adds the correct configuration to the `User` model to make
delete cascade work. This way, related objects to `User` can be properly
cascade deleted when appropriate.