### PR TITLE
feat: add permissions for site query

### DIFF
--- a/terraso_backend/apps/graphql/schema/sites.py
+++ b/terraso_backend/apps/graphql/schema/sites.py
@@ -20,8 +20,7 @@ from graphene import relay
 from graphene_django import DjangoObjectType
 
 from apps.audit_logs import api as audit_log_api
-from apps.project_management.models import Project, Site
-from apps.project_management.models import sites
+from apps.project_management.models import Project, Site, sites
 
 from .commons import BaseWriteMutation, TerrasoConnection
 from .constants import MutationTypes

--- a/terraso_backend/apps/graphql/schema/sites.py
+++ b/terraso_backend/apps/graphql/schema/sites.py
@@ -21,6 +21,7 @@ from graphene_django import DjangoObjectType
 
 from apps.audit_logs import api as audit_log_api
 from apps.project_management.models import Project, Site
+from apps.project_management.models import sites
 
 from .commons import BaseWriteMutation, TerrasoConnection
 from .constants import MutationTypes
@@ -50,6 +51,13 @@ class SiteNode(DjangoObjectType):
 
         interfaces = (relay.Node,)
         connection_class = TerrasoConnection
+
+    @classmethod
+    def get_queryset(cls, queryset, info):
+        user = info.context.user
+        if user.is_anonymous:
+            return queryset.none()
+        return sites.filter_only_sites_user_owner_or_member(user, queryset)
 
 
 class SiteAddMutation(BaseWriteMutation):

--- a/terraso_backend/apps/project_management/models/sites.py
+++ b/terraso_backend/apps/project_management/models/sites.py
@@ -16,8 +16,9 @@ from typing import Union
 
 from django.conf import settings
 from django.db import models
+from django.db.models import Q
 
-from apps.core.models import User
+from apps.core.models import Membership, User
 from apps.core.models.commons import BaseModel
 from apps.project_management import permission_rules
 
@@ -87,3 +88,13 @@ class Site(BaseModel):
 
     def human_readable(self) -> str:
         return self.name
+
+
+def filter_only_sites_user_owner_or_member(user: User, queryset):
+    return queryset.filter(
+        Q(owner=user) |
+        Q(
+            project__group__memberships__user=user,
+            project__group__memberships__membership_status=Membership.APPROVED,
+        )
+    )

--- a/terraso_backend/tests/graphql/teste_sites_query.py
+++ b/terraso_backend/tests/graphql/teste_sites_query.py
@@ -159,6 +159,3 @@ def test_query_site_permissions(client, client_query, project, project_manager, 
     assert "errors" not in response.json()
     edges = response.json()["data"]["sites"]["edges"]
     assert len(edges) == 2
-
-
-


### PR DESCRIPTION
## Description
Limits:
- sites owned the user making the query
- sites owned by projects where the user making the query is a member or Project manager

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Closes: #556

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
