### PR TITLE
fix: Improve error message on missing SSO email

### DIFF
--- a/terraso_backend/apps/auth/services.py
+++ b/terraso_backend/apps/auth/services.py
@@ -77,6 +77,10 @@ class AccountService:
         )
 
     def _persist_user(self, email, first_name="", last_name="", profile_image_url=None):
+        if not email:
+            # it is possible for the email not to be set, notably with Microsoft
+            # here throw a more descriptive error message
+            raise ValueError("Could not create account, user email is empty")
         user, created = User.objects.get_or_create(email=email)
 
         self._update_profile_image(user, profile_image_url)


### PR DESCRIPTION
## Description

If a user signs up with OAuth and the OAuth provider does not provide an email, the backend throws an inscrutable error about database constraints. This helps a bit and displays a clearer error message.

### Related Issues
Fixes #304 
