### PR TITLE
fix: Disallow "new" as a name for groups and landscapes

### DIFF
--- a/terraso_backend/apps/core/models/commons.py
+++ b/terraso_backend/apps/core/models/commons.py
@@ -1,9 +1,19 @@
 import uuid
 
+from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.text import slugify
+from django.utils.translation import gettext_lazy as _
 from rules.contrib.models import RulesModelBase, RulesModelMixin
 from safedelete.models import SOFT_DELETE_CASCADE, SafeDeleteModel
+
+
+def validate_name(value):
+    if value.lower() in settings.DISALLOWED_NAMES_LIST:
+        raise ValidationError(
+            _("%(value)s is not allowed as a name"), params={"value": value}, code="invalid"
+        )
 
 
 class BaseModel(RulesModelMixin, SafeDeleteModel, metaclass=RulesModelBase):

--- a/terraso_backend/apps/core/models/groups.py
+++ b/terraso_backend/apps/core/models/groups.py
@@ -4,7 +4,7 @@ from safedelete.models import SafeDeleteManager
 
 from apps.core import permission_rules as perm_rules
 
-from .commons import BaseModel, SlugModel
+from .commons import BaseModel, SlugModel, validate_name
 from .users import User
 
 
@@ -25,7 +25,7 @@ class Group(SlugModel):
 
     fields_to_trim = ["name", "description"]
 
-    name = models.CharField(max_length=128, unique=True)
+    name = models.CharField(max_length=128, unique=True, validators=[validate_name])
     description = models.TextField(max_length=512, blank=True, default="")
     website = models.URLField(blank=True, default="")
     email = models.EmailField(blank=True, default="")

--- a/terraso_backend/apps/core/models/landscapes.py
+++ b/terraso_backend/apps/core/models/landscapes.py
@@ -3,7 +3,7 @@ from django.db import models, transaction
 
 from apps.core import permission_rules as perm_rules
 
-from .commons import BaseModel, SlugModel
+from .commons import BaseModel, SlugModel, validate_name
 from .groups import Group
 from .users import User
 
@@ -25,7 +25,7 @@ class Landscape(SlugModel):
 
     fields_to_trim = ["name", "description"]
 
-    name = models.CharField(max_length=128, unique=True)
+    name = models.CharField(max_length=128, unique=True, validators=[validate_name])
     description = models.TextField(blank=True, default="")
     website = models.URLField(blank=True, default="")
     location = models.CharField(max_length=128, blank=True, default="")

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -128,6 +128,9 @@ USE_TZ = True
 MEDIA_URL = "/media/"
 STATIC_URL = "/static/"
 
+# don't allow "new" as a name, as the view route conflicts with the create route
+DISALLOWED_NAMES_LIST = ["new"]
+
 if not DEBUG:
     CDN_STATIC_DOMAIN = config("CDN_STATIC_DOMAIN")
     AWS_S3_CUSTOM_DOMAIN = CDN_STATIC_DOMAIN

--- a/terraso_backend/tests/core/models/test_groups.py
+++ b/terraso_backend/tests/core/models/test_groups.py
@@ -1,5 +1,4 @@
 import pytest
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from mixer.backend.django import mixer
 
@@ -47,7 +46,7 @@ def test_group_disallowed_name():
         group.full_clean()
 
 
-def test_group_additional_disallowed_name():
+def test_group_additional_disallowed_name(settings):
     group_name = "Foobar"
     settings.DISALLOWED_NAMES_LIST = ["new", "foobar"]
     group = mixer.blend(Group, name=group_name)

--- a/terraso_backend/tests/core/models/test_groups.py
+++ b/terraso_backend/tests/core/models/test_groups.py
@@ -1,4 +1,6 @@
 import pytest
+from django.conf import settings
+from django.core.exceptions import ValidationError
 from mixer.backend.django import mixer
 
 from apps.core.models.groups import Group, GroupAssociation, Membership
@@ -35,6 +37,23 @@ def test_group_string_remove_spaces_from_description():
     group.save()
 
     assert group_description.strip() == group.description
+
+
+def test_group_disallowed_name():
+    group_name = "New"
+    group = mixer.blend(Group, name=group_name)
+
+    with pytest.raises(ValidationError, match="New is not allowed as a name"):
+        group.full_clean()
+
+
+def test_group_additional_disallowed_name():
+    group_name = "Foobar"
+    settings.DISALLOWED_NAMES_LIST = ["new", "foobar"]
+    group = mixer.blend(Group, name=group_name)
+
+    with pytest.raises(ValidationError, match="Foobar is not allowed as a name"):
+        group.full_clean()
 
 
 def test_group_slug_is_updatable():

--- a/terraso_backend/tests/core/models/test_landscapes.py
+++ b/terraso_backend/tests/core/models/test_landscapes.py
@@ -1,4 +1,5 @@
 import pytest
+from django.core.exceptions import ValidationError
 from mixer.backend.django import mixer
 
 from apps.core.models.groups import Group, Membership
@@ -36,6 +37,14 @@ def test_landscape_string_remove_spaces_from_description():
     landscape.save()
 
     assert landscape_description.strip() == landscape.description
+
+
+def test_landscape_disallowed_name():
+    landscape_name = "New"
+    landscape = mixer.blend(Landscape, name=landscape_name)
+
+    with pytest.raises(ValidationError, match="New is not allowed as a name"):
+        landscape.full_clean()
 
 
 def test_landscape_slug_is_updatable():


### PR DESCRIPTION
## Description
Disallow "new" as a name for groups and landscapes through a validator.

### Checklist
- [X] Corresponding issue has been opened
- [x] New tests added


### Related Issues
Fixes #164.