### PR TITLE
fix: Allow contributors to create sites

### DIFF
--- a/terraso_backend/apps/graphql/schema/sites.py
+++ b/terraso_backend/apps/graphql/schema/sites.py
@@ -123,7 +123,7 @@ class SiteAddMutation(BaseWriteMutation):
         if adding_to_project:
             project = cls.get_or_throw(Project, "project_id", kwargs["project_id"])
             if not user.has_perm(Project.get_perm("add_site"), project):
-                raise cls.not_allowed(MutationTypes.ADD)
+                raise cls.not_allowed(MutationTypes.CREATE)
             kwargs["project"] = project
         else:
             kwargs["owner"] = info.context.user

--- a/terraso_backend/apps/project_management/models/projects.py
+++ b/terraso_backend/apps/project_management/models/projects.py
@@ -27,6 +27,8 @@ from apps.project_management.collaboration_roles import (
 
 
 class ProjectSettings(BaseModel):
+    """NOTE: Theses settings are currently ignored, and might be removed later"""
+
     class Meta(BaseModel.Meta):
         abstract = False
 

--- a/terraso_backend/apps/project_management/permission_rules.py
+++ b/terraso_backend/apps/project_management/permission_rules.py
@@ -24,9 +24,7 @@ def allowed_to_change_project(user, project):
 
 @rules.predicate
 def allowed_to_add_site_to_project(user, project):
-    return project.is_manager(user) or (
-        project.is_member(user) and project.settings.member_can_add_site_to_project
-    )
+    return project.is_manager(user) or project.is_contributor(user)
 
 
 @rules.predicate

--- a/terraso_backend/tests/conftest.py
+++ b/terraso_backend/tests/conftest.py
@@ -119,3 +119,10 @@ def project_user(project: Project) -> User:
         membership_status=Membership.APPROVED,
     )
     return user
+
+
+@pytest.fixture
+def project_user_w_role(request, project: Project):
+    user = mixer.blend(User)
+    project.add_user_with_role(user, request.param)
+    return user

--- a/terraso_backend/tests/graphql/mutations/test_sites.py
+++ b/terraso_backend/tests/graphql/mutations/test_sites.py
@@ -67,10 +67,11 @@ def test_site_creation(client_query, user):
     assert log_result.metadata == expected_metadata
 
 
-def test_site_creation_in_project(client, project_manager, project):
+@pytest.mark.parametrize("project_user_w_role", ["manager", "contributor"], indirect=True)
+def test_site_creation_in_project(client, project_user_w_role, project):
     kwargs = site_creation_keywords()
     kwargs["projectId"] = str(project.id)
-    client.force_login(project_manager)
+    client.force_login(project_user_w_role)
     response = graphql_query(CREATE_SITE_QUERY, variables={"input": kwargs}, client=client)
     content = json.loads(response.content)
     assert "errors" not in content and "errors" not in content["data"]


### PR DESCRIPTION
## Description

This change just allows contributors to create sites. I also updated the site creation test to test this.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
