### PR TITLE
fix: add MS and Apple mobile login support

### DIFF
--- a/terraso_backend/apps/auth/services.py
+++ b/terraso_backend/apps/auth/services.py
@@ -335,8 +335,8 @@ class TokenExchangeService:
 
     @staticmethod
     def _verify_payload(token, signing_key, client_id):
-        if "alg" not in signing_key._jwk_data:
-            raise TokenExchangeException("alg header missing in mobile JWT token")
+        if "kty" not in signing_key._jwk_data:
+            raise TokenExchangeException("kty header missing in mobile JWT token")
         algorithms = [signing_key._jwk_data.get("alg", "RS256")]
         return jwt.decode(token, signing_key.key, algorithms=algorithms, audience=client_id)
 

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -393,13 +393,13 @@ JWT_EXCHANGE_PROVIDERS: dict[str, JWTProvider] = {
         url="https://www.googleapis.com/oauth2/v3/certs",
         client_id=config("GOOGLE_IOS_CLIENT_ID", default=""),
     ),
-    "apple-mobile": dict(
-        url="https://appleid.apple.com/auth/authorize",  # TODO
-        client_id=config("APPLE_MOBILE_CLIENT_ID", default=""),
+    "microsoft": dict(
+        url="https://login.microsoftonline.com/common/discovery/v2.0/keys",
+        client_id=config("MICROSOFT_CLIENT_ID", default=""),
     ),
-    "microsoft-mobile": dict(
-        url="https://login.microsoftonline.com/common/oauth2/v2.0/certs",  # TODO
-        client_id=config("MICROSOFT_MOBILE_CLIENT_ID", default=""),
+    "apple": dict(
+        url="https://appleid.apple.com/auth/keys",
+        client_id=config("APPLE_CLIENT_ID", default=""),
     ),
 }
 

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -393,6 +393,14 @@ JWT_EXCHANGE_PROVIDERS: dict[str, JWTProvider] = {
         url="https://www.googleapis.com/oauth2/v3/certs",
         client_id=config("GOOGLE_IOS_CLIENT_ID", default=""),
     ),
+    "apple-mobile": dict(
+        url="https://appleid.apple.com/auth/authorize",  # TODO
+        client_id=config("APPLE_MOBILE_CLIENT_ID", default=""),
+    ),
+    "microsoft-mobile": dict(
+        url="https://login.microsoftonline.com/common/oauth2/v2.0/certs",  # TODO
+        client_id=config("MICROSOFT_MOBILE_CLIENT_ID", default=""),
+    ),
 }
 
 


### PR DESCRIPTION
## Description
* Add MS and Apple mobile login support
* Fix token verification logic. Google sends alg, which is optional, and kty. MS only sends kty. kty is required — we should only enforce that.