### PR TITLE
fix: check if default group is not None before deleting

### DIFF
--- a/terraso_backend/apps/core/models/landscapes.py
+++ b/terraso_backend/apps/core/models/landscapes.py
@@ -126,7 +126,8 @@ class Landscape(SlugModel, DirtyFieldsMixin):
         with transaction.atomic():
             ret = super().delete(*args, **kwargs)
             # default group should be deleted as well
-            default_group.delete()
+            if default_group is not None:
+                default_group.delete()
 
         return ret
 


### PR DESCRIPTION
## Description
Check if landscape's default group is not None before attempting to delete it.

### Related Issues
Fixes #721.