### PR TITLE
feat: allow clients to login from different domains

### DIFF
--- a/terraso_backend/apps/auth/views.py
+++ b/terraso_backend/apps/auth/views.py
@@ -141,9 +141,19 @@ class AbstractCallbackView(View):
         # Get the domain from the redirect URI or use configured domain
         redirect_domain = urlparse(origin).hostname
         if settings.ENV == "production" or redirect_domain == settings.WEB_CLIENT_DOMAIN:
-            response = HttpResponseRedirect(f"{origin}/{redirect_uri}")
-            response.set_cookie("atoken", access_token, domain=settings.AUTH_COOKIE_DOMAIN)
-            response.set_cookie("rtoken", refresh_token, domain=settings.AUTH_COOKIE_DOMAIN)
+            response = HttpResponseRedirect(f"{settings.WEB_CLIENT_URL}/{redirect_uri}")
+            response.set_cookie(
+                "atoken",
+                access_token,
+                secure=settings.ENV != "development",
+                domain=settings.AUTH_COOKIE_DOMAIN,
+            )
+            response.set_cookie(
+                "rtoken",
+                refresh_token,
+                secure=settings.ENV != "development",
+                domain=settings.AUTH_COOKIE_DOMAIN,
+            )
         else:
             state = self._encode_state(
                 {

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -269,6 +269,7 @@ if WEB_CLIENT_PORT != 443:
 LOGIN_URL = f"{WEB_CLIENT_URL}/account"
 AUTH_COOKIE_DOMAIN = config("AUTH_COOKIE_DOMAIN", default="")
 CORS_ORIGIN_WHITELIST = config("CORS_ORIGIN_WHITELIST", default=[], cast=config.list)
+CORS_ALLOWED_ORIGIN_REGEXES = config("CORS_ALLOWED_ORIGIN_REGEXES", default=[], cast=config.list)
 
 API_ENDPOINT = config("API_ENDPOINT", default="")
 


### PR DESCRIPTION
## Description
Updates the backend to support a new login method to use for preview branches. Clients logging in from a different apex domain than the backend is on will now get their tokens passed via query parameters instead of via cookies (which is not possible when on a different apex domain). This is not enabled in production because it's less secure.

Tests TBD.

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

### Related Issues
Related to #1709

### Verification steps
Old web clients should still work. New web clients should be able to log in from other domains (still subject to CORS restrictions).
