### PR TITLE
fix: Continue SSO signin provision for users not logged into Terraso

### DIFF
--- a/terraso_backend/apps/auth/constants.py
+++ b/terraso_backend/apps/auth/constants.py
@@ -1,0 +1,1 @@
+OAUTH_COOKIE_MAX_AGE_SECONDS = 300  # 5 minutes

--- a/terraso_backend/apps/auth/constants.py
+++ b/terraso_backend/apps/auth/constants.py
@@ -1,1 +1,2 @@
+OAUTH_COOKIE_NAME = "oauth"
 OAUTH_COOKIE_MAX_AGE_SECONDS = 300  # 5 minutes

--- a/terraso_backend/apps/auth/middleware.py
+++ b/terraso_backend/apps/auth/middleware.py
@@ -24,7 +24,7 @@ from django.http.response import JsonResponse
 from django.urls import reverse
 from jwt.exceptions import InvalidTokenError
 
-from .constants import OAUTH_COOKIE_MAX_AGE_SECONDS
+from .constants import OAUTH_COOKIE_MAX_AGE_SECONDS, OAUTH_COOKIE_NAME
 from .services import JWTService
 
 logger = structlog.get_logger(__name__)
@@ -123,19 +123,19 @@ class OAuthAuthorizeState:
 
         if request.path == self.uri_path and request.user.is_anonymous:
             # user accessing OAuth authorize URI and not logged in
-            # they will directed to log in by the frontend
-            # in the mean time, we store the URL so OAuth can start after
+            # we store the URL so OAuth can start after
             # user logged in
             cookie = request.get_full_path_info()
 
             response.set_signed_cookie(
-                "oauth",
+                OAUTH_COOKIE_NAME,
                 cookie,
                 domain=settings.AUTH_COOKIE_DOMAIN,
                 max_age=OAUTH_COOKIE_MAX_AGE_SECONDS,
                 httponly=True,
                 secure=True,
-                # need lax for our usage here
+                # lax - cookie sent from requests not originating from our domain
+                # need this for the oauth flow b/c request coming from third party
                 samesite="Lax",
             )
 

--- a/terraso_backend/apps/auth/middleware.py
+++ b/terraso_backend/apps/auth/middleware.py
@@ -123,8 +123,7 @@ class OAuthAuthorizeState:
 
         if request.path == self.uri_path and request.user.is_anonymous:
             # user accessing OAuth authorize URI and not logged in
-            # we store the URL so OAuth can start after
-            # user logged in
+            # we store the URL so OAuth can start after login
             cookie = request.get_full_path_info()
 
             response.set_signed_cookie(

--- a/terraso_backend/apps/auth/views.py
+++ b/terraso_backend/apps/auth/views.py
@@ -15,6 +15,7 @@
 
 import functools
 import json
+from urllib.parse import urlparse
 
 import httpx
 import structlog
@@ -23,8 +24,10 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth import login as dj_login
 from django.contrib.auth import logout as dj_logout
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
+from django.urls import reverse
 from django.views import View
 
+from .constants import OAUTH_COOKIE_MAX_AGE_SECONDS
 from .providers import AppleProvider, GoogleProvider, MicrosoftProvider
 from .services import AccountService, JWTService, PlausibleService
 
@@ -67,16 +70,27 @@ class AbstractCallbackView(View):
         self.error = self.request.GET.get("error")
         self.state = self.request.GET.get("state", "")
 
-        return self.process_callback()
+        return self.process_callback(request)
 
     def post(self, request, *args, **kwargs):
         self.authorization_code = self.request.POST.get("code")
         self.error = self.request.POST.get("error")
         self.state = self.request.POST.get("state", "")
 
-        return self.process_callback()
+        return self.process_callback(request)
 
-    def process_callback(self):
+    @classmethod
+    def _check_cookie(cls, cookie):
+        """Double check to make sure the redirect URI makes sense"""
+        try:
+            url = urlparse(cookie)
+            if url.hostname:
+                return False
+            return url.path.startswith(reverse("oauth2_provider:authorize"))
+        except ValueError:
+            return False
+
+    def process_callback(self, req):
         if self.error:
             logger.error("Auth provider returned error on callback", extra={"error": self.error})
             return HttpResponse(f"Error: {self.error}", status=400)
@@ -92,7 +106,14 @@ class AbstractCallbackView(View):
             logger.exception("Error attempting create access and refresh tokens")
             return HttpResponse(f"Error: {exc}", status=400)
 
-        response = HttpResponseRedirect(f"{settings.WEB_CLIENT_URL}/{self.state}")
+        redirect_uri = f"{settings.WEB_CLIENT_URL}/{self.state}"
+        if cookie := req.get_signed_cookie("oauth", None, max_age=OAUTH_COOKIE_MAX_AGE_SECONDS):
+            # we stored the original URI as a cookie
+            # redirecting the user to this URI will start our OAuth process
+            if self._check_cookie(cookie):
+                redirect_uri = cookie
+        response = HttpResponseRedirect(redirect_uri)
+        response.delete_cookie("oauth")
         response.set_cookie("atoken", access_token, domain=settings.AUTH_COOKIE_DOMAIN)
         response.set_cookie("rtoken", refresh_token, domain=settings.AUTH_COOKIE_DOMAIN)
         if created_with_service:

--- a/terraso_backend/apps/auth/views.py
+++ b/terraso_backend/apps/auth/views.py
@@ -27,7 +27,7 @@ from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.urls import reverse
 from django.views import View
 
-from .constants import OAUTH_COOKIE_MAX_AGE_SECONDS
+from .constants import OAUTH_COOKIE_MAX_AGE_SECONDS, OAUTH_COOKIE_NAME
 from .providers import AppleProvider, GoogleProvider, MicrosoftProvider
 from .services import AccountService, JWTService, PlausibleService
 
@@ -107,7 +107,9 @@ class AbstractCallbackView(View):
             return HttpResponse(f"Error: {exc}", status=400)
 
         redirect_uri = f"{settings.WEB_CLIENT_URL}/{self.state}"
-        if cookie := req.get_signed_cookie("oauth", None, max_age=OAUTH_COOKIE_MAX_AGE_SECONDS):
+        if cookie := req.get_signed_cookie(
+            OAUTH_COOKIE_NAME, None, max_age=OAUTH_COOKIE_MAX_AGE_SECONDS
+        ):
             # we stored the original URI as a cookie
             # redirecting the user to this URI will start our OAuth process
             if self._check_cookie(cookie):

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -86,6 +86,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "apps.auth.middleware.JWTAuthenticationMiddleware",
+    "apps.auth.middleware.OAuthAuthorizeState",
     "django_structlog.middlewares.RequestMiddleware",
     "django.middleware.locale.LocaleMiddleware",
 ]

--- a/terraso_backend/tests/auth/test_oauth.py
+++ b/terraso_backend/tests/auth/test_oauth.py
@@ -1,0 +1,44 @@
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from django.core import signing
+from django.urls import reverse
+from mixer.backend.django import mixer
+from oauth2_provider.models import Application
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def oauth_application():
+    return mixer.blend(Application)
+
+
+@pytest.mark.parametrize("logged_in", [False, True])
+def test_unauthenticated_user_accessing_auth_point_gets_cookie_set(
+    client, oauth_application, user, logged_in
+):
+    authorize_url = reverse("oauth2_provider:authorize")
+    params = dict(
+        response_type=["code"],
+        client_id=[oauth_application.client_id],
+        redirect_url=["https://example.org/callback"],
+    )
+    if logged_in:
+        client.force_login(user)
+    resp = client.get(authorize_url, params)
+    if not logged_in:
+        assert (cookie := resp.cookies.get("oauth", None))
+        # default salt is the key
+        signer = signing.get_cookie_signer(salt="oauth")
+        url = urlparse(signer.unsign(cookie.value))
+        assert url.path == authorize_url
+        assert parse_qs(url.query) == params
+    else:
+        assert "oauth" not in resp.cookies
+
+
+def test_other_route_does_not_get_cookie(client):
+    url = "/foo"
+    resp = client.get(url)
+    assert "oauth" not in resp.cookies


### PR DESCRIPTION
## Description

As described in #478, users currently are not redirected to continue the SSO signin process if they are not signed into their Terraso account. This PR aims to fix this by storing the URI used to start the signin in a cookie. When the user has completed logging into Terraso, we then redirect them to this original URI, starting the process.

How it works:
- User tried to query `/oauth/authorize`; because they are not logged in, the backend redirects them to our "login page", which is just `/`
- I added middleware that just checks if a not logged-in user is trying to query the URI that starts the Terraso SSO provider process (`/oauth/authorize`); if so, the URI is stored in a signed cookie. An expiry date of five minutes is set so that the cookie doesn't hand around forever.
-  User completes their login to Terraso
- At the final step of their login to Terraso, we check if this cookie is currently set. If it is, we grab the value of the cookie and make sure it matches what we expect. The redirect URI send to the user is set to the cookie value.
- The cookie is deleted.
- User is redirected to original URI and the SSO provider process starts.

Overall, this process is quite simple, but not without its drawbacks. However, I think this is a good first solution. We can continue thinking of ways to improve this process.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

### Related Issues
Fixes #478

### Verification steps
- This currently works with our staging URL and the Kobo test server
- Check slack or ask me for the URL to the test Kobo server
- Open a private window and paste the URL
- Go through the SSO signin process
- You will end up being redirected to Kobo signup screen
