### PR TITLE
fix: remove version from docker-compose file

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   web:
     image: techmatters/terraso_backend

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   web:
     extends:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   web:
     extends:


### PR DESCRIPTION
## Description
remove version from docker-compose file

Addresses:
WARN[0000] /Users/paul/.dev/backend/docker-compose.dev.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion