### PR TITLE
fix: case-insensitive matching for story map invitation email addresses

### DIFF
--- a/terraso_backend/apps/collaboration/models/memberships.py
+++ b/terraso_backend/apps/collaboration/models/memberships.py
@@ -58,7 +58,7 @@ class MembershipList(BaseModel):
         self, user_email, user_role, membership_status, validation_func, membership_class=None
     ):
         membership_class = membership_class or Membership
-        user = User.objects.filter(email=user_email).first()
+        user = User.objects.filter(email__iexact=user_email).first()
         user_exists = user is not None
 
         membership = self.get_membership(user)


### PR DESCRIPTION
## Description
Additional case-insensitive matching for story map invitation email addresses.