### PR TITLE
fix: fix hectare conversion

### DIFF
--- a/terraso_backend/apps/core/geo.py
+++ b/terraso_backend/apps/core/geo.py
@@ -32,4 +32,4 @@ def calculate_geojson_polygon_area(polygon_json):
 
 
 def m2_to_hectares(area):
-    return area / 1000
+    return area / 10000


### PR DESCRIPTION
There is 10,000 meters squared in a hectare, not 1,000

## Description

Made a small mistake in the square meters to hectares conversion that I discovered testing on staging.
