### PR TITLE
fix: make media in chapters nullable and remove multiple file check

### DIFF
--- a/terraso_backend/apps/story_map/views.py
+++ b/terraso_backend/apps/story_map/views.py
@@ -225,7 +225,6 @@ def handle_integrity_error(exc):
             NON_FIELD_ERRORS: ValidationError(
                 message="This StoryMap title already exists",
                 code="unique",
-                message="This StoryMap title already exists", code="unique",
             )
         },
     )
@@ -238,7 +237,7 @@ def from_validation_error(validation_error):
     for field, validation_errors in validation_error.error_dict.items():
         for error in validation_errors:
             error_messages.append(
-                ErrorMessage(                    
+                ErrorMessage(
                     code=error.code,
                     context=ErrorContext(model="StoryMap", field=field),
                 )

--- a/terraso_backend/apps/story_map/views.py
+++ b/terraso_backend/apps/story_map/views.py
@@ -171,7 +171,9 @@ def handle_config_media(new_config, current_config, request):
                 )
                 if matching_file:
                     url = story_map_media_upload_service.upload_file_get_path(
-                        str(request.user.id), matching_file, file_name=uuid.uuid4(),
+                        str(request.user.id),
+                        matching_file,
+                        file_name=uuid.uuid4(),
                     )
                     chapter["media"] = {"url": url, "type": media["type"]}
 
@@ -221,6 +223,8 @@ def handle_integrity_error(exc):
     validation_error = ValidationError(
         message={
             NON_FIELD_ERRORS: ValidationError(
+                message="This StoryMap title already exists",
+                code="unique",
                 message="This StoryMap title already exists", code="unique",
             )
         },
@@ -234,9 +238,11 @@ def from_validation_error(validation_error):
     for field, validation_errors in validation_error.error_dict.items():
         for error in validation_errors:
             error_messages.append(
-                ErrorMessage(code=error.code, context=ErrorContext(model="StoryMap", field=field),)
+                ErrorMessage(                    
+                    code=error.code,
+                    context=ErrorContext(model="StoryMap", field=field),
+                )
             )
-
     return error_messages
 
 
@@ -248,7 +254,11 @@ def get_error_messages(validation_errors):
             error_messages.append(
                 ErrorMessage(
                     code=error.code,
-                    context=ErrorContext(model="StoryMap", field=field, extra=error.message,),
+                    context=ErrorContext(
+                        model="StoryMap",
+                        field=field,
+                        extra=error.message,
+                    ),
                 )
             )
 

--- a/terraso_backend/apps/story_map/views.py
+++ b/terraso_backend/apps/story_map/views.py
@@ -207,9 +207,7 @@ def invalid_media_type(config):
     if "chapters" in config:
         for chapter in config["chapters"]:
             media = chapter.get("media")
-            if media and not (
-                media["type"].startswith(("image", "audio", "video", "embedded"))
-            ):
+            if media and not (media["type"].startswith(("image", "audio", "video", "embedded"))):
                 return True
         return False
 

--- a/terraso_backend/apps/story_map/views.py
+++ b/terraso_backend/apps/story_map/views.py
@@ -59,12 +59,6 @@ class StoryMapAddView(AuthenticationRequiredMixin, FormView):
             return JsonResponse(
                 {"errors": [{"message": [asdict(e) for e in error_messages]}]}, status=400
             )
-        if has_multiple_files(request.FILES.getlist("files")):
-            error_message = ErrorMessage(
-                code="More than one file uploaded",
-                context=ErrorContext(model="StoryMap", field="files"),
-            )
-            return JsonResponse({"errors": [{"message": [asdict(error_message)]}]}, status=400)
 
         if is_file_upload_oversized(request.FILES.getlist("files"), MEDIA_UPLOAD_MAX_FILE_SIZE):
             error_message = ErrorMessage(
@@ -129,12 +123,7 @@ class StoryMapUpdateView(AuthenticationRequiredMixin, FormView):
                 context=ErrorContext(model="StoryMap", field="configuration"),
             )
             return JsonResponse({"errors": [{"message": [asdict(error_message)]}]}, status=400)
-        if has_multiple_files(request.FILES.getlist("files")):
-            error_message = ErrorMessage(
-                code="Uploaded more than one file",
-                context=ErrorContext(model="StoryMap", field="files"),
-            )
-            return JsonResponse({"errors": [{"message": [asdict(error_message)]}]}, status=400)
+
         if is_file_upload_oversized(request.FILES.getlist("files"), MEDIA_UPLOAD_MAX_FILE_SIZE):
             error_message = ErrorMessage(
                 code="File size exceeds 10 MB",

--- a/terraso_backend/apps/story_map/views.py
+++ b/terraso_backend/apps/story_map/views.py
@@ -208,8 +208,7 @@ def invalid_media_type(config):
         for chapter in config["chapters"]:
             media = chapter.get("media")
             if media and not (
-                media["type"].startswith(("image", "audio", "video"))
-                or media["source"].startswith(("youtube", "vimeo"))
+                media["type"].startswith(("image", "audio", "video", "embedded"))
             ):
                 return True
         return False

--- a/terraso_backend/apps/story_map/views.py
+++ b/terraso_backend/apps/story_map/views.py
@@ -171,9 +171,7 @@ def handle_config_media(new_config, current_config, request):
                 )
                 if matching_file:
                     url = story_map_media_upload_service.upload_file_get_path(
-                        str(request.user.id),
-                        matching_file,
-                        file_name=uuid.uuid4(),
+                        str(request.user.id), matching_file, file_name=uuid.uuid4(),
                     )
                     chapter["media"] = {"url": url, "type": media["type"]}
 
@@ -209,7 +207,10 @@ def invalid_media_type(config):
     if "chapters" in config:
         for chapter in config["chapters"]:
             media = chapter.get("media")
-            if media and not (media["type"].startswith(("image", "audio", "video"))):
+            if media and not (
+                media["type"].startswith(("image", "audio", "video"))
+                or media["source"].startswith(("youtube", "vimeo"))
+            ):
                 return True
         return False
 
@@ -223,8 +224,7 @@ def handle_integrity_error(exc):
     validation_error = ValidationError(
         message={
             NON_FIELD_ERRORS: ValidationError(
-                message="This StoryMap title already exists",
-                code="unique",
+                message="This StoryMap title already exists", code="unique",
             )
         },
     )
@@ -237,10 +237,7 @@ def from_validation_error(validation_error):
     for field, validation_errors in validation_error.error_dict.items():
         for error in validation_errors:
             error_messages.append(
-                ErrorMessage(
-                    code=error.code,
-                    context=ErrorContext(model="StoryMap", field=field),
-                )
+                ErrorMessage(code=error.code, context=ErrorContext(model="StoryMap", field=field),)
             )
 
     return error_messages
@@ -254,11 +251,7 @@ def get_error_messages(validation_errors):
             error_messages.append(
                 ErrorMessage(
                     code=error.code,
-                    context=ErrorContext(
-                        model="StoryMap",
-                        field=field,
-                        extra=error.message,
-                    ),
+                    context=ErrorContext(model="StoryMap", field=field, extra=error.message,),
                 )
             )
 

--- a/terraso_backend/apps/story_map/views.py
+++ b/terraso_backend/apps/story_map/views.py
@@ -209,9 +209,9 @@ def invalid_media_type(config):
     if "chapters" in config:
         for chapter in config["chapters"]:
             media = chapter.get("media")
-            if not (media and media["type"].startswith(("image", "audio", "video"))):
+            if media and not (media["type"].startswith(("image", "audio", "video"))):
                 return True
-            return False
+        return False
 
 
 def handle_integrity_error(exc):

--- a/terraso_backend/apps/story_map/views.py
+++ b/terraso_backend/apps/story_map/views.py
@@ -30,7 +30,7 @@ from django.views.generic.edit import FormView
 
 from apps.auth.mixins import AuthenticationRequiredMixin
 from apps.core.exceptions import ErrorContext, ErrorMessage
-from apps.storage.file_utils import has_multiple_files, is_file_upload_oversized
+from apps.storage.file_utils import is_file_upload_oversized
 
 from .forms import StoryMapForm
 from .models import StoryMap

--- a/terraso_backend/tests/story_map/test_views.py
+++ b/terraso_backend/tests/story_map/test_views.py
@@ -219,3 +219,59 @@ def test_update_upload_media_invalid(logged_client, users):
     assert response.status_code == 400
     assert response_data["errors"][0]["message"][0]["code"] == "Invalid Media Type"
     assert "errors" in response_data
+
+
+def test_update_upload_multiple_media_invalid(logged_client, users):
+    story_map = mixer.blend("story_map.StoryMap", created_by=users[0])
+    url = reverse("story_map:update")
+    data = {
+        "id": story_map.pk,
+        "title": "Test StoryMap Invalid Media",
+        "is_published": "false",
+        "files": [SimpleUploadedFile(
+            name="audio_file.mp4",
+            content="content".encode(),
+            content_type="video/mp4",
+        ), SimpleUploadedFile(
+            name="audio_file.MOV",
+            content="content".encode(),
+            content_type="movie/MOV",
+        )],
+        "configuration": json.dumps(
+            {
+                "title": "Test StoryMap Updated",
+                "chapters": [
+                    {
+                        "id": "chapter-1",
+                        "title": "Chapter 1",
+                        "description": "Chapter 1 description",
+                        "media": {
+                            "contentId": "audio_file.mp4",
+                            "type": "video/mp4",
+                        },
+                    },
+                    {
+                        "id": "chapter-2",
+                        "title": "Chapter 2",
+                        "description": "Chapter 2 description",
+                        "media": {
+                            "contentId": "audio_file.MOV",
+                            "type": "movie/MOV",
+                        },
+                    },
+                ],
+            }
+        ),
+    }
+    with patch(
+        "apps.story_map.views.story_map_media_upload_service.upload_file_get_path"
+    ) as mocked_upload_service:
+        mocked_upload_service.return_value = "https://example.org/uploaded_file.mp3"
+        response = logged_client.post(url, data=data)
+        mocked_upload_service.assert_not_called()
+
+    response_data = response.json()
+
+    assert response.status_code == 400
+    assert response_data["errors"][0]["message"][0]["code"] == "Invalid Media Type"
+    assert "errors" in response_data

--- a/terraso_backend/tests/story_map/test_views.py
+++ b/terraso_backend/tests/story_map/test_views.py
@@ -228,15 +228,18 @@ def test_update_upload_multiple_media_invalid(logged_client, users):
         "id": story_map.pk,
         "title": "Test StoryMap Invalid Media",
         "is_published": "false",
-        "files": [SimpleUploadedFile(
-            name="audio_file.mp4",
-            content="content".encode(),
-            content_type="video/mp4",
-        ), SimpleUploadedFile(
-            name="audio_file.MOV",
-            content="content".encode(),
-            content_type="movie/MOV",
-        )],
+        "files": [
+            SimpleUploadedFile(
+                name="audio_file.mp4",
+                content="content".encode(),
+                content_type="video/mp4",
+            ),
+            SimpleUploadedFile(
+                name="audio_file.MOV",
+                content="content".encode(),
+                content_type="movie/MOV",
+            ),
+        ],
         "configuration": json.dumps(
             {
                 "title": "Test StoryMap Updated",


### PR DESCRIPTION
## Description
make media in story map chapters nullable, remove multiple file validation since more than one file can be uploaded per storymap, add more extensive unit tests

