### PR TITLE
feat: remove graphene code that was merged upstream

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -407,6 +407,12 @@ et-xmlfile==1.1.0 \
     --hash=sha256:8eb9e2bc2f8c97e37a2dc85a09ecdcdec9d8a396530a6d5a33b30b9a92da0c5c \
     --hash=sha256:a2ba85d1d6a74ef63837eed693bcb89c3f752169b0e3e7ae5b16ca5e1b3deada
     # via openpyxl
+exceptiongroup==1.1.2 \
+    --hash=sha256:12c3e887d6485d16943a309616de20ae5582633e0a2eda17f4e10fd61c1e8af5 \
+    --hash=sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f
+    # via
+    #   anyio
+    #   cattrs
 fiona==1.9.4.post1 \
     --hash=sha256:1a585002a6385cc8ab0f66ddf3caf18711f531901906abd011a67a0cc89ab7b0 \
     --hash=sha256:1da8b954f6f222c3c782bc285586ea8dd9d7e55e1bc7861da9cd772bca671660 \
@@ -433,9 +439,9 @@ geopandas==0.13.2 \
     --hash=sha256:101cfd0de54bcf9e287a55b5ea17ebe0db53a5e25a28bacf100143d0507cabd9 \
     --hash=sha256:e5b56d9c20800c77bcc0c914db3f27447a37b23b2cd892be543f5001a694a968
     # via -r requirements/base.in
-graphene==3.2.2 \
-    --hash=sha256:5b03e72770dc901f40be55784058d6bb1d952a49eb819a4a085962d5e1cf5fcf \
-    --hash=sha256:753de13948cbf42e32cc87fb533167c88907066eb984251fdbb006c0aab8da00
+graphene==3.3 \
+    --hash=sha256:529bf40c2a698954217d3713c6041d69d3f719ad0080857d7ee31327112446b0 \
+    --hash=sha256:bb3810be33b54cb3e6969506671eb72319e8d7ba0d5ca9c8066472f75bf35a38
     # via graphene-django
 graphene-django==3.1.3 \
     --hash=sha256:2611462ca96beead7b2e5e4f45a6633cfb760f9d2dab9cbb7709e6376c47304d \
@@ -743,6 +749,8 @@ typing-extensions==4.7.1 \
     --hash=sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36 \
     --hash=sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2
     # via
+    #   asgiref
+    #   cattrs
     #   ddtrace
     #   dj-database-url
 tzdata==2023.3 \


### PR DESCRIPTION
## Description
We were manually reproducing a bunch of logic from our dependency graphene in `TerrasoConnection` in order to make the GraphQL schema types more accurate, but they have now merged our upstream PR that adds an option to do this change using their code. This PR updates the dependency and removes the reproduced logic.

context: https://github.com/graphql-python/graphene/pull/1504
