### PR TITLE
fix: remove deprecated --rc argument for isort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ createsuperuser: check_rebuild
 	$(DC_RUN_CMD) python terraso_backend/manage.py createsuperuser
 
 format: ${VIRTUAL_ENV}/scripts/black ${VIRTUAL_ENV}/scripts/isort
-	isort -rc --atomic terraso_backend
+	isort --atomic terraso_backend
 	black terraso_backend
 
 install:


### PR DESCRIPTION
## Description
Remove deprecated `—rc` argument passed to `isort`.

>https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0.html
>
>--recursive or -rc
>Prior to version 5.0.0, isort wouldn't automatically traverse directories. The --recursive option was necessary to tell it to do so. In 5.0.0 directories are automatically traversed for all Python files, and as such this option is no longer necessary and should simply be removed.
