### PR TITLE
fix: Added permissions validation context to api error

### DIFF
--- a/terraso_backend/apps/graphql/schema/story_maps.py
+++ b/terraso_backend/apps/graphql/schema/story_maps.py
@@ -351,7 +351,9 @@ class StoryMapMembershipApproveTokenMutation(BaseUnauthenticatedMutation):
                 extra=kwargs,
             )
             raise GraphQLNotAllowedException(
-                model_name=Membership.__name__, operation=MutationTypes.UPDATE
+                model_name=Membership.__name__,
+                operation=MutationTypes.UPDATE,
+                message="permissions_validation",
             )
 
         try:

--- a/terraso_backend/apps/graphql/schema/story_maps.py
+++ b/terraso_backend/apps/graphql/schema/story_maps.py
@@ -37,12 +37,7 @@ from apps.story_map.models.story_maps import StoryMap
 from apps.story_map.notifications import send_memberships_invite_email
 from apps.story_map.services import story_map_media_upload_service
 
-from .commons import (
-    BaseAuthenticatedMutation,
-    BaseDeleteMutation,
-    BaseUnauthenticatedMutation,
-    TerrasoConnection,
-)
+from .commons import BaseAuthenticatedMutation, BaseDeleteMutation, TerrasoConnection
 from .constants import MutationTypes
 
 logger = structlog.get_logger(__name__)
@@ -290,7 +285,7 @@ class StoryMapMembershipSaveMutation(BaseAuthenticatedMutation):
         return cls(memberships=[membership["membership"] for membership in memberships])
 
 
-class StoryMapMembershipApproveTokenMutation(BaseUnauthenticatedMutation):
+class StoryMapMembershipApproveTokenMutation(BaseAuthenticatedMutation):
     model_class = Membership
     membership = graphene.Field(CollaborationMembershipNode)
     story_map = graphene.Field(StoryMapNode)

--- a/terraso_backend/apps/graphql/schema/story_maps.py
+++ b/terraso_backend/apps/graphql/schema/story_maps.py
@@ -13,6 +13,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see https://www.gnu.org/licenses/.
 
+from datetime import datetime
+
 import django_filters
 import graphene
 import rules
@@ -345,10 +347,19 @@ class StoryMapMembershipApproveTokenMutation(BaseAuthenticatedMutation):
                 "Attempt to approve a Membership, but user has no permission",
                 extra=kwargs,
             )
-            raise GraphQLNotAllowedException(
+            error = GraphQLNotAllowedException(
                 model_name=Membership.__name__,
                 operation=MutationTypes.UPDATE,
                 message="permissions_validation",
+            )
+            return cls(
+                errors=[{"message": str(error)}],
+                story_map=StoryMap(
+                    id="",
+                    title=story_map.title,
+                    created_at=datetime.now(),
+                    updated_at=datetime.now(),
+                ),
             )
 
         try:

--- a/terraso_backend/apps/story_map/permission_rules.py
+++ b/terraso_backend/apps/story_map/permission_rules.py
@@ -76,21 +76,11 @@ def allowed_to_approve_story_map_membership(user, obj):
     return is_user_membership
 
 
-# This rule is used to check if the user is allowed to approve a membership
-# with a token. This is used when the user is not logged in or when the user
-# is logged in but the membership is associated with the user.
 @rules.predicate
 def allowed_to_approve_story_map_membership_with_token(user, obj):
     membership = obj.get("membership")
     request_user = user
-
-    if membership.pending_email is not None:
-        return request_user.is_anonymous
-
-    if request_user.is_anonymous or request_user.id == membership.user.id:
-        return True
-
-    return False
+    return request_user.id == membership.user.id
 
 
 @rules.predicate

--- a/terraso_backend/apps/story_map/permission_rules.py
+++ b/terraso_backend/apps/story_map/permission_rules.py
@@ -79,8 +79,9 @@ def allowed_to_approve_story_map_membership(user, obj):
 @rules.predicate
 def allowed_to_approve_story_map_membership_with_token(user, obj):
     membership = obj.get("membership")
-    request_user = user
-    return request_user.id == membership.user.id
+    if not membership.user:
+        return False
+    return user.id == membership.user.id
 
 
 @rules.predicate

--- a/terraso_backend/tests/graphql/mutations/test_story_map_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_story_map_mutations.py
@@ -459,7 +459,7 @@ def test_story_map_approve_membership_with_token_for_unregistered_user(
 
 
 def test_story_map_approve_membership_with_token_for_registered_user_fails_due_user_mismatch(
-    client_query, story_map_user_memberships_approve_tokens
+    client_query, story_map_user_memberships_approve_tokens, story_maps
 ):
     token = story_map_user_memberships_approve_tokens[1]
 
@@ -469,6 +469,12 @@ def test_story_map_approve_membership_with_token_for_registered_user_fails_due_u
           $input: StoryMapMembershipApproveTokenMutationInput!
         ){
           approveStoryMapMembershipToken(input: $input) {
+            storyMap {
+              title
+              id
+              createdAt
+              updatedAt
+            }
             membership {
               id
               membershipStatus
@@ -485,7 +491,14 @@ def test_story_map_approve_membership_with_token_for_registered_user_fails_due_u
     )
     json_response = response.json()
 
+    print(json_response)
+
     assert "errors" in json_response["data"]["approveStoryMapMembershipToken"]
     error_result = json_response["data"]["approveStoryMapMembershipToken"]["errors"][0]["message"]
     json_error = json.loads(error_result)
     assert json_error[0]["code"] == "update_not_allowed"
+    assert (
+        json_response["data"]["approveStoryMapMembershipToken"]["storyMap"]["title"]
+        == story_maps[0].title
+    )
+    assert json_response["data"]["approveStoryMapMembershipToken"]["storyMap"]["id"] == ""

--- a/terraso_backend/tests/graphql/mutations/test_story_map_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_story_map_mutations.py
@@ -491,8 +491,6 @@ def test_story_map_approve_membership_with_token_for_registered_user_fails_due_u
     )
     json_response = response.json()
 
-    print(json_response)
-
     assert "errors" in json_response["data"]["approveStoryMapMembershipToken"]
     error_result = json_response["data"]["approveStoryMapMembershipToken"]["errors"][0]["message"]
     json_error = json.loads(error_result)

--- a/terraso_backend/tests/graphql/mutations/test_story_map_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_story_map_mutations.py
@@ -427,10 +427,8 @@ def test_story_map_approve_membership_with_token_for_registered_user(
 def test_story_map_approve_membership_with_token_for_unregistered_user(
     client_query_no_token,
     story_map_user_memberships_not_registered_approve_tokens,
-    story_map_user_memberships_not_registered,
 ):
     token = story_map_user_memberships_not_registered_approve_tokens[0]
-    membership = story_map_user_memberships_not_registered[0]
 
     response = client_query_no_token(
         """
@@ -454,12 +452,10 @@ def test_story_map_approve_membership_with_token_for_unregistered_user(
     )
     json_response = response.json()
 
-    assert json_response["data"]["approveStoryMapMembershipToken"]["errors"] is None
-
-    response_membership = json_response["data"]["approveStoryMapMembershipToken"]["membership"]
-
-    assert response_membership["id"] == str(membership.id)
-    assert response_membership["membershipStatus"] == "APPROVED"
+    assert "errors" in json_response["data"]["approveStoryMapMembershipToken"]
+    error_result = json_response["data"]["approveStoryMapMembershipToken"]["errors"][0]["message"]
+    json_error = json.loads(error_result)
+    assert json_error[0]["code"] == "unauthorized"
 
 
 def test_story_map_approve_membership_with_token_for_registered_user_fails_due_user_mismatch(


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Added permissions validation context for story map approve membership mutation
- Make story map invitation approve mutation require authentication

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added


### Related Issues
Fixes https://github.com/techmatters/terraso-web-client/issues/1196