### PR TITLE
fix: move depends_on into env specific docker-compose

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -6,6 +6,10 @@ services:
       file: docker-compose.base.yml
       service: web
 
+    depends_on:
+      db:
+        condition: service_healthy
+
   db:
     extends:
       file: docker-compose.base.yml

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,6 +8,10 @@ services:
     volumes:
       - .:/app:z
 
+    depends_on:
+      db:
+        condition: service_healthy
+
   db:
     extends:
       file: docker-compose.base.yml


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
Re-add depends_on in extended docker-compose files.