### PR TITLE
fix: Allow removing site from project

### DIFF
--- a/terraso_backend/apps/graphql/schema/sites.py
+++ b/terraso_backend/apps/graphql/schema/sites.py
@@ -192,13 +192,17 @@ class SiteUpdateMutation(BaseWriteMutation):
             kwargs["privacy"] = kwargs["privacy"].value
 
         result = super().mutate_and_get_payload(root, info, **kwargs)
-        if not project_id:
+        if project_id is False:
+            # no project id included
             return result
         site = result.site
-        project = Project.objects.get(id=project_id)
-        if not user.has_perm(Project.get_perm("add_site"), project):
-            raise cls.not_allowed(MutationTypes.UPDATE)
-        site.add_to_project(project)
+        if project_id is not None:
+            project = Project.objects.get(id=project_id)
+            if not user.has_perm(Project.get_perm("add_site"), project):
+                raise cls.not_allowed(MutationTypes.UPDATE)
+            site.add_to_project(project)
+        else:
+            site.add_owner(user)
 
         client_time = kwargs.get("client_time", None)
         if not client_time:

--- a/terraso_backend/tests/conftest.py
+++ b/terraso_backend/tests/conftest.py
@@ -110,6 +110,11 @@ def project_with_sites(project: Project) -> Project:
 
 
 @pytest.fixture
+def project_site(project: Project) -> Site:
+    return mixer.blend(Site, project=project)
+
+
+@pytest.fixture
 def project_user(project: Project) -> User:
     user = mixer.blend(User)
     Membership.objects.create(

--- a/terraso_backend/tests/graphql/mutations/test_sites.py
+++ b/terraso_backend/tests/graphql/mutations/test_sites.py
@@ -171,6 +171,17 @@ def test_adding_site_owned_by_user_to_project(client, project, site, project_man
     assert site.owned_by(project)
 
 
+def test_removing_site_from_project(client, project, project_site, project_manager):
+    client.force_login(project_manager)
+    response = graphql_query(
+        UPDATE_SITE_QUERY, input_data={"id": str(project_site.id), "projectId": None}, client=client
+    ).json()
+    assert "errors" not in response
+    assert match_json("*..site.project", response) == [None]
+    project_site.refresh_from_db()
+    assert project_site.owner == project_manager
+
+
 DELETE_SITE_QUERY = """
     mutation SiteDeleteMutation($input: SiteDeleteMutationInput!) {
         deleteSite(input: $input) {

--- a/terraso_backend/tests/graphql/mutations/test_sites.py
+++ b/terraso_backend/tests/graphql/mutations/test_sites.py
@@ -182,6 +182,19 @@ def test_removing_site_from_project(client, project, project_site, project_manag
     assert project_site.owner == project_manager
 
 
+def test_not_providing_project_id_does_not_change_project(
+    client, project, project_site, project_manager
+):
+    client.force_login(project_manager)
+    response = graphql_query(
+        UPDATE_SITE_QUERY, input_data={"id": str(project_site.id)}, client=client
+    ).json()
+    assert "errors" not in response
+    assert match_json("*..site.project.id", response) == [str(project.id)]
+    project_site.refresh_from_db()
+    assert project_site.project.id == project.id
+
+
 DELETE_SITE_QUERY = """
     mutation SiteDeleteMutation($input: SiteDeleteMutationInput!) {
         deleteSite(input: $input) {


### PR DESCRIPTION
## Description

Previously this mutation allowed changing the Site to a different project, but not from *all* projects. This PR fixes that.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Necessary for https://github.com/techmatters/terraso-mobile-client/issues/431

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
