### PR TITLE
fix: Set the combinedScore value to the locationScore if there is no combinedScore

### DIFF
--- a/terraso_backend/apps/soil_id/graphql/soil_id/resolvers.py
+++ b/terraso_backend/apps/soil_id/graphql/soil_id/resolvers.py
@@ -240,14 +240,18 @@ def resolve_data_based_soil_match(
     else:
         data_source = site_data["dataSource"]
 
+    location_match = resolve_soil_match_info(ranked_match["score_loc"], ranked_match["rank_loc"])
+    combined_match = (
+        resolve_soil_match_info(ranked_match["score_data_loc"], ranked_match["rank_data_loc"])
+        or location_match
+    )
+
     return DataBasedSoilMatch(
         data_source=data_source,
         distance_to_nearest_map_unit_m=site_data["minCompDistance"],
-        location_match=resolve_soil_match_info(ranked_match["score_loc"], ranked_match["rank_loc"]),
+        location_match=location_match,
         data_match=resolve_soil_match_info(ranked_match["score_data"], ranked_match["rank_data"]),
-        combined_match=resolve_soil_match_info(
-            ranked_match["score_data_loc"], ranked_match["rank_data_loc"]
-        ),
+        combined_match=combined_match,
         soil_info=resolve_soil_info(soil_match),
     )
 


### PR DESCRIPTION
## Description
Per this slack thread: https://tech-matters.slack.com/archives/C0376RCCXD2/p1752100638887979
This will allow the new global-enabled backend to work (mostly) with the old frontend, and with the new frontend.
The only thing that I'm aware of that doesn't work is that now on 1.2 it looks like global sites work -- until you try to view a soil match's details, and then it crashes because global matches don't have LCC but the client expects LCC.

### Related Issues
I haven't made an issue, but could if that's useful :)
