### PR TITLE
fix: enum fields in soil data push

### DIFF
--- a/terraso_backend/apps/soil_id/models/soil_data_history.py
+++ b/terraso_backend/apps/soil_id/models/soil_data_history.py
@@ -13,11 +13,21 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see https://www.gnu.org/licenses/.
 
+import enum
+
+from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 
 from apps.core.models import User
 from apps.core.models.commons import BaseModel
 from apps.project_management.models.sites import Site
+
+
+class JSONEncoder(DjangoJSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, enum.Enum):
+            return obj.value
+        return super().default(obj)
 
 
 # NOTE: this table may contain data associated with sites that was submitted
@@ -55,4 +65,4 @@ class SoilDataHistory(BaseModel):
     #     }
     #   }]
     # }
-    soil_data_changes = models.JSONField()
+    soil_data_changes = models.JSONField(encoder=JSONEncoder)

--- a/terraso_backend/tests/graphql/mutations/test_soil_data.py
+++ b/terraso_backend/tests/graphql/mutations/test_soil_data.py
@@ -875,6 +875,7 @@ def test_push_soil_data_success(client, user):
 
     soil_data_changes = {
         "slopeAspect": 10,
+        "downSlope": "CONVEX",
         "depthDependentData": [{"depthInterval": {"start": 0, "end": 10}, "clayPercent": 10}],
         "depthIntervals": [
             {


### PR DESCRIPTION
## Description
Fixes the bug with enum fields in the soil data push mutation, and takes some steps towards more robust testing.

Related to the testing part of #1487.