### PR TITLE
chore: remove no-longer-used partnership status strings

### DIFF
--- a/terraso_backend/locale/en/LC_MESSAGES/django.po
+++ b/terraso_backend/locale/en/LC_MESSAGES/django.po
@@ -56,22 +56,6 @@ msgstr ""
 msgid "Pending"
 msgstr ""
 
-#: terraso_backend/apps/core/models/landscapes.py:74
-msgid "partnership_status.none"
-msgstr ""
-
-#: terraso_backend/apps/core/models/landscapes.py:75
-msgid "partnership_status.no"
-msgstr "No"
-
-#: terraso_backend/apps/core/models/landscapes.py:76
-msgid "partnership_status.in_progress"
-msgstr "In Progress"
-
-#: terraso_backend/apps/core/models/landscapes.py:77
-msgid "partnership_status.yes"
-msgstr "Yes"
-
 #: terraso_backend/apps/core/models/taxonomy_terms.py:32
 msgid "Ecosystem Type"
 msgstr ""

--- a/terraso_backend/locale/es/LC_MESSAGES/django.po
+++ b/terraso_backend/locale/es/LC_MESSAGES/django.po
@@ -56,22 +56,6 @@ msgstr "Aprobado"
 msgid "Pending"
 msgstr "Pendiente"
 
-#: terraso_backend/apps/core/models/landscapes.py:74
-msgid "partnership_status.none"
-msgstr ""
-
-#: terraso_backend/apps/core/models/landscapes.py:75
-msgid "partnership_status.no"
-msgstr "Sin asociación"
-
-#: terraso_backend/apps/core/models/landscapes.py:76
-msgid "partnership_status.in_progress"
-msgstr "En progreso"
-
-#: terraso_backend/apps/core/models/landscapes.py:77
-msgid "partnership_status.yes"
-msgstr "Asociación formal establecida"
-
 #: terraso_backend/apps/core/models/taxonomy_terms.py:32
 msgid "Ecosystem Type"
 msgstr "Tipo de ecosistema"


### PR DESCRIPTION
## Description
Followup to #527. Removes corresponding strings from the .po files.