### PR TITLE
fix: clean up deleted files command

### DIFF
--- a/terraso_backend/apps/shared_data/management/commands/clean_up_deleted_files.py
+++ b/terraso_backend/apps/shared_data/management/commands/clean_up_deleted_files.py
@@ -14,7 +14,12 @@ class Command(BaseCommand):
         total_files_removed = 0
         older_than_date = timezone.now() - timezone.timedelta(days=past_days)
         data_entries = (
-            DataEntry.objects.deleted_only().filter(deleted_at__date__lt=older_than_date).iterator()
+            DataEntry.objects.deleted_only()
+            .filter(
+                deleted_at__date__lt=older_than_date,
+                file_removed_at__isnull=True,
+            )
+            .iterator()
         )
 
         for data_entry in data_entries:


### PR DESCRIPTION
This change updates the cleanup deleted files command to make it fetch
only registers that have `file_removed_at` attribute not set.