### PR TITLE
feat: Mobile sign in

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -45,3 +45,5 @@ AWS_SES_SECRET_ACCESS_KEY=aws-secret-access-key
 CDN_STATIC_DOMAIN=static.dev.terraso.org
 PLAUSIBLE_URL=https://plausible.io/api/event
 RENDER_API_TOKEN=your-render-token
+
+GOOGLE_MOBILE_CLIENT_ID=google-mobile-client-id

--- a/terraso_backend/apps/auth/urls.py
+++ b/terraso_backend/apps/auth/urls.py
@@ -25,6 +25,7 @@ from apps.auth.views import (
     MicrosoftAuthorizeView,
     MicrosoftCallbackView,
     RefreshAccessTokenView,
+    TokenExchangeView,
 )
 
 app_name = "apps.auth"
@@ -54,4 +55,5 @@ urlpatterns = [
     ),
     path("tokens", csrf_exempt(RefreshAccessTokenView.as_view()), name="tokens"),
     path("logout", csrf_exempt(LogoutView.as_view()), name="logout"),
+    path("token-exchange", csrf_exempt(TokenExchangeView.as_view()), name="token-exchange"),
 ]

--- a/terraso_backend/apps/auth/views.py
+++ b/terraso_backend/apps/auth/views.py
@@ -306,8 +306,8 @@ class TokenExchangeView(View):
             logger.exception("token was not verified")
             return JsonResponse({"token_error": "token was not verified"})
         user, created = self._create_or_fetch_user(**payload)
-        if created:
-            # TODO: Create analytics event to track user signup
-            pass
         rtoken, atoken = terraso_login(request, user)
-        return JsonResponse({"rtoken": rtoken, "atoken": atoken})
+        resp_payload = {"rtoken": rtoken, "atoken": atoken}
+        if created:
+            resp_payload["created"] = True
+        return JsonResponse(resp_payload)

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -14,6 +14,7 @@
 # along with this program. If not, see https://www.gnu.org/licenses/.
 import base64
 import os
+from typing import TypedDict
 
 import django
 import structlog
@@ -364,3 +365,17 @@ PUBLIC_BASE_PATHS = [
     "/healthz/",
     "/web-client/sitemap.xml",
 ]
+
+
+class JWTProvider(TypedDict):
+    url: str
+    client_id: str
+    name: str
+
+
+JWT_EXCHANGE_PROVIDERS: dict[str, JWTProvider] = {
+    "google": dict(
+        url="https://www.googleapis.com/oauth2/v3/certs",
+        client_id=config("GOOGLE_MOBILE_CLIENT_ID", default=""),
+    )
+}

--- a/terraso_backend/tests/auth/test_token_exchange.py
+++ b/terraso_backend/tests/auth/test_token_exchange.py
@@ -1,13 +1,20 @@
+import base64
 import json
+import math
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import jwt
 import pytest
 from cryptography.hazmat.primitives.asymmetric import rsa
+from django.contrib.auth import get_user_model
+from django.urls import reverse
 
-from apps.auth.models import User
-from apps.auth.service import JWTService
+from apps.auth.services import JWTService
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
 
 
 @pytest.fixture
@@ -21,8 +28,8 @@ def other_private_key():
 
 
 def get_public_numbers(private_key):
-    public_key = private_key.public_key()
-    return public_key.e, public_key.n
+    pubnum = private_key.public_key().public_numbers()
+    return pubnum.e, pubnum.n
 
 
 @pytest.fixture
@@ -33,8 +40,16 @@ def payload():
         "sub": "111111111",
         "given_name": "test",
         "family_name": "user",
+        "email": "test@example.org",
         "iat": int(datetime.now().timestamp()),
         "exp": int((datetime.now() + timedelta(hours=1)).timestamp()),
+    }
+
+
+@pytest.fixture
+def exchange_providers(settings):
+    settings.JWT_EXCHANGE_PROVIDERS = {
+        "example": {"url": "https://example.org/keys", "client_id": "CLIENT_KEY"}
     }
 
 
@@ -44,7 +59,18 @@ def sign_payload(payload, private_key):
 
 def jwks(private_key):
     e, n = get_public_numbers(private_key)
-    return [{"alg": "RS256", "use": "sig", "kty": "RSA", "n": n, "e": e, "kid": 1}]
+    return {
+        "alg": "RS256",
+        "use": "sig",
+        "kty": "RSA",
+        "n": encode_int(n),
+        "e": encode_int(e),
+        "kid": 1,
+    }
+
+
+def encode_int(n: int):
+    return base64.b64encode(n.to_bytes(math.ceil(n.bit_length() / 8), "big"))
 
 
 def set_urlopen_mock(mock, jwks):
@@ -55,21 +81,17 @@ def set_urlopen_mock(mock, jwks):
     mock.return_value = ret
 
 
-@patch("urllib.urlopen")
-def test_token_exchange(urlopen, client, private_key, payload, settings):
-    set_urlopen_mock(urlopen, jwks(private_key))
-    with settings(
-        JWT_EXCHANGE_PROVIDERS={
-            "example": {"url": "https://example.org/keys", "client_id": "CLIENT_KEY"}
-        }
-    ):
-        resp = client.post(
-            "/auth/token-exchange",
-            data={"jwt": sign_payload(payload, private_key), "provider": "example"},
-        )
-    contents = json(resp.contents)
+@patch("jwt.PyJWKClient.get_signing_key_from_jwt")
+def test_token_exchange(mock, client, private_key, payload, exchange_providers):
+    mock.return_value = jwt.api_jwk.PyJWK(jwks(private_key))
+    resp = client.post(
+        reverse("apps.auth:token-exchange"),
+        content_type="application/json",
+        data={"jwt": sign_payload(payload, private_key), "provider": "example"},
+    )
+    contents = resp.json()
     jwt_service = JWTService()
-    atoken = jwt_service.decode(contents["atoken"])
-    rtoken = jwt_service.decode(contents["rtoken"])
+    atoken = jwt_service.verify_token(contents["atoken"])
+    rtoken = jwt_service.verify_token(contents["rtoken"])
     assert atoken["email"] == rtoken["email"] == "test@example.org"
     assert User.objects.filter(email="test@example.org").exists()

--- a/terraso_backend/tests/auth/test_token_exchange.py
+++ b/terraso_backend/tests/auth/test_token_exchange.py
@@ -1,0 +1,75 @@
+import json
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from apps.auth.models import User
+from apps.auth.service import JWTService
+
+
+@pytest.fixture
+def private_key(scope="session"):
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture(scope="session")
+def other_private_key():
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def get_public_numbers(private_key):
+    public_key = private_key.public_key()
+    return public_key.e, public_key.n
+
+
+@pytest.fixture
+def payload():
+    return {
+        "iss": "https://example.org",
+        "aud": "CLIENT_KEY",
+        "sub": "111111111",
+        "given_name": "test",
+        "family_name": "user",
+        "iat": int(datetime.now().timestamp()),
+        "exp": int((datetime.now() + timedelta(hours=1)).timestamp()),
+    }
+
+
+def sign_payload(payload, private_key):
+    return jwt.encode(payload, private_key, "RS256")
+
+
+def jwks(private_key):
+    e, n = get_public_numbers(private_key)
+    return [{"alg": "RS256", "use": "sig", "kty": "RSA", "n": n, "e": e, "kid": 1}]
+
+
+def set_urlopen_mock(mock, jwks):
+    ret = MagicMock()
+    ret.getcode.return_value = 200
+    ret.read.return_value = json.dumps(jwks)
+    ret.__enter__.return_value = ret
+    mock.return_value = ret
+
+
+@patch("urllib.urlopen")
+def test_token_exchange(urlopen, client, private_key, payload, settings):
+    set_urlopen_mock(urlopen, jwks(private_key))
+    with settings(
+        JWT_EXCHANGE_PROVIDERS={
+            "example": {"url": "https://example.org/keys", "client_id": "CLIENT_KEY"}
+        }
+    ):
+        resp = client.post(
+            "/auth/token-exchange",
+            data={"jwt": sign_payload(payload, private_key), "provider": "example"},
+        )
+    contents = json(resp.contents)
+    jwt_service = JWTService()
+    atoken = jwt_service.decode(contents["atoken"])
+    rtoken = jwt_service.decode(contents["rtoken"])
+    assert atoken["email"] == rtoken["email"] == "test@example.org"
+    assert User.objects.filter(email="test@example.org").exists()


### PR DESCRIPTION
## Description

### Web OAuth

Currently Terraso follows the typical OAuth process. It works basically as follows:
    - User signs in with OAuth Provider on their website
    - User redirected to our redirect URI (something like `/oauth/<provider>/callback` with an authorization grant
    - Authorization grant exchanged for tokens from OAuth Provider
    - At the end of the process, user logged into Terraso by assigning the cookies `rtoken` and `atoken`. An account is created if not existing for the email address.

### Problems with mobile

The problem with using this workflow on mobile is the redirect URI. Because the mobile device is working as the user agent, and not the browser, we can't use https URIs as the redirect URI, but instead have to provide a custom schema. Our app registers on the device to handle this schema through hard linking. For example, it may be that we will handle `org.terraso:/googleoauth`. But because it is the mobile device that is acting as the user agent pushing the OAuth process along, we have no way of executing code on the Terraso server at the end of the OAuth process. 

Why can't we use the browser as the user agent, like we do on web? There are still browsers on mobile, obviously. The problem is that there is no way for an app to claim cookies set in the browser as belonging to the app. So even if we complete the OAuth process in a mobile browser, we have no way of gathering the necessary tokens at the end of the process. People used to get around this by creating a WebView in the app itself and grabbing the tokens from there, but this sidesteps one of the main advantages of OAuth, the user not needing to identify themself with the provider credentials to the client app itself. In other words, the client app could just as easily grab the password the user is entering to the OAuth provider app... Most OAuth providers will not continue the process if they detect the user is not using a proper browser.

In summary, how OAuth works on mobile:
- Mobile app launches a separate web browser where the user authenticated with the OAuth provider. This is closed when the authentication with the OAuth provider is complete.
- Authorization grant forwarded to custom uri schema to be handled by mobile app itself.
- Mobile app exchanges authorization grant for tokens.

### Solution

The simple solution is to exchange the id_token obtained at the end of the OAuth signup with a Terraso access token.

What is an id token? This is something defined as part of OpenID Connect, which most OAuth providers implement nowadays. There is an [ID token spec](https://openid.net/specs/openid-connect-core-1_0.html#IDToken) which outlines the various properties included within. For our uses, there are two important facts:
- It contains info on the user email, name, profile image, as well some other things we might request
- We can use the public keys published by the provider to verify the provenance of the ID token. The OAuth provider signs the JWT with their private key, and we can use the public key to ensure the contents have not been modified.

I got the basics for this approach from a [Google guide on authenticating with backend servers](https://developers.google.com/identity/sign-in/android/backend-auth). It is pretty straightforward to implement, as can be seen in the PR code itself.

