### PR TITLE
fix: add missing story map key to .env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -31,7 +31,7 @@ MICROSOFT_CERIFICATE_THUMBPRINT=thumbprint
 JWT_SECRET=superinsecuresecretchangeit
 
 PROFILE_IMAGES_S3_BUCKET=images.dev.terraso.org
-
+STORY_MAP_MEDIA_S3_BUCKET=files.staging.terraso.net
 DATA_ENTRY_FILE_S3_BUCKET=files.dev.terraso.org
 
 DB_BACKUP_S3_BUCKET=backup.dev.terraso.org


### PR DESCRIPTION
## Description
Adds the `STORY_MAP_MEDIA_S3_BUCKET` key to `.env.sample`, necessary for testing story maps in local dev.
