### PR TITLE
feat: Ignore duplicate adding user to project

### DIFF
--- a/terraso_backend/apps/project_management/graphql/projects.py
+++ b/terraso_backend/apps/project_management/graphql/projects.py
@@ -315,6 +315,10 @@ class ProjectAddUserMutation(BaseWriteMutation):
             ):
                 raise ValidationError("User cannot add membership to this project")
 
+        if membership := project.get_membership(user):
+            # if user is already a member, don't do anything
+            return ProjectAddUserMutation(project=project, membership=membership)
+
         # add membership
         try:
             _, membership = project.membership_list.save_membership(

--- a/terraso_backend/tests/graphql/mutations/test_projects.py
+++ b/terraso_backend/tests/graphql/mutations/test_projects.py
@@ -201,6 +201,7 @@ mutation addUser($input: ProjectAddUserMutationInput!) {
       id
     }
     membership {
+      id
       user {
         id
       }
@@ -265,6 +266,22 @@ def test_add_user_to_project_bad_roles(project, project_manager, client):
     response = graphql_query(ADD_USER_GRAPHQL, input_data=input_data, client=client)
     payload = response.json()
     assert "errors" in payload
+
+
+def test_add_user_project_user_already_member(project, project_manager, project_user, client):
+    client.force_login(project_manager)
+    membership = project.get_membership(project_user)
+    input_data = {
+        "projectId": str(project.id),
+        "userId": str(project_user.id),
+        "role": membership.user_role,
+    }
+    response = graphql_query(ADD_USER_GRAPHQL, client=client, input_data=input_data)
+    payload = response.json()
+    assert "errors" not in payload
+    data = payload["data"]["addUserToProject"]
+    assert data["project"]["id"] == str(project.id)
+    assert data["membership"]["id"] == str(membership.id)
 
 
 DELETE_USER_GRAPHQL = """


### PR DESCRIPTION
For adding a user to a project, the plan is to use the project info in the redux store in the app to determine if a user belongs to a project. This would create a corner case where a user might be added to the same project twice. (Actually, I think that would exist regardless). This commit just treats that case a succesful operation and does nothing, which seems like the simplest solution to me. In the future we might want to return different error statuses if the user was already added.

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues

Related somewhat to https://github.com/techmatters/terraso-mobile-client/issues/37

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
