### PR TITLE
fix: Create project soil settings on project creation

### DIFF
--- a/terraso_backend/apps/graphql/schema/schema.graphql
+++ b/terraso_backend/apps/graphql/schema/schema.graphql
@@ -2109,6 +2109,7 @@ input ProjectAddMutationInput {
   description: String
   measurementUnits: MeasurementUnits!
   siteInstructions: String
+  createSoilSettings: Boolean
   clientMutationId: String
 }
 

--- a/terraso_backend/tests/graphql/mutations/test_projects.py
+++ b/terraso_backend/tests/graphql/mutations/test_projects.py
@@ -62,6 +62,7 @@ def test_create_project(client, user):
     project = Project.objects.get(pk=id)
     assert list([mb.user for mb in project.manager_memberships.all()]) == [user]
     assert project.description == "A test project"
+    assert project.soil_settings is not None
 
     logs = Log.objects.all()
     assert len(logs) == 1


### PR DESCRIPTION
## Description

Ran into a bug on the frontend when I tried creating a new project. This commit makes sure that the project has a soil project settings associated it. It also allows this to be disabled if we're creating a project from somewhere where the project soil settings is not necessary.

Will also need to make a change to client-shared too.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
