### PR TITLE
chore: Make Sentry config optional

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -53,4 +53,5 @@ GOOGLE_IOS_CLIENT_ID=google-mobile-client-id
 MAPBOX_USERNAME=mapbox-username
 MAPBOX_ACCESS_TOKEN=your-mapbox-token
 
-SENTRY_DSN=https://xyz.ingest.sentry.io/abcd
+# Uncomment and populate with a DSN to enable sentry.
+# SENTRY_DSN=https://xyz.ingest.sentry.io/abcd

--- a/.env.sample
+++ b/.env.sample
@@ -53,5 +53,5 @@ GOOGLE_IOS_CLIENT_ID=google-mobile-client-id
 MAPBOX_USERNAME=mapbox-username
 MAPBOX_ACCESS_TOKEN=your-mapbox-token
 
-# Uncomment and populate with a DSN to enable sentry.
+# Uncomment and populate with a DSN to enable Sentry.
 # SENTRY_DSN=https://xyz.ingest.sentry.io/abcd

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -418,14 +418,18 @@ MAPBOX_API_URL = config("MAPBOX_API_URL", default="https://api.mapbox.com")
 MAPBOX_USERNAME = config("MAPBOX_USERNAME", default="")
 MAPBOX_ACCESS_TOKEN = config("MAPBOX_ACCESS_TOKEN", default="")
 
-sentry_sdk.init(
-    dsn=config("SENTRY_DSN", default=""),
-    environment=config("ENV", default="development"),
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
-    # Set profiles_sample_rate to 1.0 to profile 100%
-    # of sampled transactions.
-    # We recommend adjusting this value in production.
-    profiles_sample_rate=1.0,
-)
+if config("SENTRY_DSN", default=""):
+    sentry_sdk.init(
+        dsn=config("SENTRY_DSN", default=""),
+        environment=config("ENV", default="development"),
+        # Set traces_sample_rate to 1.0 to capture 100%
+        # of transactions for performance monitoring.
+        traces_sample_rate=1.0,
+        # Set profiles_sample_rate to 1.0 to profile 100%
+        # of sampled transactions.
+        # We recommend adjusting this value in production.
+        profiles_sample_rate=1.0,
+    )
+else:
+    # structlog is already set up at this point, so we can log nicely.
+    structlog.get_logger().warning("SENTRY_DSN is not defined, continuing without Sentry.")


### PR DESCRIPTION
Description
===

Since the application crashes with an invalid/incomplete Sentry DSN, and it seems somewhat unnecessary for local dev, I made it optional. (Should this perhaps also detect if it's in production and still crash in case of misconfigurations?)

Let me know what you think, and feel free to close the issue if you don't like the idea altogether.

Changes:

- Log a warning and continue when sentry DSN is absent

There are no tests for settings.py. I'd have to mock out awkward things to make a meaningful test for this, but I'm happy to do so if desired.

### Verification steps

- `make run` with SENTRY_DSN absent from .env
- `make run` with SENTRY_DSN present in .env
- Deploy the application and ensure sentry traces are still being sent
