### PR TITLE
fix: Save unique project group names

### DIFF
--- a/terraso_backend/apps/graphql/schema/projects.py
+++ b/terraso_backend/apps/graphql/schema/projects.py
@@ -71,8 +71,6 @@ class ProjectAddMutation(BaseWriteMutation):
         logger = cls.get_logger()
         user = info.context.user
         with transaction.atomic():
-            group = Project.create_default_group(name=kwargs["name"])
-            kwargs["group"] = group
             kwargs["privacy"] = kwargs["privacy"].value
             result = super().mutate_and_get_payload(root, info, **kwargs)
             result.project.add_manager(user)

--- a/terraso_backend/apps/project_management/models/projects.py
+++ b/terraso_backend/apps/project_management/models/projects.py
@@ -12,7 +12,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see https://www.gnu.org/licenses/.
-from datetime import datetime
+import secrets
 
 from django.db import models
 from django.utils.translation import gettext_lazy as _
@@ -78,7 +78,7 @@ class Project(BaseModel):
     @staticmethod
     def create_default_group(name: str):
         """Creates a default group for a project"""
-        group_name = f"project_group_{name}_{datetime.now().timestamp()}"
+        group_name = f"project_group_{name}_{secrets.token_hex(6)}"
         return Group.objects.create(
             name=group_name,
             membership_type=Group.MEMBERSHIP_TYPE_OPEN,

--- a/terraso_backend/apps/project_management/models/projects.py
+++ b/terraso_backend/apps/project_management/models/projects.py
@@ -12,6 +12,8 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see https://www.gnu.org/licenses/.
+from datetime import datetime
+
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
@@ -66,7 +68,7 @@ class Project(BaseModel):
         if not hasattr(self, "settings"):
             self.settings = self.default_settings()
         if not hasattr(self, "group"):
-            self.group = self.create_default_group(f"project_group_{self.name}")
+            self.group = self.create_default_group(self.name)
         return super(Project, self).save(*args, **kwargs)
 
     archived = models.BooleanField(
@@ -76,8 +78,9 @@ class Project(BaseModel):
     @staticmethod
     def create_default_group(name: str):
         """Creates a default group for a project"""
+        group_name = f"project_group_{name}_{datetime.now().timestamp()}"
         return Group.objects.create(
-            name=name,
+            name=group_name,
             membership_type=Group.MEMBERSHIP_TYPE_OPEN,
             enroll_method=Group.ENROLL_METHOD_INVITE,
         )


### PR DESCRIPTION
Added a timestamp to a project group name. This makes it so that there is practically no chance of project creation failing because the associated group has the same name as the project.

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
