### PR TITLE
fix: Pin GDAL to 3.11.3 using Debian snapshot archive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,10 @@ ENV PATH=/home/terraso/.local/bin:$PATH
 # see https://github.com/aws/aws-cli/tags for list of versions
 ENV AWS_CLI_VERSION=2.8.12
 
-# Add testing sources and pin the GDAL packages to testing
-# Allows us to get 3.10.x versions of GDAL
-RUN sed 's/trixie/testing/g' /etc/apt/sources.list.d/debian.sources >  /etc/apt/sources.list.d/testing.sources
-
-RUN echo 'Package: libgdal-dev gdal-bin\nPin: release a=testing\nPin-Priority: 900' > /etc/apt/preferences.d/gdal-testing
+# Add Debian snapshot archive for GDAL 3.11.3 (frozen version for reproducible builds)
+# Using snapshot ensures system GDAL matches Python gdal==3.11.3 bindings
+RUN printf 'Types: deb\nURIs: http://snapshot.debian.org/archive/debian/20250822T205752Z/\nSuites: sid\nComponents: main\nCheck-Valid-Until: no\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n' > /etc/apt/sources.list.d/snapshot.sources && \
+    echo 'Package: libgdal-dev gdal-bin libgdal34t64\nPin: version 3.11.3*\nPin-Priority: 1000' > /etc/apt/preferences.d/gdal-pinned
 
 RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -12,6 +12,7 @@ django-storages
 django-structlog
 fiona
 --no-binary fiona
+gdal==3.11.3
 geopandas
 graphene-django
 httpx


### PR DESCRIPTION
Replace rolling Debian testing repo with frozen snapshot archive to ensure system GDAL version matches Python gdal==3.11.3 bindings.

Changes:
- Use Debian snapshot (20250822) with GDAL 3.11.3+dfsg-1
- Pin GDAL packages to version 3.11.3* with priority 1000
- Add explicit gdal==3.11.3 to requirements/base.in

This fixes version mismatch issues and provides reproducible builds by preventing unexpected GDAL version updates.

This is the simplest fix, but probably the right one for now.
We could to go 3.11.4 pretty easily ; 3.11.5 missing some bindings.
We could also go to 3.12, but that would require more testing.

NOTE: the PR double purpose is to make sure the GitHub build works; assuming it does, the PR is probably good.
