### PR TITLE
build: update posgres to 16

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -14,7 +14,7 @@ services:
     tty: true
 
   db:
-    image: 'postgis/postgis:14-master'
+    image: 'postgis/postgis:16-master'
     labels:
       org.techmatters.project: terraso_backend
     env_file: .env


### PR DESCRIPTION
## Description

To upgrade your local development environment
With Postgres 14: ensure your backend Docker container is running (`make run`).
Back up your database:
```
CONTAINER_ID=`docker ps | grep postgis | cut -c 1-12`
docker exec -it  ${CONTAINER_ID} pg_dumpall -U postgres > terraso.sql
```

Delete the data directory:
```
docker compose -f docker-compose.dev.yml down
docker volume rm backend_postgresql_data
```

With Postgres 16: ensure your backend Docker container is running (`make run`).
Restore the data:
```
CONTAINER_ID=`docker ps | grep postgis | cut -c 1-12`
cat terraso.sql| docker exec -i ${CONTAINER_ID} psql -U postgres
```