### PR TITLE
fix: remove Data/ path prefix from hashFiles() call

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: Data/
-          key: ${{ runner.os }}-data-${{ hashFiles('Data/*') }}
+          key: ${{ runner.os }}-data-${{ hashFiles('*') }}
           restore-keys: ${{ runner.os }}-data-
 
       - name: Setup Python


### PR DESCRIPTION
## Description
move Data/ path prefix from hashFiles() call. Hopefully will result in cache named `Linux-data-xyz` instead of `Linux-data-`.