### PR TITLE
feat: allow Group manager delete shared files

### DIFF
--- a/terraso_backend/apps/shared_data/permission_rules.py
+++ b/terraso_backend/apps/shared_data/permission_rules.py
@@ -8,7 +8,10 @@ def allowed_to_change_data_entry(user, data_entry):
 
 @rules.predicate
 def allowed_to_delete_data_entry(user, data_entry):
-    return data_entry.created_by == user
+    return (
+        data_entry.created_by == user
+        or user.memberships.managers_only().filter(group__in=data_entry.groups.all()).exists()
+    )
 
 
 @rules.predicate

--- a/terraso_backend/tests/shared_data/test_models.py
+++ b/terraso_backend/tests/shared_data/test_models.py
@@ -33,7 +33,14 @@ def test_data_entry_can_be_deleted_by_its_creator(user, data_entry):
     assert user.has_perm(DataEntry.get_perm("delete"), obj=data_entry)
 
 
-def test_data_entry_cannot_be_deleted_by_non_creator(user, user_b, data_entry_user_b):
+def test_data_entry_can_be_deleted_by_group_manager(user_b, group, data_entry):
+    group.add_manager(user_b)
+    data_entry.groups.add(group)
+
+    assert user_b.has_perm(DataEntry.get_perm("delete"), obj=data_entry)
+
+
+def test_data_entry_cannot_be_deleted_by_non_creator_or_manager(user, user_b, data_entry_user_b):
     assert not user.has_perm(DataEntry.get_perm("delete"), obj=data_entry_user_b)
 
 


### PR DESCRIPTION
This change updates the permission rule to delete `DataEntry` to allow
Group managers to delete files in their groups.

Fix:
- #181 