### PR TITLE
fix: 'make run' now checks if it needs to rebuild the docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ setup-git-hooks:
 
 pre-commit: lint
 
-run:
+run: check_rebuild
 	@./scripts/docker.sh "$(DC_FILE_ARG)"
 
 setup: build setup-pre-commit


### PR DESCRIPTION
## Description
'make run' now checks if it needs to rebuild the docker image

(Issue surfaced from [this](https://tech-matters.slack.com/archives/C02K02L3Q48/p1715967037419279) slack thread, where a dependency was added but the backend couldn't find it because the docker image had not been updated)

### Checklist
N/A

### Related Issues
N/A

### Verification steps
See description