### PR TITLE
fix: Moved data entries group data migration to shared_data app

### DIFF
--- a/terraso_backend/apps/core/migrations/0046_shared_resource.py
+++ b/terraso_backend/apps/core/migrations/0046_shared_resource.py
@@ -26,36 +26,6 @@ from django.db import migrations, models
 import apps.core.models.commons
 
 
-def data_entries_to_shared_resources(apps, schema_editor):
-    ContentType = apps.get_model("contenttypes", "ContentType")
-    LandscapeGroup = apps.get_model("core", "LandscapeGroup")
-    SharedResource = apps.get_model("core", "SharedResource")
-    DataEntry = apps.get_model("shared_data", "DataEntry")
-    data_entries = DataEntry.objects.all()
-    for data_entry in data_entries:
-        groups = data_entry.groups.all()
-        for group in groups:
-            landscape_group = LandscapeGroup.objects.filter(
-                group=group, is_default_landscape_group=True
-            ).first()
-            if landscape_group is None:
-                SharedResource.objects.create(
-                    source_content_type=ContentType.objects.get_for_model(data_entry),
-                    source_object_id=data_entry.id,
-                    target_content_type=ContentType.objects.get_for_model(group),
-                    target_object_id=group.id,
-                )
-            else:
-                SharedResource.objects.create(
-                    source_content_type=ContentType.objects.get_for_model(data_entry),
-                    source_object_id=data_entry.id,
-                    target_content_type=ContentType.objects.get_for_model(
-                        landscape_group.landscape
-                    ),
-                    target_object_id=landscape_group.landscape.id,
-                )
-
-
 class Migration(migrations.Migration):
     dependencies = [
         ("contenttypes", "0002_remove_content_type_name"),
@@ -102,5 +72,4 @@ class Migration(migrations.Migration):
             },
             bases=(rules.contrib.models.RulesModelMixin, models.Model),
         ),
-        migrations.RunPython(data_entries_to_shared_resources),
     ]

--- a/terraso_backend/apps/shared_data/migrations/0015_dataentry_groups_move_data.py
+++ b/terraso_backend/apps/shared_data/migrations/0015_dataentry_groups_move_data.py
@@ -1,0 +1,59 @@
+# Copyright © 2023 Technology Matters
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see https://www.gnu.org/licenses/.
+
+from django.conf import settings
+from django.db import migrations
+
+
+def data_entries_to_shared_resources(apps, schema_editor):
+    ContentType = apps.get_model("contenttypes", "ContentType")
+    LandscapeGroup = apps.get_model("core", "LandscapeGroup")
+    SharedResource = apps.get_model("core", "SharedResource")
+    DataEntry = apps.get_model("shared_data", "DataEntry")
+    data_entries = DataEntry.objects.all()
+    for data_entry in data_entries:
+        groups = data_entry.groups.all()
+        for group in groups:
+            landscape_group = LandscapeGroup.objects.filter(
+                group=group, is_default_landscape_group=True
+            ).first()
+            if landscape_group is None:
+                SharedResource.objects.create(
+                    source_content_type=ContentType.objects.get_for_model(data_entry),
+                    source_object_id=data_entry.id,
+                    target_content_type=ContentType.objects.get_for_model(group),
+                    target_object_id=group.id,
+                )
+            else:
+                SharedResource.objects.create(
+                    source_content_type=ContentType.objects.get_for_model(data_entry),
+                    source_object_id=data_entry.id,
+                    target_content_type=ContentType.objects.get_for_model(
+                        landscape_group.landscape
+                    ),
+                    target_object_id=landscape_group.landscape.id,
+                )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("core", "0046_shared_resource"),
+        ("shared_data", "0014_visualizationconfig_owner_null"),
+    ]
+
+    operations = [
+        migrations.RunPython(data_entries_to_shared_resources),
+    ]

--- a/terraso_backend/apps/shared_data/migrations/0015_dataentry_groups_move_data.py
+++ b/terraso_backend/apps/shared_data/migrations/0015_dataentry_groups_move_data.py
@@ -18,6 +18,15 @@ from django.db import migrations
 
 
 def data_entries_to_shared_resources(apps, schema_editor):
+    connection = schema_editor.connection
+
+    # Check if the relation (table) exists in the database
+    cursor = connection.cursor()
+    cursor.execute("SELECT to_regclass('public.shared_data_dataentry_groups');")
+    relation = cursor.fetchone()
+    if not (relation and relation[0]):
+        return
+
     ContentType = apps.get_model("contenttypes", "ContentType")
     LandscapeGroup = apps.get_model("core", "LandscapeGroup")
     SharedResource = apps.get_model("core", "SharedResource")

--- a/terraso_backend/apps/shared_data/migrations/0016_remove_dataentry_groups_and_more.py
+++ b/terraso_backend/apps/shared_data/migrations/0016_remove_dataentry_groups_and_more.py
@@ -22,7 +22,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-        ("shared_data", "0014_visualizationconfig_owner_null"),
+        ("shared_data", "0015_dataentry_groups_move_data"),
     ]
 
     operations = [


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
There was an issue running the DB migrations for an empty DB because of apps dependencies, I moved the data migration for data entry groups to the correct app.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
