### PR TITLE
fix: Update permissions for site contributors to match requirements

### DIFF
--- a/terraso_backend/apps/graphql/schema/sites.py
+++ b/terraso_backend/apps/graphql/schema/sites.py
@@ -189,8 +189,11 @@ class SiteUpdateMutation(BaseWriteMutation):
         site = cls.get_or_throw(Site, "id", kwargs["id"])
         if not user.has_perm(Site.get_perm("change"), site):
             raise cls.not_allowed(MutationTypes.UPDATE)
-        project_id = kwargs.pop("project_id", False)
+        if Site.SETTINGS_FIELDS.intersection(kwargs.keys()):
+            if not user.has_perm(Site.get_perm("change_settings"), site):
+                raise cls.not_allowed(MutationTypes.UPDATE)
 
+        project_id = kwargs.pop("project_id", False)
         result = super().mutate_and_get_payload(root, info, **kwargs)
         if project_id is False:
             # no project id included

--- a/terraso_backend/apps/graphql/schema/sites.py
+++ b/terraso_backend/apps/graphql/schema/sites.py
@@ -189,7 +189,7 @@ class SiteUpdateMutation(BaseWriteMutation):
         site = cls.get_or_throw(Site, "id", kwargs["id"])
         if not user.has_perm(Site.get_perm("change"), site):
             raise cls.not_allowed(MutationTypes.UPDATE)
-        
+
         # if any site settings fields are present in the mutuation, check that the user
         # has the associated settings-change permission as well
         if Site.SETTINGS_FIELDS.intersection(kwargs.keys()):

--- a/terraso_backend/apps/graphql/schema/sites.py
+++ b/terraso_backend/apps/graphql/schema/sites.py
@@ -189,6 +189,9 @@ class SiteUpdateMutation(BaseWriteMutation):
         site = cls.get_or_throw(Site, "id", kwargs["id"])
         if not user.has_perm(Site.get_perm("change"), site):
             raise cls.not_allowed(MutationTypes.UPDATE)
+        
+        # if any site settings fields are present in the mutuation, check that the user
+        # has the associated settings-change permission as well
         if Site.SETTINGS_FIELDS.intersection(kwargs.keys()):
             if not user.has_perm(Site.get_perm("change_settings"), site):
                 raise cls.not_allowed(MutationTypes.UPDATE)

--- a/terraso_backend/apps/project_management/models/sites.py
+++ b/terraso_backend/apps/project_management/models/sites.py
@@ -40,6 +40,7 @@ class Site(BaseModel):
             "change": permission_rules.allowed_to_update_site,
             "delete": permission_rules.allowed_to_delete_site,
             "transfer": permission_rules.allowed_to_transfer_site_to_project,
+            "change_settings": permission_rules.allowed_to_update_site_settings,
             "update_depth_interval": permission_rules.allowed_to_update_depth_interval,
         }
 
@@ -63,6 +64,9 @@ class Site(BaseModel):
     DEFAULT_PRIVACY_STATUS = PRIVATE
 
     PRIVACY_STATUS = ((PRIVATE, _("Private")), (PUBLIC, _("Public")))
+
+    # changing settings fields must be restricted by the corresponding permission
+    SETTINGS_FIELDS = set(["name", "privacy", "projectId"])
 
     privacy = models.CharField(
         max_length=32, null=False, choices=PRIVACY_STATUS, default=DEFAULT_PRIVACY_STATUS

--- a/terraso_backend/apps/project_management/permission_rules.py
+++ b/terraso_backend/apps/project_management/permission_rules.py
@@ -31,12 +31,21 @@ def allowed_to_add_site_to_project(user, project):
 def allowed_to_update_site(user, site):
     if site.owned_by_user:
         return site.owner == user
-    return site.project.is_manager(user)
+    return site.project.is_manager(user) or site.project.is_contributor(user)
 
 
 @rules.predicate
 def allowed_to_delete_site(user, site):
-    return allowed_to_update_site(user, site)
+    if site.owned_by_user:
+        return site.owner == user
+    return site.project.is_manager(user)
+
+
+@rules.predicate
+def allowed_to_update_site_settings(user, site):
+    if site.owned_by_user:
+        return site.owner == user
+    return site.project.is_manager(user)
 
 
 @rules.predicate

--- a/terraso_backend/tests/graphql/mutations/test_sites.py
+++ b/terraso_backend/tests/graphql/mutations/test_sites.py
@@ -140,7 +140,7 @@ def test_update_site_in_project(client, project, project_manager, site_with_soil
     assert log_result.metadata["project_id"] == str(project.id)
 
 
-@pytest.mark.parametrize("project_user_w_role", ["contributor"], indirect=True)
+@pytest.mark.parametrize("project_user_w_role", ["CONTRIBUTOR"], indirect=True)
 def test_update_site_settings_contributor(client, project, project_user_w_role, site):
     site.add_to_project(project)
 
@@ -158,7 +158,7 @@ def test_update_site_settings_contributor(client, project, project_user_w_role, 
     assert json_error[0]["code"] == "update_not_allowed"
 
 
-@pytest.mark.parametrize("project_user_w_role", ["manager"], indirect=True)
+@pytest.mark.parametrize("project_user_w_role", ["MANAGER"], indirect=True)
 def test_update_site_settings_manager(client, project, project_user_w_role, site):
     site.add_to_project(project)
 

--- a/terraso_backend/tests/graphql/mutations/test_sites.py
+++ b/terraso_backend/tests/graphql/mutations/test_sites.py
@@ -140,6 +140,44 @@ def test_update_site_in_project(client, project, project_manager, site_with_soil
     assert log_result.metadata["project_id"] == str(project.id)
 
 
+@pytest.mark.parametrize("project_user_w_role", ["contributor"], indirect=True)
+def test_update_site_settings_contributor(client, project, project_user_w_role, site):
+    site.add_to_project(project)
+
+    client.force_login(project_user_w_role)
+    response = graphql_query(
+        UPDATE_SITE_QUERY,
+        variables={
+            "input": {"id": str(site.id), "projectId": str(project.id), "name": "this is a test"}
+        },
+        client=client,
+    )
+
+    error_result = response.json()["data"]["updateSite"]["errors"][0]["message"]
+    json_error = json.loads(error_result)
+    assert json_error[0]["code"] == "update_not_allowed"
+
+
+@pytest.mark.parametrize("project_user_w_role", ["manager"], indirect=True)
+def test_update_site_settings_manager(client, project, project_user_w_role, site):
+    site.add_to_project(project)
+
+    client.force_login(project_user_w_role)
+    response = graphql_query(
+        UPDATE_SITE_QUERY,
+        variables={
+            "input": {"id": str(site.id), "projectId": str(project.id), "name": "this is a test"}
+        },
+        client=client,
+    )
+
+    content = json.loads(response.content)
+    assert content["data"]["updateSite"]["errors"] is None
+
+    site.refresh_from_db()
+    assert site.name == "this is a test"
+
+
 def test_adding_site_to_project_user_not_manager(client, project, site, project_user):
     site_creator = project_user
     client.force_login(site_creator)


### PR DESCRIPTION
## Description

Fix problems with site contributor permissions by granting the "change site" permission to project contributors. Restrict the name, privacy, and project id fields to owner/manager to maintain access restrictions parity with mobile client. Add test cases verifying new access controls.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

### Related Issues
Fixes [#843](https://github.com/techmatters/terraso-mobile-client/issues/843), [#925](https://github.com/techmatters/terraso-mobile-client/issues/925), [#851](https://github.com/techmatters/terraso-mobile-client/issues/851)

### Verification steps

Create a project and a site as one user, then add a second user to the site as a contributor. Verify that the second user can now update soil data, crack data, texture data. Verify that the second user cannot update the name or privacy, but that the first user still can.