### PR TITLE
fix: return all soil components even when component changes within group

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1092,8 +1092,8 @@ sniffio==1.3.1 \
     --hash=sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2 \
     --hash=sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc
     # via anyio
-soil-id @ https://github.com/techmatters/soil-id-algorithm/archive/428ec72.zip \
-    --hash=sha256:2f96e40917cf46c357052c89a5179a042153e1678b1aa2484afbe06f4b06ea43
+soil-id @ https://github.com/techmatters/soil-id-algorithm/archive/0ad935a.zip \
+    --hash=sha256:ed149727720f60a69069811bd060158cbdfbe6c1ea7e60e052f1849eb9fd4b29
     # via -r requirements/base.in
 sqlparse==0.5.3 \
     --hash=sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272 \

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -26,4 +26,4 @@ requests
 rules
 sentry-sdk[django]
 shapely
-soil-id @ https://github.com/techmatters/soil-id-algorithm/archive/428ec72.zip
+soil-id @ https://github.com/techmatters/soil-id-algorithm/archive/0ad935a.zip

--- a/terraso_backend/apps/soil_id/graphql/soil_id/resolvers.py
+++ b/terraso_backend/apps/soil_id/graphql/soil_id/resolvers.py
@@ -161,7 +161,7 @@ def resolve_soil_info(soil_match: dict):
 
 
 def resolve_soil_match_info(score: Optional[float], rank: Optional[str]):
-    if score is None or rank is None or rank == "":
+    if score is None or rank is None:
         return None
     return SoilMatchInfo(score=score, rank=int(rank) - 1)
 
@@ -271,10 +271,14 @@ def resolve_soil_match(
     return SoilMatch(
         data_source=data_source,
         distance_to_nearest_map_unit_m=site_data["minCompDistance"],
-        location_match=resolve_soil_match_info(ranked_match["score_loc"], ranked_match["rank_loc"]),
-        data_match=resolve_soil_match_info(ranked_match["score_data"], ranked_match["rank_data"]),
+        location_match=resolve_soil_match_info(
+            ranked_match["score_loc_group"], ranked_match["rank_loc_group"]
+        ),
+        data_match=resolve_soil_match_info(
+            ranked_match["score_data"], ranked_match["rank_data_group"]
+        ),
         combined_match=resolve_soil_match_info(
-            ranked_match["score_data_loc"], ranked_match["rank_data_loc"]
+            ranked_match["score_data_loc"], ranked_match["rank_data_loc_group"]
         ),
         soil_info=resolve_soil_info(soil_match),
     )
@@ -392,12 +396,7 @@ def resolve_soil_matches(
 ):
     ranked_matches = []
     for ranked_match in rank_json["soilRank"]:
-        rankValues = [
-            ranked_match["rank_loc"],
-            ranked_match["rank_data"],
-            ranked_match["rank_data_loc"],
-        ]
-        if all([value != "Not Displayed" for value in rankValues]):
+        if not ranked_match["not_displayed"]:
             ranked_matches.append(
                 resolve_soil_match(data_region, soil_list_json["soilList"], ranked_match)
             )


### PR DESCRIPTION
## Description
Take advantage of the new information returned by the algorithm in https://github.com/techmatters/soil-id-algorithm/pull/331 to ensure that we always return a soil component for each group, even if the specific component changes after the user has input data.

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

### Related Issues
Resolves, when QA'd, #1695 

### Verification steps
Should no longer be able to repro #1695