### PR TITLE
fix: Validate managers count on update

### DIFF
--- a/terraso_backend/tests/graphql/mutations/test_landscape_membership_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_landscape_membership_mutations.py
@@ -31,6 +31,8 @@ def test_landscape_membership_add(client_query, managed_landscapes, users):
     landscape = managed_landscapes[0]
     user = users[0]
 
+    landscape.membership_list.memberships.all().delete()
+
     response = client_query(
         """
         mutation addLandscapeMembership($input: LandscapeMembershipSaveMutationInput!){


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Validate managers count on membership update

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
- https://github.com/techmatters/terraso-web-client/issues/1527
