### PR TITLE
Fix: parse_surface_cracks should return true for Deep Vertical Cracks

### DIFF
--- a/terraso_backend/apps/soil_id/graphql/soil_id/resolvers.py
+++ b/terraso_backend/apps/soil_id/graphql/soil_id/resolvers.py
@@ -321,10 +321,15 @@ def parse_color_LAB(color_LAB: Optional[LABColorInput]):
     return [color_LAB.L, color_LAB.A, color_LAB.B]
 
 
+# Argument type hint would be SoilDataNode.surface_cracks_enum() if that were allowed
+# which for some reason is different than SoilData.SurfaceCracks...
+# Probably related, surface_cracks == SoilData.SurfaceCracks.DEEP_VERTICAL_CRACKS
+# (without the .value) evaluates to false even when it's set to Deep Vertical Cracks
+# This seems the case for all the enums
 def parse_surface_cracks(surface_cracks: SoilData.SurfaceCracks):
     if surface_cracks is None:
         return None
-    return surface_cracks == SoilData.SurfaceCracks.DEEP_VERTICAL_CRACKING
+    return surface_cracks.value == SoilData.SurfaceCracks.DEEP_VERTICAL_CRACKS.value
 
 
 def parse_rank_soils_input_data(

--- a/terraso_backend/tests/soil_id/test_graphql_resolvers.py
+++ b/terraso_backend/tests/soil_id/test_graphql_resolvers.py
@@ -1,5 +1,6 @@
 from apps.soil_id.graphql.soil_id.resolvers import (
     parse_rock_fragment_volume,
+    parse_surface_cracks,
     resolve_data_based_soil_match,
     resolve_data_based_soil_matches,
     resolve_ecological_site,
@@ -14,7 +15,8 @@ from apps.soil_id.graphql.soil_id.resolvers import (
 )
 from apps.soil_id.models.soil_id_cache import SoilIdCache
 from apps.soil_id.models.depth_dependent_soil_data import DepthDependentSoilData
-from apps.soil_id.graphql.soil_data.queries import DepthDependentSoilDataNode
+from apps.soil_id.graphql.soil_data.queries import DepthDependentSoilDataNode, SoilDataNode
+from apps.soil_id.models.soil_data import SoilData
 
 
 sample_soil_list_json = [
@@ -421,3 +423,15 @@ def test_parse_rock_fragment_volume():
     assert parse_rock_fragment_volume(DepthDependentSoilData.RockFragmentVolume.VOLUME_60) == ">60%"
 
     assert parse_rock_fragment_volume(None) is None
+
+
+def test_parse_surface_cracks():
+    SurfaceCracksEnum = SoilDataNode.surface_cracks_enum()
+
+    assert parse_surface_cracks(SurfaceCracksEnum.NO_CRACKING) is False
+    assert parse_surface_cracks(SurfaceCracksEnum.SURFACE_CRACKING_ONLY) is False
+    assert parse_surface_cracks(SurfaceCracksEnum.DEEP_VERTICAL_CRACKS) is True
+
+    assert parse_surface_cracks(SoilData.SurfaceCracks.NO_CRACKING) is False
+    assert parse_surface_cracks(SoilData.SurfaceCracks.SURFACE_CRACKING_ONLY) is False
+    assert parse_surface_cracks(SoilData.SurfaceCracks.DEEP_VERTICAL_CRACKS) is True


### PR DESCRIPTION
## Description
Previously it was always returning False.
Also add a test.

Weird stuff: 
- Changing the surface cracks still appears to have no affect on the match scores
- We offer users 3 cracking options but the soil-id-algorithm just expects a boolean

### Related Issues
Part of https://github.com/techmatters/terraso-product/issues/1279

