### PR TITLE
fix: prevent the removal of the only manager from projects

### DIFF
--- a/terraso_backend/apps/project_management/graphql/projects.py
+++ b/terraso_backend/apps/project_management/graphql/projects.py
@@ -398,6 +398,10 @@ class ProjectDeleteUserMutation(BaseWriteMutation):
             cls.not_allowed(
                 MutationTypes.DELETE, msg="User not allowed to remove member from project"
             )
+
+        if project.is_sole_manager(user):
+            cls.not_allowed(MutationTypes.DELETE, msg="Cannot remove the last manager from project")
+
         # remove membership
         membership = project.get_membership(user)
         membership.delete()

--- a/terraso_backend/apps/project_management/models/projects.py
+++ b/terraso_backend/apps/project_management/models/projects.py
@@ -111,6 +111,9 @@ class Project(BaseModel):
     def user_has_role(self, user: User, role: ProjectRole) -> bool:
         return self.memberships_by_role(role).filter(user=user).exists()
 
+    def is_sole_manager(self, user: User) -> bool:
+        return self.is_manager(user) and self.manager_memberships.count() == 1
+
     def is_manager(self, user: User) -> bool:
         return self.user_has_role(user, ProjectRole.MANAGER)
 

--- a/terraso_backend/tests/project_management/models/test_projects.py
+++ b/terraso_backend/tests/project_management/models/test_projects.py
@@ -1,4 +1,4 @@
-# Copyright © 2023 Technology Matters
+# Copyright © 2024 Technology Matters
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published

--- a/terraso_backend/tests/project_management/models/test_projects.py
+++ b/terraso_backend/tests/project_management/models/test_projects.py
@@ -1,0 +1,43 @@
+# Copyright © 2023 Technology Matters
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see https://www.gnu.org/licenses/.
+
+import pytest
+from mixer.backend.django import mixer
+
+from apps.core.models.users import User
+
+pytestmark = pytest.mark.django_db
+
+
+def test_is_sole_manager_one_manager(project, project_manager):
+    assert project.is_sole_manager(project_manager) is True
+
+
+def test_is_sole_manager_no_membership(project):
+    user = mixer.blend(User)
+    assert project.is_sole_manager(user) is False
+
+
+def test_is_sole_manager_not_manager(project):
+    user = mixer.blend(User)
+    project.add_contributor(user)
+    assert project.is_sole_manager(user) is False
+
+
+def test_is_sole_manager_multiple_managers(project, project_manager):
+    user = mixer.blend(User)
+    project.add_manager(user)
+    assert project.is_sole_manager(user) is False
+    assert project.is_sole_manager(project_manager) is False


### PR DESCRIPTION
## Description
Add check to reject project user-deletion requests if the user in question is the only manager for the project. The system was accepting incoming user-removal requests for the project's only manager, despite requirements that removing the only manager on a project is not permitted.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

### Related Issues
Fixes #[496](https://github.com/techmatters/terraso-mobile-client/issues/496)

### Verification steps

See automated tests covering these cases.