### PR TITLE
fix: handle unauthenticated requests for public group information

### DIFF
--- a/terraso_backend/apps/graphql/schema/groups.py
+++ b/terraso_backend/apps/graphql/schema/groups.py
@@ -97,6 +97,15 @@ class GroupNode(DjangoObjectType):
     def resolve_memberships_count(self, info):
         if hasattr(self, "memberships_count"):
             return self.memberships_count
+
+        # Nonmembers cannot see the number of members of a closed group
+        if self.membership_type == Group.MEMBERSHIP_TYPE_CLOSED:
+            is_member = (
+                self.memberships.approved_only().filter(user__id=info.context.user.pk).exists()
+            )
+            if not is_member:
+                return 0
+
         return self.memberships.approved_only().count()
 
 

--- a/terraso_backend/apps/graphql/schema/memberships.py
+++ b/terraso_backend/apps/graphql/schema/memberships.py
@@ -49,6 +49,10 @@ class MembershipNode(DjangoObjectType):
 
     @classmethod
     def get_queryset(cls, queryset, info):
+        user = info.context.user
+        if user.is_anonymous:
+            return queryset.none()
+
         user_groups_ids = Membership.objects.filter(
             user=info.context.user, membership_status=Membership.APPROVED
         ).values_list("group", flat=True)


### PR DESCRIPTION
## Description
Handle unauthenticated (anonymous) requests for public group information
- provide a 0 for counts for closed groups
- return empty list for members

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added

### Related Issues
Web client https://github.com/techmatters/terraso-web-client/issues/324