### PR TITLE
fix: don't do extraneous group existence check

### DIFF
--- a/terraso_backend/apps/graphql/schema/data_entries.py
+++ b/terraso_backend/apps/graphql/schema/data_entries.py
@@ -114,13 +114,6 @@ class DataEntryAddMutation(BaseWriteMutation):
         if "entry_type" in kwargs:
             kwargs["entry_type"] = DataEntry.get_entry_type_from_text(kwargs["entry_type"])
 
-        group_slug = kwargs.pop("group_slug")
-        try:
-            group = Group.objects.get(slug=group_slug)
-        except Group.DoesNotExist:
-            logger.error("Group not found when adding Data Entry", extra={"group_slug": group_slug})
-            raise GraphQLNotFoundException(field="group", model_name=DataEntry.__name__)
-
         result = super().mutate_and_get_payload(root, info, **kwargs)
 
         result.data_entry.groups.set([group])


### PR DESCRIPTION
## Description
Removes an extra check for group existence that was causing a bug in prod backend.

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

### Related Issues
Fixes https://github.com/techmatters/terraso-product/issues/143

### Verification steps
Should now be able to add shared links to groups and landscapes again.