### PR TITLE
Fix: Editing depth interval should remove old interval earlier

### DIFF
--- a/terraso_backend/apps/soil_id/graphql/soil_data/push_mutation.py
+++ b/terraso_backend/apps/soil_id/graphql/soil_data/push_mutation.py
@@ -196,6 +196,8 @@ class SoilDataPush(BaseWriteMutation):
                     reason=reason,
                 )
 
+            # Delete depth intervals first to avoid errors during validation if new
+            # intervals overlap with deleted ones
             SoilDataPush.delete_depth_intervals(soil_data, deleted_depth_intervals)
             SoilDataPush.update_soil_data(soil_data, update_data)
             SoilDataPush.update_depth_intervals(soil_data, depth_intervals)

--- a/terraso_backend/apps/soil_id/graphql/soil_data/push_mutation.py
+++ b/terraso_backend/apps/soil_id/graphql/soil_data/push_mutation.py
@@ -196,10 +196,10 @@ class SoilDataPush(BaseWriteMutation):
                     reason=reason,
                 )
 
+            SoilDataPush.delete_depth_intervals(soil_data, deleted_depth_intervals)
             SoilDataPush.update_soil_data(soil_data, update_data)
             SoilDataPush.update_depth_intervals(soil_data, depth_intervals)
             SoilDataPush.update_depth_dependent_data(soil_data, depth_dependent_data)
-            SoilDataPush.delete_depth_intervals(soil_data, deleted_depth_intervals)
 
             history_entry.update_succeeded = True
             history_entry.save()


### PR DESCRIPTION
## Description
**Previously**: Editing a depth interval could cause a conflict if the new depth interval overlapped the old one:
```{"data":{"pushSoilData":{"results":[{"siteId":"6652e310-0938-48c6-99f8-b2895183004e","result":{"__typename":"SoilDataPushEntryFailure","reason":"INVALID_DATA"}}],"errors":null}}}```
This is because it would try to add the new interval to the site, validate the site's intervals (where it could fail), and then delete the old interval. This would cause the old interval to stay around, though a new interval would also appear, and the project conflict dialog would show.

**Now**: Delete the old interval before trying to add the new interval to the site. Honestly I didn't investigate why the project conflict dialog would show, but it no longer does. Also add a test.


### Related Issues
Addresses #1618

### Verification steps
See bug
