### PR TITLE
Fix: Modify admin panel tables and names

### DIFF
--- a/terraso_backend/apps/project_management/models/projects.py
+++ b/terraso_backend/apps/project_management/models/projects.py
@@ -25,6 +25,7 @@ class ProjectSettings(BaseModel):
 
     class Meta(BaseModel.Meta):
         abstract = False
+        verbose_name_plural = "project settings"
 
     member_can_update_site = models.BooleanField(default=False)
     member_can_add_site_to_project = models.BooleanField(default=False)

--- a/terraso_backend/apps/soil_id/admin.py
+++ b/terraso_backend/apps/soil_id/admin.py
@@ -50,7 +50,15 @@ class SoilDataAdmin(admin.ModelAdmin):
     def site_name(self, obj):
         return obj.site.name
 
-    list_display = ("site_name", "depth_interval_preset")
+    @admin.display(ordering="site__owner")
+    def site_owner(self, obj):
+        return obj.site.owner
+
+    @admin.display(ordering="site__project__name")
+    def project(self, obj):
+        return obj.site.project.name if obj.site.project is not None else None
+
+    list_display = ("site_name", "project", "site_owner", "depth_interval_preset")
     inlines = [
         DepthDependentSoilDataInline,
         SoilDataDepthIntervalInline,

--- a/terraso_backend/apps/soil_id/models/project_soil_settings.py
+++ b/terraso_backend/apps/soil_id/models/project_soil_settings.py
@@ -48,6 +48,7 @@ BLMIntervalDefaults = [
 class ProjectSoilSettings(BaseModel):
     class Meta(BaseModel.Meta):
         abstract = False
+        verbose_name_plural = "project soil settings"
 
     project = models.OneToOneField(Project, on_delete=models.CASCADE, related_name="soil_settings")
 

--- a/terraso_backend/apps/soil_id/models/soil_data.py
+++ b/terraso_backend/apps/soil_id/models/soil_data.py
@@ -215,6 +215,9 @@ class SoilData(BaseModel):
         default=SoilDataDepthIntervalPreset.NRCS.value,
     )
 
+    class Meta(BaseModel.Meta):
+        verbose_name_plural = "soil data"
+
 
 class SoilDataDepthInterval(BaseModel, BaseDepthInterval):
     soil_data = models.ForeignKey(


### PR DESCRIPTION
## Description
In Django admin panel:
- Add custom plurals when plurals were incorrect
- Add project and site owner to "Soil data"
Now looks like:
![image](https://github.com/user-attachments/assets/24d4be41-9178-4c32-afa0-d4255381766a)

### Related Issues
N/A

### Verification steps
Look at django admin panel
