### PR TITLE
fix: minor fixes to OAuth provider configs

### DIFF
--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -115,7 +115,7 @@ OAUTH2_PROVIDER = {
         "profile": "User's information scope",
     },
     "OAUTH2_VALIDATOR_CLASS": "apps.auth.provider.oauth_validator.TerrasoOAuth2Validator",
-    "OIDC_RSA_PRIVATE_KEY": config("OAUTH_OIDC_KEY", default=""),
+    "OIDC_RSA_PRIVATE_KEY": config("OAUTH_OIDC_KEY", default="").replace("\\n", "\n"),
 }
 
 

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -116,6 +116,7 @@ OAUTH2_PROVIDER = {
     },
     "OAUTH2_VALIDATOR_CLASS": "apps.auth.provider.oauth_validator.TerrasoOAuth2Validator",
     "OIDC_RSA_PRIVATE_KEY": config("OAUTH_OIDC_KEY", default="").replace("\\n", "\n"),
+    "PKCE_REQUIRED": False,
 }
 
 


### PR DESCRIPTION
- This change updates how the OIDC private key is loaded from environment
variables, so we can work with multi-line values.

- After latest release of Django OAuth Toolkit, the option `PKCE_REQUIRED`
became `True` as default. This change makes it `False` at least until the
clients start supporting it.