### PR TITLE
chore: increase dependabot open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Description
allows dependabot to open more PRs at once, hopefully decreasing chance it will create a dependency conflict without creating a huge flood of PRs. can adjust further as needed
