### PR TITLE
fix: delete users with shared files

### DIFF
--- a/terraso_backend/apps/shared_data/models/data_entries.py
+++ b/terraso_backend/apps/shared_data/models/data_entries.py
@@ -54,7 +54,7 @@ class DataEntry(BaseModel):
     size = models.PositiveBigIntegerField(null=True, blank=True)
 
     groups = models.ManyToManyField(Group, related_name="data_entries")
-    created_by = models.ForeignKey(User, on_delete=models.PROTECT)
+    created_by = models.ForeignKey(User, null=True, on_delete=models.SET_NULL)
     file_removed_at = models.DateTimeField(blank=True, null=True)
 
     class Meta(BaseModel.Meta):

--- a/terraso_backend/apps/shared_data/models/data_entries.py
+++ b/terraso_backend/apps/shared_data/models/data_entries.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
+from safedelete.models import SOFT_DELETE
 
 from apps.core.models import BaseModel, Group, User
 from apps.shared_data import permission_rules as perm_rules
@@ -35,6 +36,9 @@ class DataEntry(BaseModel):
         User who created the resource
     """
 
+    # file will not be deleted in cascade
+    _safedelete_policy = SOFT_DELETE
+
     name = models.CharField(max_length=128)
     description = models.TextField(blank=True, default="")
 
@@ -54,7 +58,7 @@ class DataEntry(BaseModel):
     size = models.PositiveBigIntegerField(null=True, blank=True)
 
     groups = models.ManyToManyField(Group, related_name="data_entries")
-    created_by = models.ForeignKey(User, null=True, on_delete=models.SET_NULL)
+    created_by = models.ForeignKey(User, null=True, on_delete=models.DO_NOTHING)
     file_removed_at = models.DateTimeField(blank=True, null=True)
 
     class Meta(BaseModel.Meta):

--- a/terraso_backend/tests/shared_data/test_models.py
+++ b/terraso_backend/tests/shared_data/test_models.py
@@ -1,6 +1,7 @@
 import pytest
 from django.db import models
 
+from apps.core.models import User
 from apps.shared_data.models import DataEntry, VisualizationConfig
 
 pytestmark = pytest.mark.django_db
@@ -116,3 +117,10 @@ def test_delete_user_with_shared_data(user, data_entry):
         user.delete()
     except models.deletion.ProtectedError as e:
         assert False, f"Deleting a user should not raise an exception. {e}"
+    # user should be soft-deleted
+    assert not User.objects.filter(id=user.id).exists()
+    # dataentry should not be soft deleted
+    assert DataEntry.objects.filter(id=data_entry.id).exists()
+    # data entry should still link to user
+    data_entry.refresh_from_db()
+    assert data_entry.created_by == user

--- a/terraso_backend/tests/shared_data/test_models.py
+++ b/terraso_backend/tests/shared_data/test_models.py
@@ -117,10 +117,7 @@ def test_delete_user_with_shared_data(user, data_entry):
         user.delete()
     except models.deletion.ProtectedError as e:
         assert False, f"Deleting a user should not raise an exception. {e}"
-    # user should be soft-deleted
-    assert not User.objects.filter(id=user.id).exists()
-    # dataentry should not be soft deleted
-    assert DataEntry.objects.filter(id=data_entry.id).exists()
-    # data entry should still link to user
+    assert not User.objects.filter(id=user.id).exists(), "User should be soft-deleted"
+    assert DataEntry.objects.filter(id=data_entry.id).exists(), "Data entry should not be deleted"
     data_entry.refresh_from_db()
-    assert data_entry.created_by == user
+    assert data_entry.created_by == user, "Data entry should still link to user"

--- a/terraso_backend/tests/shared_data/test_models.py
+++ b/terraso_backend/tests/shared_data/test_models.py
@@ -1,4 +1,5 @@
 import pytest
+from django.db import models
 
 from apps.shared_data.models import DataEntry, VisualizationConfig
 
@@ -108,3 +109,10 @@ def test_visualization_config_cannot_be_viewed_by_non_group_members(
 
     assert not user_b.has_perm(VisualizationConfig.get_perm("view"), obj=visualization_config)
     assert user.has_perm(VisualizationConfig.get_perm("view"), obj=visualization_config)
+
+
+def test_delete_user_with_shared_data(user, data_entry):
+    try:
+        user.delete()
+    except models.deletion.ProtectedError as e:
+        assert False, f"Deleting a user should not raise an exception. {e}"


### PR DESCRIPTION
## Description

Allows a user to be deleted, even if they have associated data files.

Follows the following logic:

- On a soft delete: linked `data entry` not affected
- On a hard delete: `created_by` field in linked data entry set to null.

Here is the [reference on soft delete policies](https://django-safedelete.readthedocs.io/en/latest/models.html#policies) that will be helpful in code review.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

### Related Issues
Fixes #190

### Verification steps

- Try deleting a user with associated data files
