### PR TITLE
fix: don't delete users when cleaning up old models

### DIFF
--- a/terraso_backend/apps/core/management/commands/harddelete.py
+++ b/terraso_backend/apps/core/management/commands/harddelete.py
@@ -43,6 +43,8 @@ class Command(BaseCommand):
         app_models = apps.get_models()
         objects = []
         for model in app_models:
+            if model._meta.label in settings.DELETION_EXCEPTION_LIST:
+                continue
             for field in model._meta.fields:
                 if field.name == "deleted_at" and isinstance(field, models.fields.DateTimeField):
                     objects.extend(

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -385,6 +385,9 @@ PUBLIC_BASE_PATHS = [
 
 HARD_DELETE_DELETION_GAP = config("HARD_DELETE_DELETION_GAP_DAYS", default="30", cast=config.eval)
 
+# Preserve users to ensure audit logs are readable.
+DELETION_EXCEPTION_LIST = ["core.User"]
+
 
 class JWTProvider(TypedDict):
     """Type hint to indicate correct config for JWT_EXCHANGE_PROVIDERS"""

--- a/terraso_backend/tests/core/commands/test_harddelete.py
+++ b/terraso_backend/tests/core/commands/test_harddelete.py
@@ -23,7 +23,7 @@ from apps.shared_data.models import DataEntry
 pytestmark = pytest.mark.django_db
 
 
-@pytest.mark.parametrize("model", [User, Group, DataEntry])
+@pytest.mark.parametrize("model", [Group, DataEntry])
 def test_delete_model_deleted(model, delete_date):
     obj = mixer.blend(model)
     obj.delete()
@@ -33,6 +33,18 @@ def test_delete_model_deleted(model, delete_date):
     assert (
         not model.objects.all(force_visibility=True).filter(id=obj.id).exists()
     ), "Model should be deleted"
+
+
+@pytest.mark.parametrize("model", [User])
+def test_delete_user_not_deleted(model, delete_date):
+    obj = mixer.blend(model)
+    obj.delete()
+    obj.deleted_at = delete_date
+    obj.save(keep_deleted=True)
+    call_command("harddelete")
+    assert (
+        model.objects.all(force_visibility=True).filter(id=obj.id).exists()
+    ), "Model should not be deleted"
 
 
 @pytest.mark.parametrize("model", [User, Group, DataEntry])


### PR DESCRIPTION
## Description
Don't delete users when cleaning up old models. Preserves integrity of audit log.