### PR TITLE
feat: filter healthcheck logs

### DIFF
--- a/terraso_backend/config/logging_filters.py
+++ b/terraso_backend/config/logging_filters.py
@@ -1,0 +1,40 @@
+# Copyright © 2021-2025 Technology Matters
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see https://www.gnu.org/licenses/.
+
+import logging
+
+
+class HealthCheckFilter(logging.Filter):
+    """
+    Filter out successful healthz request logs to reduce log noise.
+
+    Health checks run every 5 seconds (~17,000/day) and clutter the logs.
+    This filter removes healthz logs unless they indicate an error (non-200 status).
+    """
+
+    def filter(self, record):
+        # If not a structlog dict message, keep it
+        if not isinstance(record.msg, dict):
+            return True
+
+        request = record.msg.get("request", "")
+        code = record.msg.get("code")
+
+        # If it's a healthz request and succeeded (200) or has no code (request_started), filter it out
+        if "/healthz" in request:
+            if code is None or code == 200:
+                return False
+
+        return True

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -217,10 +217,16 @@ LOGGING = {
             "processor": structlog.dev.ConsoleRenderer(),
         },
     },
+    "filters": {
+        "healthcheck_filter": {
+            "()": "config.logging_filters.HealthCheckFilter",
+        },
+    },
     "handlers": {
         "console": {
             "class": "logging.StreamHandler",
             "formatter": config("LOGS_FORMATTER", default="json_formatter"),
+            "filters": ["healthcheck_filter"],
         },
     },
     "loggers": {


### PR DESCRIPTION
filters out all the /healthz queries (17000 of them, each with multiple log entries).
still includes if the query fails although if service is completely dead, then obviously won't log anything.

bonus: a script that reads the render logs.  requires an api key, so this is safe to commit.
