### PR TITLE
fix: specify optional param in many to many field

### DIFF
--- a/terraso_backend/apps/core/models/landscapes.py
+++ b/terraso_backend/apps/core/models/landscapes.py
@@ -65,7 +65,7 @@ class Landscape(SlugModel, DirtyFieldsMixin):
     groups = models.ManyToManyField(Group, through="LandscapeGroup")
 
     area_types = models.JSONField(blank=True, null=True)
-    taxonomy_terms = models.ManyToManyField(TaxonomyTerm)
+    taxonomy_terms = models.ManyToManyField(TaxonomyTerm, blank=True)
     population = models.IntegerField(blank=True, null=True)
 
     PARTNERSHIP_STATUS_NONE = ""


### PR DESCRIPTION
## Description
_Fix:_
Specified `Blank=True` in taxonomy_terms many to many field

### Checklist
-[X] "taxonomy terms" is an optional field for Django admin

### Related Issues
Fixes #459 

### Verification steps
1. Click Landscapes under Core
2. Click on Add or click on an existing landscape 
3. Remove any selected taxonomy terms 
4. Press save (save should be successful)
