### PR TITLE
feat: Display depth interval data and settings in django admin panel

### DIFF
--- a/terraso_backend/apps/soil_id/admin.py
+++ b/terraso_backend/apps/soil_id/admin.py
@@ -1,0 +1,58 @@
+# Copyright © 2021-2024 Technology Matters
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see https://www.gnu.org/licenses/.
+
+# Register your models here.
+from django.contrib import admin
+
+from apps.soil_id.models import (
+    DepthDependentSoilData,
+    ProjectDepthInterval,
+    ProjectSoilSettings,
+    SoilData,
+    SoilDataDepthInterval,
+)
+
+
+class DepthDependentSoilDataInline(admin.TabularInline):
+    model = DepthDependentSoilData
+
+
+class SoilDataDepthIntervalInline(admin.TabularInline):
+    model = SoilDataDepthInterval
+
+
+class ProjectDepthIntervalInline(admin.TabularInline):
+    model = ProjectDepthInterval
+
+
+@admin.register(ProjectSoilSettings)
+class ProjectSoilSettingsAdmin(admin.ModelAdmin):
+    list_display = ("project", "depth_interval_preset")
+    inlines = [
+        ProjectDepthIntervalInline,
+    ]
+
+
+@admin.register(SoilData)
+class SoilDataAdmin(admin.ModelAdmin):
+    @admin.display(ordering="site__name")
+    def site_name(self, obj):
+        return obj.site.name
+
+    list_display = ("site_name", "depth_interval_preset")
+    inlines = [
+        DepthDependentSoilDataInline,
+        SoilDataDepthIntervalInline,
+    ]

--- a/terraso_backend/apps/soil_id/admin.py
+++ b/terraso_backend/apps/soil_id/admin.py
@@ -1,4 +1,4 @@
-# Copyright © 2021-2024 Technology Matters
+# Copyright © 2024 Technology Matters
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published

--- a/terraso_backend/apps/soil_id/admin.py
+++ b/terraso_backend/apps/soil_id/admin.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see https://www.gnu.org/licenses/.
 
-# Register your models here.
 from django.contrib import admin
 
 from apps.soil_id.models import (


### PR DESCRIPTION
Adds these two change list views:
![Screenshot 2024-07-24 at 4 29 56 PM](https://github.com/user-attachments/assets/a0d0f19b-6bdb-4138-8298-9b3e1777fa97)

For each project, shows the project name and the depth interval preset.
When you click on a project, shows project soil settings like required inputs and defined depth intervals.

For each site, shows the site name and the depth interval preset.
When you click on a site, shows entered site data, including data entered at each depth interval (`DepthDependentSoilData`) and interval definitions themselves (`SoilDataDepthIntervals`) -- which I find to be a slightly confusing model but that's how it works :)


### Related Issues
N/A

### Verification steps
Go to django admin panel, view the two new items
