### PR TITLE
fix: Remove unused context class from structlog config

### DIFF
--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -182,7 +182,6 @@ structlog.configure(
         structlog.processors.UnicodeDecoder(),
         structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
     ],
-    context_class=structlog.threadlocal.wrap_dict(dict),
     logger_factory=structlog.stdlib.LoggerFactory(),
     wrapper_class=structlog.stdlib.BoundLogger,
     cache_logger_on_first_use=True,


### PR DESCRIPTION
## Description

It seems like this `context_class` option was included in our structlog setup. However, the feature of context-local logging variables does not seem to have been actually used. I tried removing it and it does not appear to affect the logging output of a few simple requests. As the `threadlocal` module is now deprecated, it makes most sense to remove this config option completely.

My guess is that this was included as part of the default config in the [setup docs for django-structlog](https://django-structlog.readthedocs.io/en/latest/getting_started.html#installation) and never actually used. I didn't verify this though. 

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes #195 

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
