### PR TITLE
fix: Disable Ruff cache in CI to avoid Docker permission failures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,12 +12,12 @@ repos:
         pass_filenames: false
 
 -   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
-    rev: v0.8.0
+    rev: v0.9.0
     hooks:
     -   id: pre-commit-update
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.2
+    rev: v0.14.6
     hooks:
     -   id: ruff-check
         args: [--fix]

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,14 @@ install-dev:
 	uv pip install -r requirements-dev.txt $(UV_FLAGS)
 
 lint: check_api_schema
+ifeq ($(DC_ENV),ci)
+	# Disable Ruff cache in CI to avoid Docker permission failures
+	$(DC_RUN_CMD) ruff check terraso_backend --no-cache
+	$(DC_RUN_CMD) ruff format terraso_backend --diff --no-cache
+else
 	$(DC_RUN_CMD) ruff check terraso_backend
 	$(DC_RUN_CMD) ruff format terraso_backend --diff
+endif
 
 lock:
 	CUSTOM_COMPILE_COMMAND="make lock" uv pip compile --upgrade --generate-hashes --emit-build-options requirements/base.in requirements/deploy.in -o requirements.txt


### PR DESCRIPTION
## Description
Disable Ruff cache in CI to avoid Docker permission failures

Should address:
```
docker compose -f docker-compose.ci.yml run --quiet-pull --rm web ruff check terraso_backend
 Container terraso-backend-soil-id-db-1  Running
 Container terraso-backend-db-1  Running
error: Failed to initialize cache at /app/.ruff_cache: Permission denied (os error 13)
ruff failed
  Cause: Failed to create temporary file
  Cause: No such file or directory (os error 2) at path "/app/.ruff_cache/0.14.4/.tmpB76K4d"

make: *** [Makefile:49: lint] Error 2
```