### PR TITLE
fix: mark sitemap path as public

### DIFF
--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -358,4 +358,5 @@ PUBLIC_BASE_PATHS = [
     "/oauth/",
     "/auth/",
     "/healthz/",
+    "/web-client/sitemap.xml",
 ]


### PR DESCRIPTION
## Description
Mark sitemap path as public in `PUBLIC_BASE_PATHS`.