### PR TITLE
fix: Use user id to filter membership to work with anonymous users

### DIFF
--- a/terraso_backend/apps/collaboration/models/memberships.py
+++ b/terraso_backend/apps/collaboration/models/memberships.py
@@ -139,7 +139,7 @@ class MembershipList(BaseModel):
         return self.approved_members.filter(id=user.id).exists()
 
     def is_member(self, user: User) -> bool:
-        return self.memberships.filter(user=user).exists()
+        return self.memberships.filter(user__id=user.id).exists()
 
     def get_membership(self, user: User):
         if not user:

--- a/terraso_backend/tests/graphql/test_groups.py
+++ b/terraso_backend/tests/graphql/test_groups.py
@@ -89,3 +89,42 @@ def test_project_groups_not_included_in_query(client_query, project):
     )
     total_count = reponse.json()["data"]["groups"]["totalCount"]
     assert total_count == 0
+
+
+def test_groups_memberships_not_included_for_anonymous_user(client_query_no_token, groups_closed):
+    reponse = client_query_no_token(
+        """
+        {groups {
+          totalCount
+          edges {
+            node {
+              slug
+              membershipList {
+                memberships {
+                  edges {
+                    node {
+                      id
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }}
+        """
+    )
+    json_response = reponse.json()
+
+    assert "errors" not in json_response
+
+    total_count = json_response["data"]["groups"]["totalCount"]
+    assert total_count == 2
+
+    assert (
+        len(
+            json_response["data"]["groups"]["edges"][0]["node"]["membershipList"]["memberships"][
+                "edges"
+            ]
+        )
+        == 0
+    )


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
-  Use user id to filter membership to work with anonymous users

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
- https://github.com/techmatters/terraso-web-client/issues/1409
