### PR TITLE
fix: parse_rock_fragment_volume no longer always returns >60%

### DIFF
--- a/terraso_backend/apps/soil_id/graphql/soil_id/resolvers.py
+++ b/terraso_backend/apps/soil_id/graphql/soil_id/resolvers.py
@@ -287,13 +287,13 @@ def parse_rock_fragment_volume(
 ):
     if rock_fragment_volume is None:
         return None
-    elif rock_fragment_volume == DepthDependentSoilData.RockFragmentVolume.VOLUME_0_1:
+    elif rock_fragment_volume.value == DepthDependentSoilData.RockFragmentVolume.VOLUME_0_1.value:
         return "0-1%"
-    elif rock_fragment_volume == DepthDependentSoilData.RockFragmentVolume.VOLUME_1_15:
+    elif rock_fragment_volume.value == DepthDependentSoilData.RockFragmentVolume.VOLUME_1_15.value:
         return "1-15%"
-    elif rock_fragment_volume == DepthDependentSoilData.RockFragmentVolume.VOLUME_15_35:
+    elif rock_fragment_volume.value == DepthDependentSoilData.RockFragmentVolume.VOLUME_15_35.value:
         return "15-35%"
-    elif rock_fragment_volume == DepthDependentSoilData.RockFragmentVolume.VOLUME_35_60:
+    elif rock_fragment_volume.value == DepthDependentSoilData.RockFragmentVolume.VOLUME_35_60.value:
         return "35-60%"
     else:
         return ">60%"

--- a/terraso_backend/apps/soil_id/graphql/soil_id/resolvers.py
+++ b/terraso_backend/apps/soil_id/graphql/soil_id/resolvers.py
@@ -276,15 +276,13 @@ def parse_data_region(data_region: Optional[str]):
         raise ValueError(f"Unknown data region: {data_region}")
 
 
-def parse_texture(texture: Optional[DepthDependentSoilData.Texture]):
+def parse_texture(texture):
     if texture is None:
         return None
     return texture.value.replace("_", " ").lower()
 
 
-def parse_rock_fragment_volume(
-    rock_fragment_volume: Optional[DepthDependentSoilData.RockFragmentVolume],
-):
+def parse_rock_fragment_volume(rock_fragment_volume):
     if rock_fragment_volume is None:
         return None
     elif rock_fragment_volume.value == DepthDependentSoilData.RockFragmentVolume.VOLUME_0_1.value:

--- a/terraso_backend/apps/soil_id/graphql/soil_id/resolvers.py
+++ b/terraso_backend/apps/soil_id/graphql/soil_id/resolvers.py
@@ -276,12 +276,14 @@ def parse_data_region(data_region: Optional[str]):
         raise ValueError(f"Unknown data region: {data_region}")
 
 
+# Argument type hint would be DepthDependentSoilDataNode.texture_enum() if that were allowed :)
 def parse_texture(texture):
     if texture is None:
         return None
     return texture.value.replace("_", " ").lower()
 
 
+# Argument type hint would be DepthDependentSoilDataNode.rock_fragment_volume_enum() if that were allowed :)
 def parse_rock_fragment_volume(rock_fragment_volume):
     if rock_fragment_volume is None:
         return None

--- a/terraso_backend/tests/soil_id/test_graphql_resolvers.py
+++ b/terraso_backend/tests/soil_id/test_graphql_resolvers.py
@@ -1,4 +1,5 @@
 from apps.soil_id.graphql.soil_id.resolvers import (
+    parse_rock_fragment_volume,
     resolve_data_based_soil_match,
     resolve_data_based_soil_matches,
     resolve_ecological_site,
@@ -10,6 +11,8 @@ from apps.soil_id.graphql.soil_id.resolvers import (
     resolve_texture,
 )
 from apps.soil_id.models.soil_id_cache import SoilIdCache
+from apps.soil_id.models.depth_dependent_soil_data import DepthDependentSoilData
+
 
 sample_soil_list_json = [
     {
@@ -351,3 +354,14 @@ def test_resolve_data_based_soil_matches():
     )
 
     assert len(result.matches) == 2
+
+
+def test_parse_rock_fragment_volume(): 
+    # Is there something we can import to use the same type as the product code?
+    # assert parse_rock_fragment_volume(SoilIdDepthDependentSoilDataRockFragmentVolumeChoices.VOLUME_0_1) == "0-1%"
+    assert parse_rock_fragment_volume(DepthDependentSoilData.RockFragmentVolume.VOLUME_0_1) == "0-1%"
+    assert parse_rock_fragment_volume(DepthDependentSoilData.RockFragmentVolume.VOLUME_1_15) == "1-15%"
+    assert parse_rock_fragment_volume(DepthDependentSoilData.RockFragmentVolume.VOLUME_15_35) == "15-35%"
+    assert parse_rock_fragment_volume(DepthDependentSoilData.RockFragmentVolume.VOLUME_35_60) == "35-60%"
+    assert parse_rock_fragment_volume(DepthDependentSoilData.RockFragmentVolume.VOLUME_60) == ">60%"
+    assert parse_rock_fragment_volume(None) is None

--- a/terraso_backend/tests/soil_id/test_graphql_resolvers.py
+++ b/terraso_backend/tests/soil_id/test_graphql_resolvers.py
@@ -12,6 +12,7 @@ from apps.soil_id.graphql.soil_id.resolvers import (
 )
 from apps.soil_id.models.soil_id_cache import SoilIdCache
 from apps.soil_id.models.depth_dependent_soil_data import DepthDependentSoilData
+from apps.soil_id.graphql.soil_data.queries import DepthDependentSoilDataNode
 
 
 sample_soil_list_json = [
@@ -356,12 +357,29 @@ def test_resolve_data_based_soil_matches():
     assert len(result.matches) == 2
 
 
-def test_parse_rock_fragment_volume(): 
-    # Is there something we can import to use the same type as the product code?
-    # assert parse_rock_fragment_volume(SoilIdDepthDependentSoilDataRockFragmentVolumeChoices.VOLUME_0_1) == "0-1%"
-    assert parse_rock_fragment_volume(DepthDependentSoilData.RockFragmentVolume.VOLUME_0_1) == "0-1%"
-    assert parse_rock_fragment_volume(DepthDependentSoilData.RockFragmentVolume.VOLUME_1_15) == "1-15%"
-    assert parse_rock_fragment_volume(DepthDependentSoilData.RockFragmentVolume.VOLUME_15_35) == "15-35%"
-    assert parse_rock_fragment_volume(DepthDependentSoilData.RockFragmentVolume.VOLUME_35_60) == "35-60%"
+def test_parse_rock_fragment_volume():
+    RockFragmentVolumeEnum = DepthDependentSoilDataNode.rock_fragment_volume_enum()
+
+    assert parse_rock_fragment_volume(RockFragmentVolumeEnum.VOLUME_0_1) == "0-1%"
+    assert parse_rock_fragment_volume(RockFragmentVolumeEnum.VOLUME_1_15) == "1-15%"
+    assert parse_rock_fragment_volume(RockFragmentVolumeEnum.VOLUME_15_35) == "15-35%"
+    assert parse_rock_fragment_volume(RockFragmentVolumeEnum.VOLUME_35_60) == "35-60%"
+    assert parse_rock_fragment_volume(RockFragmentVolumeEnum.VOLUME_60) == ">60%"
+
+    assert (
+        parse_rock_fragment_volume(DepthDependentSoilData.RockFragmentVolume.VOLUME_0_1) == "0-1%"
+    )
+    assert (
+        parse_rock_fragment_volume(DepthDependentSoilData.RockFragmentVolume.VOLUME_1_15) == "1-15%"
+    )
+    assert (
+        parse_rock_fragment_volume(DepthDependentSoilData.RockFragmentVolume.VOLUME_15_35)
+        == "15-35%"
+    )
+    assert (
+        parse_rock_fragment_volume(DepthDependentSoilData.RockFragmentVolume.VOLUME_35_60)
+        == "35-60%"
+    )
     assert parse_rock_fragment_volume(DepthDependentSoilData.RockFragmentVolume.VOLUME_60) == ">60%"
+
     assert parse_rock_fragment_volume(None) is None


### PR DESCRIPTION
## Description
`parse_rock_fragment_volume` would always return “>60%“, even when I selected another value range. I believe this was because according to Python's `type(obj)`:
- The input type is `<enum 'SoilIdDepthDependentSoilDataRockFragmentVolumeChoices'>`
- The type we’re comparing to is `<enum 'RockFragmentVolume'>`

I'm wondering how to refer to the `SoilIdDepthDependentSoilDataRockFragmentVolumeChoices` to replace the type hint, and to pass in the test? It looks like only schema.graphql defines the type, and it doesn’t seem like we import things from that file?


### Related Issues
One of the things for [#1691](https://github.com/techmatters/terraso-backend/issues/1691)