### PR TITLE
fix: Change approval setting to only prompt on signup

### DIFF
--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -138,6 +138,7 @@ OAUTH2_PROVIDER = {
     # easiest way to force https:// is to provide this explicitly
     "OIDC_ISS_ENDPOINT": config("OIDC_ISS_ENDPOINT", default="https://api.terraso.org/oauth/"),
     "PKCE_REQUIRED": False,
+    "REQUEST_APPROVAL_PROMPT": "auto",
 }
 
 LANGUAGE_CODE = "en-us"


### PR DESCRIPTION
## Description

The default settings of [django-oauth-toolkit](https://github.com/jazzband/django-oauth-toolkit) force the user to reauthorize our OAuth authorization every time the user signs in from an OAuth client. This PR updates the settings so it only prompts for an authorization the first time the user authenticates.
