### PR TITLE
fix: Docker should build the db container on arm64 architecture

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -14,6 +14,8 @@ services:
     tty: true
 
   db:
+    # We can remove the 'platform' line if postgis makes an official multi-platform build available
+    # See https://hub.docker.com/r/postgis/postgis/tags
     platform: linux/amd64
     image: postgis/postgis:16-master
     labels:

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -14,6 +14,7 @@ services:
     tty: true
 
   db:
+    platform: linux/amd64
     image: postgis/postgis:16-master
     labels:
       org.techmatters.project: terraso_backend

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -3,7 +3,7 @@ set -e
 
 build_hash()
 {
-    if [ -z $(which md5sum) ]; then
+    if [[ "$(uname -s)" == "Darwin" ]]; then
         # macOS support
         md5 -r requirements/base.in requirements/deploy.in requirements/dev.in requirements.txt requirements-dev.txt > .rebuild
     else
@@ -14,7 +14,7 @@ build_hash()
 
 check_hash()
 {
-    if [ -z $(which md5sum) ]; then
+    if [[ "$(uname -s)" == "Darwin" ]]; then
         # macOS support
         md5 -r requirements/base.in requirements/deploy.in requirements/dev.in requirements.txt requirements-dev.txt | diff .rebuild - > /dev/null 2>&1
         echo $?


### PR DESCRIPTION
## Description
I started getting an error ‘no matching manifest for linux/arm64/v8 in the manifest list entries’ when running ‘make run’. 
My understanding is that the postgis/postgis image we use only specifies that it can run on linux/amd64, but my mac uses Apple Silicon’s ARM architecture. Docker has a setting to use amd64 emulation on Apple Silicon, but it seems like this change was needed to get Docker to actually build the container from the image.

I’m not sure why it was working before, though…? It started happening after a git pull and after deleting a bunch of docker objects in Docker Desktop to free up disk space.

### Play-by-play
Made the change per this: https://stackoverflow.com/questions/65456814/docker-apple-silicon-m1-preview-mysql-no-matching-manifest-for-linux-arm64-v8 
And confirmed that the listed postgis OS/Arch does not include ARM64: https://hub.docker.com/r/postgis/postgis/tags
Backend is now running: 
![Screenshot 2025-06-12 at 10 46 08 PM](https://github.com/user-attachments/assets/199ecf26-dcb2-4603-9517-81c32556be8a)


### Verification steps
Do `make run` on a macbook with Apple Silicon