### PR TITLE
chore: add dnsutils to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN adduser --disabled-password terraso
 ENV PATH /home/terraso/.local/bin:$PATH
 
 RUN apt-get update && \
-    apt-get install -q -y --no-install-recommends build-essential libpq-dev libmagic-dev mailcap && \
+    apt-get install -q -y --no-install-recommends build-essential libpq-dev dnsutils libmagic-dev mailcap && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Description
Add dnsutils to Dockerfile. Render support believes this will resolve the lookup error:
```
Aug 2 12:02:08 AM  django.db.utils.OperationalError: could not translate host name "dpg-c6t4e7fh8vl8fj5kkua0" to address: Temporary failure in name resolution
```