### PR TITLE
chore: use docker compose v2 in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DC_ENV ?= dev
 DC_FILE_ARG = -f docker-compose.$(DC_ENV).yml
-DC_RUN_CMD = docker-compose $(DC_FILE_ARG) run --rm web
+DC_RUN_CMD = docker compose $(DC_FILE_ARG) run --rm web
 
 api_docs:
 	npx spectaql --one-file --target-file=docs.html --target-dir=terraso_backend/apps/graphql/templates/ terraso_backend/apps/graphql/spectaql.yml
@@ -12,7 +12,7 @@ build_base_image:
 	docker build --tag=techmatters/terraso_backend --file=Dockerfile .
 
 build: build_base_image
-	docker-compose $(DC_FILE_ARG) build
+	docker compose $(DC_FILE_ARG) build
 
 check_rebuild:
 	./scripts/rebuild.sh
@@ -75,10 +75,10 @@ run:
 setup: build setup-pre-commit
 
 start-%:
-	@docker-compose $(DC_FILE_ARG) up -d $(@:start-%=%)
+	@docker compose $(DC_FILE_ARG) up -d $(@:start-%=%)
 
 stop:
-	@docker-compose $(DC_FILE_ARG) stop
+	@docker compose $(DC_FILE_ARG) stop
 
 test: clean check_rebuild compile-translations
 	if [ -z "$(PATTERN)" ]; then \

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -2,7 +2,7 @@
 
 DOCKER_ERRORS=$(docker info 2>/dev/null | grep -c ERROR)
 if [ "${DOCKER_ERRORS}" = "0" ]; then
-  docker-compose $1 up
+  docker compose $1 up
 else
   echo "Docker is not running. Please start it and try 'make run' again."
 fi


### PR DESCRIPTION
## Description
Docker compose v1 is at EOL next month (see https://docs.docker.com/compose/compose-v2/). This updates our scripts to say `docker compose` instead of `docker-compose` so that we are not using an unsupported version in CI (see https://github.com/actions/runner-images/issues/4657#issuecomment-1125700203). This may break people's local workflows, but we should all be making sure to use v2 locally as well.
