### PR TITLE
refactor: use API_ENDPOINT setting instead of individual settings for Google/Apple/MS

### DIFF
--- a/terraso_backend/apps/auth/providers.py
+++ b/terraso_backend/apps/auth/providers.py
@@ -32,7 +32,7 @@ class GoogleProvider:
     GOOGLE_TOKEN_URI = "https://oauth2.googleapis.com/token"
     CLIENT_ID = settings.GOOGLE_CLIENT_ID
     CLIENT_SECRET = settings.GOOGLE_CLIENT_SECRET
-    REDIRECT_URI = settings.GOOGLE_AUTH_REDIRECT_URI
+    REDIRECT_URI = f"{settings.API_ENDPOINT}/auth/google/callback"
 
     @classmethod
     def login_url(cls, state=None):
@@ -84,7 +84,7 @@ class AppleProvider:
     OAUTH_BASE_URL = "https://appleid.apple.com/auth/authorize?"
     TOKEN_URI = "https://appleid.apple.com/auth/token"
     CLIENT_ID = settings.APPLE_CLIENT_ID
-    REDIRECT_URI = settings.APPLE_AUTH_REDIRECT_URI
+    REDIRECT_URI = f"{settings.API_ENDPOINT}/auth/apple/callback"
     JWT_ALGORITHM = "ES256"
     JWT_AUD = "https://appleid.apple.com"
 
@@ -157,7 +157,7 @@ class MicrosoftProvider:
     TOKEN_URI = f"{MS_BASE_URI}token"
     CLIENT_ID = settings.MICROSOFT_CLIENT_ID
     CLIENT_SECRET = settings.MICROSOFT_CLIENT_SECRET
-    REDIRECT_URI = settings.MICROSOFT_AUTH_REDIRECT_URI
+    REDIRECT_URI = f"{settings.API_ENDPOINT}/auth/microsoft/callback"
 
     @classmethod
     def login_url(cls, state=None):

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -217,22 +217,21 @@ LOGIN_URL = f"{WEB_CLIENT_URL}/account"
 AUTH_COOKIE_DOMAIN = config("AUTH_COOKIE_DOMAIN", default="")
 CORS_ORIGIN_WHITELIST = config("CORS_ORIGIN_WHITELIST", default=[], cast=config.list)
 
+API_ENDPOINT = config("API_ENDPOINT", default="")
+
 AIRTABLE_API_KEY = config("AIRTABLE_API_KEY", default="")
 
 GOOGLE_CLIENT_ID = config("GOOGLE_CLIENT_ID", default="")
 GOOGLE_CLIENT_SECRET = config("GOOGLE_CLIENT_SECRET", default="")
-GOOGLE_AUTH_REDIRECT_URI = config("GOOGLE_AUTH_REDIRECT_URI", default="")
 
 APPLE_KEY_ID = config("APPLE_KEY_ID", default="")
 APPLE_TEAM_ID = config("APPLE_TEAM_ID", default="")
 APPLE_PRIVATE_KEY = config("APPLE_PRIVATE_KEY", default="").replace("\\n", "\n")
 APPLE_CLIENT_ID = config("APPLE_CLIENT_ID", default="")
-APPLE_AUTH_REDIRECT_URI = config("APPLE_AUTH_REDIRECT_URI", default="")
 
 MICROSOFT_CLIENT_ID = config("MICROSOFT_CLIENT_ID", default="")
 MICROSOFT_CLIENT_SECRET = config("MICROSOFT_CLIENT_SECRET", default="")
 MICROSOFT_TENANT = config("MICROSOFT_TENANT", default="")
-MICROSOFT_AUTH_REDIRECT_URI = config("MICROSOFT_AUTH_REDIRECT_URI", default="")
 
 JWT_SECRET = config("JWT_SECRET")
 JWT_ALGORITHM = config("JWT_ALGORITHM", default="HS512")


### PR DESCRIPTION
## Description
Previously, we had `GOOGLE_AUTH_REDIRECT_URI`, `APPLE_AUTH_REDIRECT_URI` and `MICROSOFT_AUTH_REDIRECT_URI`. 

Now we have `API_ENDPOINT`.

This repeated the same hostname three times, cluttering up the environment variables.

The path part of the URI didn't change from environment to environment; this can stay in the code.