### PR TITLE
fix: Limit project query to member of project

### DIFF
--- a/terraso_backend/apps/project_management/graphql/projects.py
+++ b/terraso_backend/apps/project_management/graphql/projects.py
@@ -143,6 +143,12 @@ class ProjectNode(DjangoObjectType):
             return True
         return self.seen_by.filter(id=user.id).exists()
 
+    @classmethod
+    def get_queryset(cls, queryset, info):
+        # limit queries to membership lists of projects to which the user belongs
+        user_pk = getattr(info.context.user, "pk", None)
+        return queryset.filter(membership_list__memberships__user_id=user_pk)
+
 
 class ProjectPrivacy(graphene.Enum):
     PRIVATE = Project.PRIVATE

--- a/terraso_backend/tests/graphql/test_sites_query.py
+++ b/terraso_backend/tests/graphql/test_sites_query.py
@@ -23,13 +23,13 @@ from apps.project_management.models.projects import Project
 pytestmark = pytest.mark.django_db
 
 
-def test_query_site_fields(client, project, user):
+def test_query_site_fields(client, project, project_user):
     sites = [
         Site(
             name="site 1",
             latitude=1.0,
             longitude=-1.0,
-            owner=user,
+            owner=project_user,
             privacy="PRIVATE",
             archived=False,
         ),
@@ -59,7 +59,7 @@ def test_query_site_fields(client, project, user):
       }
     }
     """
-    client.force_login(user)
+    client.force_login(project_user)
 
     for site, response in [(site, graphql_query(query % site.id, client=client)) for site in sites]:
         assert "errors" not in response.json()


### PR DESCRIPTION
## Description

Only users who are a member of a project should be able to query the GraphQL backend to find the members of projects to which they belong.

### Checklist
- [x] New tests added

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
