### PR TITLE
fix: trim whitespace from name and description fields

### DIFF
--- a/terraso_backend/apps/core/models/commons.py
+++ b/terraso_backend/apps/core/models/commons.py
@@ -9,6 +9,8 @@ from safedelete.models import SOFT_DELETE_CASCADE, SafeDeleteModel
 class BaseModel(RulesModelMixin, SafeDeleteModel, metaclass=RulesModelBase):
     _safedelete_policy = SOFT_DELETE_CASCADE
 
+    fields_to_trim = []
+
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
@@ -17,6 +19,11 @@ class BaseModel(RulesModelMixin, SafeDeleteModel, metaclass=RulesModelBase):
         abstract = True
         get_latest_by = "-created_at"
         ordering = ["created_at"]
+
+    def save(self, *args, **kwargs):
+        for field in self.fields_to_trim:
+            setattr(self, field, getattr(self, field).strip())
+        return super().save(*args, **kwargs)
 
 
 class SlugModel(BaseModel):

--- a/terraso_backend/apps/core/models/groups.py
+++ b/terraso_backend/apps/core/models/groups.py
@@ -23,6 +23,8 @@ class Group(SlugModel):
     Terraso backend platform is made by the GroupAssociation model.
     """
 
+    fields_to_trim = ["name", "description"]
+
     name = models.CharField(max_length=128, unique=True)
     description = models.TextField(max_length=512, blank=True, default="")
     website = models.URLField(blank=True, default="")

--- a/terraso_backend/apps/core/models/landscapes.py
+++ b/terraso_backend/apps/core/models/landscapes.py
@@ -23,6 +23,8 @@ class Landscape(SlugModel):
     Landscape can cross several countries.
     """
 
+    fields_to_trim = ["name", "description"]
+
     name = models.CharField(max_length=128, unique=True)
     description = models.TextField(blank=True, default="")
     website = models.URLField(blank=True, default="")

--- a/terraso_backend/apps/core/models/users.py
+++ b/terraso_backend/apps/core/models/users.py
@@ -70,6 +70,12 @@ class User(SafeDeleteModel, AbstractUser):
             ),
         )
 
+    def save(self, *args, **kwargs):
+        for field in self.fields_to_trim:
+            setattr(self, field, getattr(self, field).strip())
+        return super().save(*args, **kwargs)
+
+
     def is_landscape_manager(self, landscape_id):
         return (
             self.memberships.managers_only()

--- a/terraso_backend/apps/core/models/users.py
+++ b/terraso_backend/apps/core/models/users.py
@@ -42,6 +42,8 @@ class UserManager(SafeDeleteManager, BaseUserManager):
 class User(SafeDeleteModel, AbstractUser):
     """This model represents a User on Terraso platform."""
 
+    fields_to_trim = ["first_name", "last_name"]
+
     _safedelete_policy = SOFT_DELETE_CASCADE
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)

--- a/terraso_backend/apps/core/models/users.py
+++ b/terraso_backend/apps/core/models/users.py
@@ -75,7 +75,6 @@ class User(SafeDeleteModel, AbstractUser):
             setattr(self, field, getattr(self, field).strip())
         return super().save(*args, **kwargs)
 
-
     def is_landscape_manager(self, landscape_id):
         return (
             self.memberships.managers_only()

--- a/terraso_backend/tests/core/models/test_groups.py
+++ b/terraso_backend/tests/core/models/test_groups.py
@@ -20,6 +20,23 @@ def test_group_is_slugifiable_by_name():
     assert group.slug == "this-is-my-name"
 
 
+def test_group_string_remove_spaces_from_name():
+    group_name = "Terraso Group Name "
+    group = mixer.blend(Group, name=group_name)
+
+    assert group_name.strip() == str(group)
+
+
+def test_group_string_remove_spaces_from_description():
+    group_name = "Terraso Group Name"
+    group_description = "Terraso Group Description "
+    group = mixer.blend(Group, name=group_name)
+    group.description = group_description
+    group.save()
+
+    assert group_description.strip() == group.description
+
+
 def test_group_slug_is_updatable():
     group = mixer.blend(Group, name="This is My Name", slug=None)
     group.name = "New name"

--- a/terraso_backend/tests/core/models/test_landscapes.py
+++ b/terraso_backend/tests/core/models/test_landscapes.py
@@ -21,6 +21,23 @@ def test_landscape_is_slugifiable_by_name():
     assert landscape.slug == "this-is-my-name"
 
 
+def test_landscape_string_remove_spaces_from_name():
+    landscape_name = "Terraso Landscape Name "
+    landscape = mixer.blend(Landscape, name=landscape_name)
+
+    assert landscape_name.strip() == str(landscape)
+
+
+def test_landscape_string_remove_spaces_from_description():
+    landscape_name = "Terraso Landscape Name"
+    landscape_description = "Terraso Landscape Description "
+    landscape = mixer.blend(Landscape, name=landscape_name)
+    landscape.description = landscape_description
+    landscape.save()
+
+    assert landscape_description.strip() == landscape.description
+
+
 def test_landscape_slug_is_updatable():
     landscape = mixer.blend(Landscape, name="This is My Name", slug=None)
     landscape.name = "New name"

--- a/terraso_backend/tests/core/models/test_users.py
+++ b/terraso_backend/tests/core/models/test_users.py
@@ -13,6 +13,15 @@ def test_user_string_format_is_its_email():
     assert user_email == str(user)
 
 
+def test_user_string_remove_spaces_from_name():
+    user_first_name = "First Name "
+    user_last_name = "Last Name "
+    user = mixer.blend(User, first_name=user_first_name, last_name=user_last_name)
+
+    assert user_first_name.strip() == user.first_name
+    assert user_last_name.strip() == user.last_name
+
+
 @pytest.mark.parametrize(
     "is_default_landscape_group, is_expected_to_be_manager",
     (


### PR DESCRIPTION
## Description
Ensures whitespace is trimmed from fields at the model level.

### Checklist
- [X] Corresponding issue has been opened
- [x] New tests added

### Related Issues
Fixes #159.