### PR TITLE
feat: (dev-only) console logs include graphql query/mutation info

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -65,3 +65,9 @@ HUBSPOT_AUTH_TOKEN="pat-xxxxxxx"
 # Export system - controls pagination size for GraphQL queries in export endpoints
 # you may want to use 1 for testing purposes to make sure pagination working correctly
 EXPORT_PAGE_SIZE=50
+
+# Controls verbosity of GraphQL operation logging in development. Only active when ENV="development".
+# "minimal" - default Django structlog logging (no GraphQL-specific info)
+# "names"   - include GraphQL operation name in request_started/request_finished logs
+# "full"    - also include input variables (request_started) and response (request_finished)
+GRAPHQL_LOG_LEVEL="names"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     -   id: pre-commit-update
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.10
+    rev: v0.14.14
     hooks:
     -   id: ruff-check
         args: [--fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,14 +17,14 @@ repos:
     -   id: pre-commit-update
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.14
+    rev: v0.15.2
     hooks:
     -   id: ruff-check
         args: [--fix]
     -   id: ruff-format
 
 -   repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
     -   id: conventional-pre-commit
         stages: [commit-msg]

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,4 @@ addopts =
     --nomigrations
 markers =
     integration: mark as integration test (depends on external components)
+    unit: mark as unit test

--- a/terraso_backend/config/graphql_log.py
+++ b/terraso_backend/config/graphql_log.py
@@ -1,0 +1,158 @@
+# Copyright © 2021-2025 Technology Matters
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see https://www.gnu.org/licenses/.
+
+import json
+import re
+
+from django.conf import settings
+from django.dispatch import receiver
+from django_structlog import signals
+
+
+def _get_log_level():
+    """Read GRAPHQL_LOG_LEVEL at call time so code changes take effect on hot reload."""
+    if getattr(settings, "ENV", "") != "development":
+        return "minimal"
+    return getattr(settings, "GRAPHQL_LOG_LEVEL", "names")
+
+
+def _is_graphql_request(request):
+    return request.method == "POST" and request.path.rstrip("/").endswith("/graphql")
+
+
+def _parse_graphql_body(request):
+    """Parse GraphQL request body, returning (query_string, variables) or (None, None)."""
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return None, None
+
+    query = body.get("query")
+    variables = body.get("variables")
+    return query, variables
+
+
+# Matches named operations like "query getSites" or "mutation updateUser" and captures the name.
+# Example: "query getSites { ... }" -> captures "getSites"
+_OPERATION_RE = re.compile(r"^\s*(?:query|mutation|subscription)\s+(\w+)", re.MULTILINE)
+
+# Matches the operation type keyword (query/mutation/subscription) to determine the operation type.
+# Used for both named and anonymous operations.
+_OPERATION_TYPE_RE = re.compile(r"^\s*(query|mutation|subscription)\b", re.MULTILINE)
+
+# Matches field names followed by arguments or selection sets: "fieldName(" or "fieldName{".
+# Used to extract top-level fields from anonymous queries for logging context.
+_TOP_LEVEL_FIELDS_RE = re.compile(r"(\w+)\s*[\({]", re.MULTILINE)
+
+
+def _extract_top_level_fields(query):
+    """Extract top-level field names from a GraphQL query body (the part after the first '{')."""
+    brace_pos = query.find("{")
+    if brace_pos == -1:
+        return []
+    body = query[brace_pos + 1 :]
+    fields = []
+    for match in _TOP_LEVEL_FIELDS_RE.finditer(body):
+        # Count braces before this match to determine depth
+        preceding = body[: match.start()]
+        depth = preceding.count("{") - preceding.count("}")
+        if depth == 0:
+            fields.append(match.group(1))
+    return fields[:5]
+
+
+def _extract_operation_name(query):
+    """Extract a human-readable operation description from a GraphQL query string.
+
+    Returns strings like:
+        "userSoilData (query)"
+        "updateSite (mutation)"
+        "Anonymous: [sites, users] (query)"
+    """
+    if not query:
+        return None
+
+    match = _OPERATION_RE.search(query)
+    if match:
+        name = match.group(1)
+        type_match = _OPERATION_TYPE_RE.search(query)
+        op_type = type_match.group(1) if type_match else "query"
+        return f"{name} ({op_type})"
+
+    type_match = _OPERATION_TYPE_RE.search(query)
+    op_type = type_match.group(1) if type_match else "query"
+    fields = _extract_top_level_fields(query)
+    if fields:
+        field_list = ", ".join(fields)
+        return f"Anonymous: [{field_list}] ({op_type})"
+
+    return f"Anonymous ({op_type})"
+
+
+@receiver(signals.bind_extra_request_metadata)
+def add_graphql_request_info(request, logger, log_kwargs, **kwargs):
+    """Enrich 'request_started' log with GraphQL operation name and variables."""
+    log_level = _get_log_level()
+    if log_level == "minimal" or not _is_graphql_request(request):
+        return
+
+    query, variables = _parse_graphql_body(request)
+    operation = _extract_operation_name(query)
+    if operation:
+        log_kwargs["graphql_operation"] = operation
+
+    if log_level == "full" and variables:
+        log_kwargs["graphql_variables"] = variables
+
+
+@receiver(signals.bind_extra_request_finished_metadata)
+def add_graphql_response_info(request, logger, response, log_kwargs, **kwargs):
+    """Enrich 'request_finished' log with GraphQL operation name, error flag, and response."""
+    log_level = _get_log_level()
+    if log_level == "minimal" or not _is_graphql_request(request):
+        return
+
+    query, _ = _parse_graphql_body(request)
+    operation = _extract_operation_name(query)
+    if operation:
+        log_kwargs["graphql_operation"] = operation
+
+    try:
+        response_data = json.loads(response.content)
+    except (json.JSONDecodeError, ValueError, AttributeError):
+        response_data = None
+
+    if response_data and "errors" in response_data:
+        log_kwargs["graphql_has_errors"] = True
+
+    if log_level == "full" and response_data is not None:
+        log_kwargs["graphql_response"] = response_data
+
+
+@receiver(signals.bind_extra_request_failed_metadata)
+def add_graphql_error_info(request, logger, exception, log_kwargs, **kwargs):
+    """Enrich 'request_failed' log with GraphQL operation name and variables.
+    This is rare, as it only happens with unhandled exceptions, and graphene catches exceptions and converts them to errors in the response body."""
+    log_level = _get_log_level()
+    if log_level == "minimal" or not _is_graphql_request(request):
+        return
+
+    query, variables = _parse_graphql_body(request)
+    operation = _extract_operation_name(query)
+    if operation:
+        log_kwargs["graphql_operation"] = operation
+
+    if log_level == "full" and variables:
+        log_kwargs["graphql_variables"] = variables

--- a/terraso_backend/config/graphql_log.py
+++ b/terraso_backend/config/graphql_log.py
@@ -22,7 +22,10 @@ from django_structlog import signals
 
 
 def _get_log_level():
-    """Read GRAPHQL_LOG_LEVEL at call time so code changes take effect on hot reload."""
+    """Read GRAPHQL_LOG_LEVEL at call time so code changes take effect on hot reload.
+
+    See .env.sample for description of the log levels.
+    """
     if getattr(settings, "ENV", "") != "development":
         return "minimal"
     return getattr(settings, "GRAPHQL_LOG_LEVEL", "names")

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -36,12 +36,6 @@ PROJECT_DIR = os.path.dirname(os.path.abspath(BASE_DIR))
 
 ENV = config("ENV", default="development")
 
-# Controls verbosity of GraphQL operation logging in development. Only active when ENV="development".
-# "minimal" - default Django structlog logging (no GraphQL-specific info)
-# "names"   - include GraphQL operation name in request_started/request_finished logs
-# "full"    - also include input variables (request_started) and response (request_finished)
-GRAPHQL_LOG_LEVEL = "names"
-
 DEBUG = config("DEBUG", default=False, cast=config.boolean)
 
 ALLOWED_HOSTS = config("ALLOWED_HOSTS", default="*", cast=config.list)
@@ -264,6 +258,12 @@ structlog.configure(
     wrapper_class=structlog.stdlib.BoundLogger,
     cache_logger_on_first_use=True,
 )
+
+# Controls verbosity of GraphQL operation logging in development. Only active when ENV="development".
+# "minimal" - default Django structlog logging (no GraphQL-specific info)
+# "names"   - include GraphQL operation name in request_started/request_finished logs
+# "full"    - also include input variables (request_started) and response (request_finished)
+GRAPHQL_LOG_LEVEL = "names"
 
 GRAPHENE = {
     "SCHEMA": "apps.graphql.schema.schema.schema",

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -36,6 +36,12 @@ PROJECT_DIR = os.path.dirname(os.path.abspath(BASE_DIR))
 
 ENV = config("ENV", default="development")
 
+# Controls GraphQL operation logging in development. Only active when ENV="development".
+# "minimal" - default Django structlog logging (no GraphQL-specific info)
+# "names"   - include GraphQL operation name in request_started/request_finished logs
+# "full"    - also include input variables (request_started) and response (request_finished)
+GRAPHQL_LOG_LEVEL = "full"
+
 DEBUG = config("DEBUG", default=False, cast=config.boolean)
 
 ALLOWED_HOSTS = config("ALLOWED_HOSTS", default="*", cast=config.list)
@@ -215,7 +221,7 @@ LOGGING = {
         },
         "plain_console": {
             "()": structlog.stdlib.ProcessorFormatter,
-            "processor": structlog.dev.ConsoleRenderer(),
+            "processor": structlog.dev.ConsoleRenderer(sort_keys=False),
         },
     },
     "filters": {
@@ -460,3 +466,5 @@ HUBSPOT_ACCOUNT_DELETION_FORM_API_URL = (
 GLOBAL_SOIL_ID_BUFFER_DISTANCE = config(
     "GLOBAL_SOIL_ID_BUFFER_DISTANCE", default="30000", cast=config.eval
 )
+
+import config.graphql_log  # noqa: E402, F401 — registers django_structlog signal receivers

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -36,11 +36,11 @@ PROJECT_DIR = os.path.dirname(os.path.abspath(BASE_DIR))
 
 ENV = config("ENV", default="development")
 
-# Controls GraphQL operation logging in development. Only active when ENV="development".
+# Controls verbosity of GraphQL operation logging in development. Only active when ENV="development".
 # "minimal" - default Django structlog logging (no GraphQL-specific info)
 # "names"   - include GraphQL operation name in request_started/request_finished logs
 # "full"    - also include input variables (request_started) and response (request_finished)
-GRAPHQL_LOG_LEVEL = "full"
+GRAPHQL_LOG_LEVEL = "names"
 
 DEBUG = config("DEBUG", default=False, cast=config.boolean)
 

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -259,11 +259,8 @@ structlog.configure(
     cache_logger_on_first_use=True,
 )
 
-# Controls verbosity of GraphQL operation logging in development. Only active when ENV="development".
-# "minimal" - default Django structlog logging (no GraphQL-specific info)
-# "names"   - include GraphQL operation name in request_started/request_finished logs
-# "full"    - also include input variables (request_started) and response (request_finished)
-GRAPHQL_LOG_LEVEL = "names"
+# See .env.sample for description of the log levels
+GRAPHQL_LOG_LEVEL = config("GRAPHQL_LOG_LEVEL", default="names")
 
 GRAPHENE = {
     "SCHEMA": "apps.graphql.schema.schema.schema",

--- a/terraso_backend/tests/test_graphql_log.py
+++ b/terraso_backend/tests/test_graphql_log.py
@@ -1,0 +1,278 @@
+# Copyright © 2021-2025 Technology Matters
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see https://www.gnu.org/licenses/.
+
+import json
+
+import pytest
+from config.graphql_log import (
+    _extract_operation_name,
+    add_graphql_error_info,
+    add_graphql_request_info,
+    add_graphql_response_info,
+)
+from django.test import RequestFactory, override_settings
+
+# NOTE: This tests the graphql info displayed in development-only console logs, so it should not be relevant for product code
+
+
+@pytest.mark.unit
+class TestExtractOperationName:
+    def test_named_query(self):
+        assert (
+            _extract_operation_name("query userSoilData { soil { id } }") == "userSoilData (query)"
+        )
+
+    def test_named_mutation(self):
+        query = "mutation updateSite($input: Input!) { updateSite(input: $input) { id } }"
+        assert _extract_operation_name(query) == "updateSite (mutation)"
+
+    def test_named_subscription(self):
+        assert (
+            _extract_operation_name("subscription onUpdate { updated { id } }")
+            == "onUpdate (subscription)"
+        )
+
+    def test_anonymous_query_with_fields(self):
+        assert (
+            _extract_operation_name("{ sites { id } users { name } }")
+            == "Anonymous: [sites, users] (query)"
+        )
+
+    def test_anonymous_explicit_query(self):
+        assert _extract_operation_name("query { sites { id } }") == "Anonymous: [sites] (query)"
+
+    def test_empty_query(self):
+        assert _extract_operation_name("") is None
+        assert _extract_operation_name(None) is None
+
+    def test_multiline_query(self):
+        query = """
+        query getSiteData($id: ID!) {
+            site(id: $id) {
+                name
+            }
+        }
+        """
+        assert _extract_operation_name(query) == "getSiteData (query)"
+
+
+def _make_graphql_request(body):
+    factory = RequestFactory()
+    return factory.post(
+        "/graphql/",
+        data=json.dumps(body),
+        content_type="application/json",
+    )
+
+
+# These handlers are called by django_structlog signals:
+# - add_graphql_request_info  -> bind_extra_request_metadata    -> enriches "request_started" log
+# - add_graphql_response_info -> bind_extra_request_finished_metadata -> enriches "request_finished" log
+# - add_graphql_error_info    -> bind_extra_request_failed_metadata   -> enriches "request_failed" log
+
+
+@pytest.mark.unit
+class TestAddGraphqlRequestInfo:
+    @override_settings(ENV="development", GRAPHQL_LOG_LEVEL="names")
+    def test_names_adds_operation(self):
+        request = _make_graphql_request({"query": "query getSites { sites { id } }"})
+        log_kwargs = {}
+        add_graphql_request_info(request=request, logger=None, log_kwargs=log_kwargs, sender=None)
+        assert log_kwargs["graphql_operation"] == "getSites (query)"
+        assert "graphql_variables" not in log_kwargs
+
+    @override_settings(ENV="development", GRAPHQL_LOG_LEVEL="full")
+    def test_full_adds_variables(self):
+        request = _make_graphql_request(
+            {
+                "query": "mutation updateSite($id: ID!) { updateSite(id: $id) { id } }",
+                "variables": {"id": "123"},
+            }
+        )
+        log_kwargs = {}
+        add_graphql_request_info(request=request, logger=None, log_kwargs=log_kwargs, sender=None)
+        assert log_kwargs["graphql_operation"] == "updateSite (mutation)"
+        assert log_kwargs["graphql_variables"] == {"id": "123"}
+
+    @override_settings(ENV="development", GRAPHQL_LOG_LEVEL="minimal")
+    def test_minimal_adds_nothing(self):
+        request = _make_graphql_request({"query": "query getSites { sites { id } }"})
+        log_kwargs = {}
+        add_graphql_request_info(request=request, logger=None, log_kwargs=log_kwargs, sender=None)
+        assert log_kwargs == {}
+
+    @override_settings(ENV="production", GRAPHQL_LOG_LEVEL="names")
+    def test_non_dev_env_adds_nothing(self):
+        request = _make_graphql_request({"query": "query getSites { sites { id } }"})
+        log_kwargs = {}
+        add_graphql_request_info(request=request, logger=None, log_kwargs=log_kwargs, sender=None)
+        assert log_kwargs == {}
+
+    @override_settings(ENV="development", GRAPHQL_LOG_LEVEL="names")
+    def test_non_graphql_request_ignored(self):
+        factory = RequestFactory()
+        request = factory.post("/api/other/", data="{}", content_type="application/json")
+        log_kwargs = {}
+        add_graphql_request_info(request=request, logger=None, log_kwargs=log_kwargs, sender=None)
+        assert log_kwargs == {}
+
+    @override_settings(ENV="development", GRAPHQL_LOG_LEVEL="full")
+    def test_full_no_variables(self):
+        request = _make_graphql_request({"query": "query getSites { sites { id } }"})
+        log_kwargs = {}
+        add_graphql_request_info(request=request, logger=None, log_kwargs=log_kwargs, sender=None)
+        assert "graphql_variables" not in log_kwargs
+
+    @override_settings(ENV="development", GRAPHQL_LOG_LEVEL="names")
+    def test_malformed_json_does_not_crash(self):
+        factory = RequestFactory()
+        request = factory.post("/graphql/", data="not json", content_type="application/json")
+        log_kwargs = {}
+        add_graphql_request_info(request=request, logger=None, log_kwargs=log_kwargs, sender=None)
+        assert log_kwargs == {}
+
+    @override_settings(ENV="development", GRAPHQL_LOG_LEVEL="names")
+    def test_get_request_ignored(self):
+        factory = RequestFactory()
+        request = factory.get("/graphql/")
+        log_kwargs = {}
+        add_graphql_request_info(request=request, logger=None, log_kwargs=log_kwargs, sender=None)
+        assert log_kwargs == {}
+
+
+@pytest.mark.unit
+class TestAddGraphqlResponseInfo:
+    @override_settings(ENV="development", GRAPHQL_LOG_LEVEL="names")
+    def test_names_adds_operation(self):
+        request = _make_graphql_request({"query": "query getSites { sites { id } }"})
+
+        class FakeResponse:
+            content = b'{"data": {}}'
+
+        log_kwargs = {}
+        add_graphql_response_info(
+            request=request,
+            logger=None,
+            response=FakeResponse(),
+            log_kwargs=log_kwargs,
+            sender=None,
+        )
+        assert log_kwargs["graphql_operation"] == "getSites (query)"
+        assert "graphql_response" not in log_kwargs
+
+    @override_settings(ENV="development", GRAPHQL_LOG_LEVEL="full")
+    def test_full_adds_response(self):
+        request = _make_graphql_request({"query": "query getSites { sites { id } }"})
+
+        class FakeResponse:
+            content = b'{"data": {"sites": []}}'
+
+        log_kwargs = {}
+        add_graphql_response_info(
+            request=request,
+            logger=None,
+            response=FakeResponse(),
+            log_kwargs=log_kwargs,
+            sender=None,
+        )
+        assert log_kwargs["graphql_operation"] == "getSites (query)"
+        assert log_kwargs["graphql_response"] == {"data": {"sites": []}}
+
+    @override_settings(ENV="development", GRAPHQL_LOG_LEVEL="names")
+    def test_names_flags_graphql_errors(self):
+        request = _make_graphql_request({"query": "query getSites { sites { id } }"})
+
+        class FakeResponse:
+            content = b'{"errors": [{"message": "Not found"}]}'
+
+        log_kwargs = {}
+        add_graphql_response_info(
+            request=request,
+            logger=None,
+            response=FakeResponse(),
+            log_kwargs=log_kwargs,
+            sender=None,
+        )
+        assert log_kwargs["graphql_has_errors"] is True
+
+    @override_settings(ENV="development", GRAPHQL_LOG_LEVEL="names")
+    def test_names_no_error_flag_on_success(self):
+        request = _make_graphql_request({"query": "query getSites { sites { id } }"})
+
+        class FakeResponse:
+            content = b'{"data": {"sites": []}}'
+
+        log_kwargs = {}
+        add_graphql_response_info(
+            request=request,
+            logger=None,
+            response=FakeResponse(),
+            log_kwargs=log_kwargs,
+            sender=None,
+        )
+        assert "graphql_has_errors" not in log_kwargs
+
+    @override_settings(ENV="development", GRAPHQL_LOG_LEVEL="names")
+    def test_partial_errors_flagged(self):
+        """GraphQL can return both data and errors (partial success)."""
+        request = _make_graphql_request({"query": "query getSites { sites { id } }"})
+
+        class FakeResponse:
+            content = b'{"data": {"sites": []}, "errors": [{"message": "Partial failure"}]}'
+
+        log_kwargs = {}
+        add_graphql_response_info(
+            request=request,
+            logger=None,
+            response=FakeResponse(),
+            log_kwargs=log_kwargs,
+            sender=None,
+        )
+        assert log_kwargs["graphql_has_errors"] is True
+
+
+@pytest.mark.unit
+class TestAddGraphqlErrorInfo:
+    @override_settings(ENV="development", GRAPHQL_LOG_LEVEL="names")
+    def test_names_adds_operation_on_exception(self):
+        request = _make_graphql_request({"query": "mutation updateSite { update { id } }"})
+        log_kwargs = {}
+        add_graphql_error_info(
+            request=request,
+            logger=None,
+            exception=Exception("boom"),
+            log_kwargs=log_kwargs,
+            sender=None,
+        )
+        assert log_kwargs["graphql_operation"] == "updateSite (mutation)"
+
+    @override_settings(ENV="development", GRAPHQL_LOG_LEVEL="full")
+    def test_full_adds_variables_on_exception(self):
+        request = _make_graphql_request(
+            {
+                "query": "mutation updateSite($id: ID!) { updateSite(id: $id) { id } }",
+                "variables": {"id": "123"},
+            }
+        )
+        log_kwargs = {}
+        add_graphql_error_info(
+            request=request,
+            logger=None,
+            exception=Exception("boom"),
+            log_kwargs=log_kwargs,
+            sender=None,
+        )
+        assert log_kwargs["graphql_operation"] == "updateSite (mutation)"
+        assert log_kwargs["graphql_variables"] == {"id": "123"}


### PR DESCRIPTION
## Description
- The new `GRAPHQL_LOG_LEVEL` in settings.py has 3 verbosity options:
  - `minimal`: what's logged today
  - `names` (default): includes above, plus name of graphql operation and if it errored
  - `full`: includes above, plus input variables and output data
- django_structlog is middleware that handles logging. It sends django [signals](https://django-structlog.readthedocs.io/en/latest/api_documentation.html#django_structlog.signals.bind_extra_request_failed_metadata) that allow our new receivers to customize log metadata. The receivers need to be registered by importing the module.
- Note: It's annoying that logs are duplicated, but this was the case before my changes.

**Level of scrutiny**: 2/5 -- I used claude code to write this, and reviewed at a high level, but didn't read every line. I manually tested and got claude to write unit tests that I also reviewed at a high level. It should just affect logging in development environments, so seems low risk. But let me know if you think this merits closer inspection.

### Example:
(With "full" log level)
<img width="935" height="221" alt="Screenshot 2026-01-28 at 11 30 30 AM" src="https://github.com/user-attachments/assets/ada75edd-99a2-4e7b-8077-0504a603fdcb" />


### Related Issues
Implements https://github.com/techmatters/terraso-product/issues/1514

### Verification steps
- As a developer, run the server. Take actions, and confirm you can see the names of the graphql operations in the console logs. 
- Update GRAPHQL_LOG_LEVEL in settings.py to "full" or "minimal". Make sure you see the correct amount of info in console logs.
- Run tests
