### PR TITLE
fix: Allow updates with null privacy

### DIFF
--- a/terraso_backend/apps/project_management/graphql/projects.py
+++ b/terraso_backend/apps/project_management/graphql/projects.py
@@ -290,13 +290,15 @@ class ProjectUpdateMutation(BaseWriteMutation):
         cls.remove_null_fields(kwargs, ["privacy", "measurement_units"])
         if not user.has_perm(Project.get_perm("change"), project):
             cls.not_allowed()
-        kwargs["privacy"] = kwargs["privacy"].value
 
         metadata = {
             "name": kwargs["name"],
-            "privacy": kwargs["privacy"],
             "description": kwargs["description"] if "description" in kwargs else None,
         }
+
+        if privacy := kwargs.get("privacy"):
+            metadata["privacy"] = privacy.value
+
         logger.log(
             user=user,
             action=log_api.CHANGE,


### PR DESCRIPTION
## Description

The GraphQL type allows this, but we were trying to access the privacy regardless of whether it was null or not.

### Checklist
- [ ] Corresponding issue has been opened
- [x] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
