### PR TITLE
fix: Sign media urls for published configuration

### DIFF
--- a/terraso_backend/tests/graphql/conftest.py
+++ b/terraso_backend/tests/graphql/conftest.py
@@ -493,7 +493,10 @@ def story_maps(users):
         StoryMap,
         created_by=users[1],
         is_published=True,
-        published_configuration={"title": "Published"},
+        published_configuration={
+            "title": "Published",
+            "chapters": [{"media": {"type": "image", "url": "test_url"}}],
+        },
         configuration={"title": "Draft"},
     )
     user_1_stories_drafts = mixer.cycle(5).blend(StoryMap, created_by=users[1], is_published=False)


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Added signed urls for published story map configuration

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
- https://github.com/techmatters/terraso-web-client/issues/2631
