### PR TITLE
fix: replace CheckConstraint.check with CheckConstraint.condition and add FORMS_URLFIELD_ASSUME_HTTPS

### DIFF
--- a/terraso_backend/apps/project_management/migrations/0003_remove_site_project_management_site_unique_active_slug_and_more.py
+++ b/terraso_backend/apps/project_management/migrations/0003_remove_site_project_management_site_unique_active_slug_and_more.py
@@ -49,7 +49,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="site",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(("project__isnull", False), ("owner__isnull", False), _connector="OR"),
                     models.Q(("project__isnull", True), ("owner__isnull", True), _connector="OR"),
                 ),

--- a/terraso_backend/apps/soil_id/migrations/0003_alter_depthdependentsoildata_options_and_more.py
+++ b/terraso_backend/apps/soil_id/migrations/0003_alter_depthdependentsoildata_options_and_more.py
@@ -499,7 +499,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="depthdependentsoildata",
             constraint=models.CheckConstraint(
-                check=models.Q(("depth_start__lt", models.F("depth_end"))),
+                condition=models.Q(("depth_start__lt", models.F("depth_end"))),
                 name="depth_interval_coherence",
             ),
         ),

--- a/terraso_backend/apps/soil_id/migrations/0005_projectdepthinterval_projectsoilsettings_and_more.py
+++ b/terraso_backend/apps/soil_id/migrations/0005_projectdepthinterval_projectsoilsettings_and_more.py
@@ -205,7 +205,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="depthdependentsoildata",
             constraint=models.CheckConstraint(
-                check=models.Q(("depth_interval_start__lt", models.F("depth_interval_end"))),
+                condition=models.Q(("depth_interval_start__lt", models.F("depth_interval_end"))),
                 name="soil_id_depthdependentsoildata_depth_interval_coherence",
             ),
         ),
@@ -247,7 +247,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="soildatadepthinterval",
             constraint=models.CheckConstraint(
-                check=models.Q(("depth_interval_start__lt", models.F("depth_interval_end"))),
+                condition=models.Q(("depth_interval_start__lt", models.F("depth_interval_end"))),
                 name="soil_id_soildatadepthinterval_depth_interval_coherence",
             ),
         ),
@@ -262,7 +262,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="projectdepthinterval",
             constraint=models.CheckConstraint(
-                check=models.Q(("depth_interval_start__lt", models.F("depth_interval_end"))),
+                condition=models.Q(("depth_interval_start__lt", models.F("depth_interval_end"))),
                 name="soil_id_projectdepthinterval_depth_interval_coherence",
             ),
         ),

--- a/terraso_backend/apps/soil_id/models/depth_interval.py
+++ b/terraso_backend/apps/soil_id/models/depth_interval.py
@@ -38,7 +38,7 @@ class BaseDepthInterval(models.Model):
                 name="%(app_label)s_%(class)s_unique_depth_interval",
             ),
             models.CheckConstraint(
-                check=models.Q(depth_interval_start__lt=models.F("depth_interval_end")),
+                condition=models.Q(depth_interval_start__lt=models.F("depth_interval_end")),
                 name="%(app_label)s_%(class)s_depth_interval_coherence",
             ),
         ]

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -445,3 +445,6 @@ HUBSPOT_ACCOUNT_DELETION_FORM_API_URL = (
     f"https://api.hsforms.com/submissions/v3/integration/submit/"
     f"{HUBSPOT_PORTAL_ID}/{HUBSPOT_ACCOUNT_DELETION_FORM_ID}"
 )
+
+# Neeed for Django 5.x to silence warning. Remove when Django 6.0 is released.
+FORMS_URLFIELD_ASSUME_HTTPS=True

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -447,4 +447,4 @@ HUBSPOT_ACCOUNT_DELETION_FORM_API_URL = (
 )
 
 # Neeed for Django 5.x to silence warning. Remove when Django 6.0 is released.
-FORMS_URLFIELD_ASSUME_HTTPS=True
+FORMS_URLFIELD_ASSUME_HTTPS = True


### PR DESCRIPTION
## Description
* replace CheckConstraint.check with CheckConstraint.condition 
*  add FORMS_URLFIELD_ASSUME_HTTPS=True

Fixes two warnings:
```
RemovedInDjango60Warning: CheckConstraint.check is deprecated in favor of `.condition`.
```

```
RemovedInDjango60Warning: The default scheme will be changed from 'http' to 'https' in Django 6.0. Pass the forms.URLField.assume_scheme argument to silence this warning, or set the FORMS_URLFIELD_ASSUME_HTTPS transitional setting to True to opt into using 'https' as the new default scheme.
```