### PR TITLE
fix: mark userratings list items as non-null

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,12 +12,12 @@ repos:
         pass_filenames: false
 
 -   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
-    rev: v0.8.0
+    rev: v0.9.0
     hooks:
     -   id: pre-commit-update
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.2
+    rev: v0.14.4
     hooks:
     -   id: ruff-check
         args: [--fix]

--- a/terraso_backend/apps/graphql/schema/schema.graphql
+++ b/terraso_backend/apps/graphql/schema/schema.graphql
@@ -1564,7 +1564,7 @@ enum SoilIdDepthDependentSoilDataCarbonatesChoices {
 
 type SoilMetadataNode {
   site: SiteNode!
-  userRatings: [UserRatingEntry]!
+  userRatings: [UserRatingEntry!]!
   selectedSoilId: String
 }
 

--- a/terraso_backend/apps/soil_id/graphql/soil_metadata/queries.py
+++ b/terraso_backend/apps/soil_id/graphql/soil_metadata/queries.py
@@ -37,7 +37,7 @@ class SoilMetadataNode(DjangoObjectType):
     selected_soil_id = graphene.String()
 
     # New field: expose user_ratings as a list
-    user_ratings = graphene.List(UserRatingEntry, required=True)
+    user_ratings = graphene.List(graphene.NonNull(UserRatingEntry), required=True)
 
     class Meta:
         model = SoilMetadata


### PR DESCRIPTION
## Description
Change the backend type so that the Typescript type is `userRatings: Array<UserRatingEntry>;` instead of `userRatings: Array<Maybe<UserRatingEntry>>;`

There shouldn't be any time that we have an entry in userRatings that is null
