### PR TITLE
feat: refactor soil id endpoints to return more specific error messages

### DIFF
--- a/terraso_backend/apps/graphql/schema/schema.graphql
+++ b/terraso_backend/apps/graphql/schema/schema.graphql
@@ -96,9 +96,11 @@ type Query {
 
 """Soil ID algorithm queries."""
 type SoilId {
-  locationBasedSoilMatches(latitude: Float!, longitude: Float!): LocationBasedSoilMatches
-  dataBasedSoilMatches(latitude: Float!, longitude: Float!, data: SoilIdInputData!): DataBasedSoilMatches
+  locationBasedSoilMatches(latitude: Float!, longitude: Float!): LocationBasedResult!
+  dataBasedSoilMatches(latitude: Float!, longitude: Float!, data: SoilIdInputData!): DataBasedResult!
 }
+
+union LocationBasedResult = LocationBasedSoilMatches | SoilIdFailure
 
 """A ranked group of soil matches based solely on a coordinate pair."""
 type LocationBasedSoilMatches {
@@ -227,6 +229,17 @@ type SoilMatchInfo {
   score: Float!
   rank: Int!
 }
+
+type SoilIdFailure {
+  reason: SoilIdFailureReason!
+}
+
+enum SoilIdFailureReason {
+  DATA_UNAVAILABLE
+  ALGORITHM_FAILURE
+}
+
+union DataBasedResult = DataBasedSoilMatches | SoilIdFailure
 
 """
 A ranked group of soil matches based on a coordinate pair and soil data.

--- a/terraso_backend/apps/soil_id/graphql/soil_id/endpoints.py
+++ b/terraso_backend/apps/soil_id/graphql/soil_id/endpoints.py
@@ -17,12 +17,12 @@
 import graphene
 
 from apps.soil_id.graphql.soil_id.resolvers import (
-    resolve_data_based_soil_matches,
-    resolve_location_based_soil_matches,
+    resolve_data_based_result,
+    resolve_location_based_result,
 )
 from apps.soil_id.graphql.soil_id.schema import (
-    DataBasedSoilMatches,
-    LocationBasedSoilMatches,
+    DataBasedResult,
+    LocationBasedResult,
     SoilIdInputData,
 )
 
@@ -31,18 +31,18 @@ class SoilId(graphene.ObjectType):
     """Soil ID algorithm queries."""
 
     location_based_soil_matches = graphene.Field(
-        LocationBasedSoilMatches,
+        graphene.NonNull(LocationBasedResult),
         latitude=graphene.Float(required=True),
         longitude=graphene.Float(required=True),
-        resolver=resolve_location_based_soil_matches,
+        resolver=resolve_location_based_result,
     )
 
     data_based_soil_matches = graphene.Field(
-        DataBasedSoilMatches,
+        graphene.NonNull(DataBasedResult),
         latitude=graphene.Float(required=True),
         longitude=graphene.Float(required=True),
         data=graphene.Argument(SoilIdInputData, required=True),
-        resolver=resolve_data_based_soil_matches,
+        resolver=resolve_data_based_result,
     )
 
 

--- a/terraso_backend/apps/soil_id/graphql/soil_id/schema.py
+++ b/terraso_backend/apps/soil_id/graphql/soil_id/schema.py
@@ -102,6 +102,20 @@ class LocationBasedSoilMatches(graphene.ObjectType):
     matches = graphene.List(graphene.NonNull(LocationBasedSoilMatch), required=True)
 
 
+class SoilIdFailureReason(graphene.Enum):
+    DATA_UNAVAILABLE = "DATA_UNAVAILABLE"
+    ALGORITHM_FAILURE = "ALGORITHM_FAILURE"
+
+
+class SoilIdFailure(graphene.ObjectType):
+    reason = graphene.Field(SoilIdFailureReason, required=True)
+
+
+class LocationBasedResult(graphene.Union):
+    class Meta:
+        types = (LocationBasedSoilMatches, SoilIdFailure)
+
+
 class DataBasedSoilMatch(SoilMatch):
     """A soil match based on a coordinate pair and soil data."""
 
@@ -115,6 +129,11 @@ class DataBasedSoilMatches(graphene.ObjectType):
     """A ranked group of soil matches based on a coordinate pair and soil data."""
 
     matches = graphene.List(graphene.NonNull(DataBasedSoilMatch), required=True)
+
+
+class DataBasedResult(graphene.Union):
+    class Meta:
+        types = (DataBasedSoilMatches, SoilIdFailure)
 
 
 class LABColorInput(graphene.InputObjectType):

--- a/terraso_backend/tests/soil_id/test_graphql_resolvers.py
+++ b/terraso_backend/tests/soil_id/test_graphql_resolvers.py
@@ -1,9 +1,9 @@
 from apps.soil_id.graphql.soil_id.resolvers import (
     resolve_data_based_soil_match,
-    resolve_data_matches_from_soil_id_result,
+    resolve_data_based_soil_matches,
     resolve_ecological_site,
     resolve_location_based_soil_match,
-    resolve_location_matches_from_soil_id_result,
+    resolve_location_based_soil_matches,
     resolve_rock_fragment_volume,
     resolve_soil_data,
     resolve_soil_info,
@@ -290,8 +290,8 @@ def test_resolve_location_based_soil_match():
     assert result.soil_info.soil_series.name == "Randall"
 
 
-def test_resolve_location_matches_from_soil_id_result():
-    result = resolve_location_matches_from_soil_id_result({"soilList": sample_soil_list_json})
+def test_resolve_location_based_soil_matches():
+    result = resolve_location_based_soil_matches({"soilList": sample_soil_list_json})
 
     assert len(result.matches) == 2
 
@@ -307,8 +307,8 @@ def test_resolve_data_based_soil_match():
     assert result.soil_info.soil_series.name == "Randall"
 
 
-def test_resolve_data_matches_from_soil_id_result():
-    result = resolve_data_matches_from_soil_id_result(
+def test_resolve_data_based_soil_matches():
+    result = resolve_data_based_soil_matches(
         {"soilList": sample_soil_list_json}, {"soilRank": sample_rank_json}
     )
 


### PR DESCRIPTION
## Description
Refactors the soil ID algorithm endpoints to always return successfully but provide a specific reason if no results are returned. For now we will not be more granular than saying either "data unavailable" or "algorithm failed", since that would require refactoring the actual algorithm to return more useful output.'

Related to https://github.com/techmatters/terraso-product/issues/895
