### PR TITLE
feat: Set is first login value inside token

### DIFF
--- a/terraso_backend/apps/auth/services.py
+++ b/terraso_backend/apps/auth/services.py
@@ -150,7 +150,7 @@ class JWTService:
             raise ValueError("User is not a test user")
         return self.create_token(user, None, {"test": True, "access": True})
 
-    def create_access_token(self, user, created_with_service):
+    def create_access_token(self, user, created_with_service=None):
         return self.create_token(
             user,
             self.JWT_ACCESS_EXP_DELTA_SECONDS,

--- a/terraso_backend/apps/auth/services.py
+++ b/terraso_backend/apps/auth/services.py
@@ -150,8 +150,12 @@ class JWTService:
             raise ValueError("User is not a test user")
         return self.create_token(user, None, {"test": True, "access": True})
 
-    def create_access_token(self, user):
-        return self.create_token(user, self.JWT_ACCESS_EXP_DELTA_SECONDS, {"access": True})
+    def create_access_token(self, user, created_with_service):
+        return self.create_token(
+            user,
+            self.JWT_ACCESS_EXP_DELTA_SECONDS,
+            {"access": True, "createdWithService": created_with_service},
+        )
 
     def verify_access_token(self, token):
         decoded = self._verify_token(token)

--- a/terraso_backend/apps/auth/services.py
+++ b/terraso_backend/apps/auth/services.py
@@ -150,11 +150,11 @@ class JWTService:
             raise ValueError("User is not a test user")
         return self.create_token(user, None, {"test": True, "access": True})
 
-    def create_access_token(self, user, created_with_service=None):
+    def create_access_token(self, user, extra_params={}):
         return self.create_token(
             user,
             self.JWT_ACCESS_EXP_DELTA_SECONDS,
-            {"access": True, "createdWithService": created_with_service},
+            {**extra_params, "access": True},
         )
 
     def verify_access_token(self, token):

--- a/terraso_backend/apps/auth/views.py
+++ b/terraso_backend/apps/auth/views.py
@@ -244,7 +244,7 @@ class LogoutView(View):
         return HttpResponse("OK", status=200)
 
 
-def terraso_login(request, user, created_with_service):
+def terraso_login(request, user, created_with_service=None):
     access_token = jwt_service.create_access_token(user, created_with_service)
     refresh_token = jwt_service.create_refresh_token(user)
     dj_login(request, user, backend="django.contrib.auth.backends.ModelBackend")

--- a/terraso_backend/apps/auth/views.py
+++ b/terraso_backend/apps/auth/views.py
@@ -108,7 +108,8 @@ class AbstractCallbackView(View):
 
         try:
             user, created_with_service = self.process_signup()
-            access_token, refresh_token = terraso_login(self.request, user, created_with_service)
+            is_first_login = created_with_service is not None
+            access_token, refresh_token = terraso_login(self.request, user, is_first_login)
         except Exception as exc:
             logger.exception("Error attempting create access and refresh tokens")
             return HttpResponse(f"Error: {exc}", status=400)
@@ -244,8 +245,8 @@ class LogoutView(View):
         return HttpResponse("OK", status=200)
 
 
-def terraso_login(request, user, created_with_service=None):
-    access_token = jwt_service.create_access_token(user, created_with_service)
+def terraso_login(request, user, is_first_login=False):
+    access_token = jwt_service.create_access_token(user, {"isFirstLogin": is_first_login})
     refresh_token = jwt_service.create_refresh_token(user)
     dj_login(request, user, backend="django.contrib.auth.backends.ModelBackend")
 

--- a/terraso_backend/apps/auth/views.py
+++ b/terraso_backend/apps/auth/views.py
@@ -108,7 +108,7 @@ class AbstractCallbackView(View):
 
         try:
             user, created_with_service = self.process_signup()
-            access_token, refresh_token = terraso_login(self.request, user)
+            access_token, refresh_token = terraso_login(self.request, user, created_with_service)
         except Exception as exc:
             logger.exception("Error attempting create access and refresh tokens")
             return HttpResponse(f"Error: {exc}", status=400)
@@ -244,8 +244,8 @@ class LogoutView(View):
         return HttpResponse("OK", status=200)
 
 
-def terraso_login(request, user):
-    access_token = jwt_service.create_access_token(user)
+def terraso_login(request, user, created_with_service):
+    access_token = jwt_service.create_access_token(user, created_with_service)
     refresh_token = jwt_service.create_refresh_token(user)
     dj_login(request, user, backend="django.contrib.auth.backends.ModelBackend")
 

--- a/terraso_backend/tests/auth/test_views.py
+++ b/terraso_backend/tests/auth/test_views.py
@@ -263,7 +263,7 @@ def test_userinfo_claims(rf, bearer_header, user):
 
 
 @mock_aws
-def test_sign_up_created_with_service(client, access_tokens_google, respx_mock):
+def test_sign_up_is_first_login(client, access_tokens_google, respx_mock):
     respx_mock.post(GoogleProvider.GOOGLE_TOKEN_URI).mock(
         return_value=Response(200, json=access_tokens_google)
     )
@@ -274,4 +274,4 @@ def test_sign_up_created_with_service(client, access_tokens_google, respx_mock):
 
     decoded_payload = JWTService().verify_access_token(token.value)
 
-    assert decoded_payload["createdWithService"] == "google"
+    assert decoded_payload["isFirstLogin"] is True


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Added parameter inside token to know if the user was created with a service

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
- https://github.com/techmatters/terraso-web-client/issues/1145

