### PR TITLE
feat: enable GraphiQL interface on production

### DIFF
--- a/terraso_backend/apps/graphql/urls.py
+++ b/terraso_backend/apps/graphql/urls.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see https://www.gnu.org/licenses/.
 
-from django.conf import settings
 from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
 
@@ -25,11 +24,5 @@ app_name = "apps.graphql"
 
 urlpatterns = [
     path("docs", TerrasoGraphQLDocs.as_view()),
+    path("", csrf_exempt(auth_optional(TerrasoGraphQLView.as_view(graphiql=True)))),
 ]
-
-if settings.DEBUG:
-    urlpatterns.append(
-        path("", csrf_exempt(auth_optional(TerrasoGraphQLView.as_view(graphiql=True))))
-    )
-else:
-    urlpatterns.append(path("", csrf_exempt(auth_optional(TerrasoGraphQLView.as_view()))))


### PR DESCRIPTION
## Description
Enables the GraphiQL interface for our GraphQL API in production. Introspection was already enabled, so anyone could browse our GraphQL API (which is also published on GitHub) using a local client, but having the GraphiQL link available will enable us to send a convenient link to collaborators who want to test any public API endpoints we provide (concretely, we're hoping to let the devs at Virtual Agronomist test out our soil ID algorithm endpoint).

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
