### PR TITLE
fix: Set SiteNoteNode to be not null

### DIFF
--- a/terraso_backend/apps/graphql/schema/schema.graphql
+++ b/terraso_backend/apps/graphql/schema/schema.graphql
@@ -794,13 +794,14 @@ type SiteNoteNodeConnection {
   pageInfo: PageInfo!
 
   """Contains the nodes in this connection."""
-  edges: [SiteNoteNodeEdge]!
+  edges: [SiteNoteNodeEdge!]!
+  totalCount: Int!
 }
 
 """A Relay edge containing a `SiteNoteNode` and its cursor."""
 type SiteNoteNodeEdge {
   """The item at the end of the edge"""
-  node: SiteNoteNode
+  node: SiteNoteNode!
 
   """A cursor for use in pagination"""
   cursor: String!

--- a/terraso_backend/apps/project_management/graphql/site_notes.py
+++ b/terraso_backend/apps/project_management/graphql/site_notes.py
@@ -17,7 +17,11 @@ import graphene
 from django.db import transaction
 from graphene_django import DjangoObjectType
 
-from apps.graphql.schema.commons import BaseDeleteMutation, BaseWriteMutation
+from apps.graphql.schema.commons import (
+    BaseDeleteMutation,
+    BaseWriteMutation,
+    TerrasoConnection,
+)
 from apps.project_management.models.site_notes import SiteNote
 from apps.project_management.models.sites import Site
 
@@ -29,6 +33,8 @@ class SiteNoteNode(DjangoObjectType):
         model = SiteNote
         fields = "__all__"
         interfaces = (graphene.relay.Node,)
+
+        connection_class = TerrasoConnection
 
 
 class SiteNoteAddMutation(BaseWriteMutation):


### PR DESCRIPTION
## Description

Needs a Terraso Connection for django-graphene to pick up on the fact that there are no null objects in the connection.