### PR TITLE
chore: update boto/botocore versions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -47,13 +47,13 @@ black==23.3.0 \
     --hash=sha256:ec751418022185b0c1bb7d7736e6933d40bbb14c14a0abcf9123d1b159f98dd4 \
     --hash=sha256:f0bd2f4a58d6666500542b26354978218a9babcdc972722f4bf90779524515f3
     # via -r requirements/dev.in
-boto3==1.26.154 \
-    --hash=sha256:cf1067d101be538f399b685bbe6beb4bfed01095da8497d0c7fa8b8788a65c6b \
-    --hash=sha256:ee2b3733f40f935da78bf76bc8e82af6e90841406e04605e3b2d765b50cad05e
+boto3==1.26.156 \
+    --hash=sha256:3a60283676399ae94b49b7a170fb0f42ca2ddcde490988fb0af7fd5a64440ab8 \
+    --hash=sha256:455b6e1f12768b21b5f3990cf1fadeed9bf1c6b36e5a7a303352b927f530c434
     # via moto
-botocore==1.29.155 \
-    --hash=sha256:32d5da68212e10c060fd484f41df4f7048fc7731ccd16fd00e37b11b6e841142 \
-    --hash=sha256:7fbb7ebba5f645c9750fe557b1ea789d40017a028cdaa2c22fcbf06d4a4d3c1d
+botocore==1.29.156 \
+    --hash=sha256:21d0c2cb1461f2676e41a896e6e551c7da09e923f416322182520851b179ebda \
+    --hash=sha256:44b26a5468402bb9e5028d8f9ef2eba973cde016979aa72f87db32ef9000dab4
     # via
     #   boto3
     #   moto

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,15 +26,15 @@ attrs==23.1.0 \
     #   ddtrace
     #   fiona
     #   jsonschema
-boto3==1.26.154 \
-    --hash=sha256:cf1067d101be538f399b685bbe6beb4bfed01095da8497d0c7fa8b8788a65c6b \
-    --hash=sha256:ee2b3733f40f935da78bf76bc8e82af6e90841406e04605e3b2d765b50cad05e
+boto3==1.26.156 \
+    --hash=sha256:3a60283676399ae94b49b7a170fb0f42ca2ddcde490988fb0af7fd5a64440ab8 \
+    --hash=sha256:455b6e1f12768b21b5f3990cf1fadeed9bf1c6b36e5a7a303352b927f530c434
     # via
     #   -r requirements/base.in
     #   django-ses
-botocore==1.29.155 \
-    --hash=sha256:32d5da68212e10c060fd484f41df4f7048fc7731ccd16fd00e37b11b6e841142 \
-    --hash=sha256:7fbb7ebba5f645c9750fe557b1ea789d40017a028cdaa2c22fcbf06d4a4d3c1d
+botocore==1.29.156 \
+    --hash=sha256:21d0c2cb1461f2676e41a896e6e551c7da09e923f416322182520851b179ebda \
+    --hash=sha256:44b26a5468402bb9e5028d8f9ef2eba973cde016979aa72f87db32ef9000dab4
     # via
     #   boto3
     #   s3transfer


### PR DESCRIPTION
## Description
Update boto/botocore versions. Dependabot was unable to upgrade both.