### PR TITLE
fix: Use ProjectMembershipNodes in Project mutation return types

### DIFF
--- a/terraso_backend/apps/collaboration/models/memberships.py
+++ b/terraso_backend/apps/collaboration/models/memberships.py
@@ -54,7 +54,10 @@ class MembershipList(BaseModel):
         default=DEFAULT_MEMERBSHIP_TYPE,
     )
 
-    def save_membership(self, user_email, user_role, membership_status, validation_func):
+    def save_membership(
+        self, user_email, user_role, membership_status, validation_func, membership_class=None
+    ):
+        membership_class = membership_class or Membership
         user = User.objects.filter(email=user_email).first()
         user_exists = user is not None
 
@@ -73,7 +76,7 @@ class MembershipList(BaseModel):
             raise ValidationError("User cannot request membership")
 
         if is_new:
-            membership = Membership(
+            membership = membership_class(
                 membership_list=self,
                 user=user if user_exists else None,
                 pending_email=user_email if not user_exists else None,

--- a/terraso_backend/apps/graphql/schema/schema.graphql
+++ b/terraso_backend/apps/graphql/schema/schema.graphql
@@ -1861,7 +1861,7 @@ input ProjectDeleteMutationInput {
 type ProjectAddUserMutationPayload {
   errors: GenericScalar
   project: ProjectNode!
-  membership: CollaborationMembershipNode!
+  membership: ProjectMembershipNode!
   clientMutationId: String
 }
 
@@ -1875,7 +1875,7 @@ input ProjectAddUserMutationInput {
 type ProjectDeleteUserMutationPayload {
   errors: GenericScalar
   project: ProjectNode!
-  membership: CollaborationMembershipNode!
+  membership: ProjectMembershipNode!
   clientMutationId: String
 }
 
@@ -1888,7 +1888,7 @@ input ProjectDeleteUserMutationInput {
 type ProjectUpdateUserRoleMutationPayload {
   errors: GenericScalar
   project: ProjectNode!
-  membership: CollaborationMembershipNode!
+  membership: ProjectMembershipNode!
   clientMutationId: String
 }
 

--- a/terraso_backend/apps/project_management/models/projects.py
+++ b/terraso_backend/apps/project_management/models/projects.py
@@ -146,7 +146,9 @@ class Project(BaseModel):
         )
 
     def get_membership(self, user: User):
-        return self.membership_list.memberships.filter(user=user).first()
+        return ProjectMembership.objects.filter(
+            membership_list=self.membership_list, user=user
+        ).first()
 
     def mark_seen_by(self, user: User):
         self.seen_by.add(user)


### PR DESCRIPTION
This matches what the frontend expects, especially wrt to roles etc. I had to redefine the utility method `get_member` to explicity use the ProjectMembership object manager. There might be a more elegant way of doing this with extending object managers, but I think that this will do the trick for now.

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Part of https://github.com/techmatters/terraso-mobile-client/issues/37

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
