### PR TITLE
fix: correct production API URL in doc HTML files

### DIFF
--- a/terraso_backend/apps/export/docs/csv_dynamic_wp.html
+++ b/terraso_backend/apps/export/docs/csv_dynamic_wp.html
@@ -15,7 +15,7 @@
       BASE = "https://api.staging.terraso.net/export/docs";
       sheetsId = "1D8HTWaUkHQJZ5CQKQ7FvHwA6BjPPdGIC4YSv_LfdCDY";
     } else if (host === "landpks.terraso.org") {
-      BASE = "https://api.terraso.net/export/docs";
+      BASE = "https://api.terraso.org/export/docs";
       sheetsId = "1hNw0zCOuZ9td3ueWMXNZZahEagIDeGt8ryCreyNyqGc";
     } else {
       BASE = "http://localhost:8000/export/docs";

--- a/terraso_backend/apps/export/docs/json_dynamic_fields_wp.html
+++ b/terraso_backend/apps/export/docs/json_dynamic_fields_wp.html
@@ -15,7 +15,7 @@
       BASE = "https://api.staging.terraso.net/export/docs";
       sheetsId = "1D8HTWaUkHQJZ5CQKQ7FvHwA6BjPPdGIC4YSv_LfdCDY";
     } else if (host === "landpks.terraso.org") {
-      BASE = "https://api.terraso.net/export/docs";
+      BASE = "https://api.terraso.org/export/docs";
       sheetsId = "1hNw0zCOuZ9td3ueWMXNZZahEagIDeGt8ryCreyNyqGc";
     } else {
       BASE = "http://localhost:8000/export/docs";

--- a/terraso_backend/apps/export/docs/json_dynamic_hierarchy_wp.html
+++ b/terraso_backend/apps/export/docs/json_dynamic_hierarchy_wp.html
@@ -15,7 +15,7 @@
       BASE = "https://api.staging.terraso.net/export/docs";
       sheetsId = "1D8HTWaUkHQJZ5CQKQ7FvHwA6BjPPdGIC4YSv_LfdCDY";
     } else if (host === "landpks.terraso.org") {
-      BASE = "https://api.terraso.net/export/docs";
+      BASE = "https://api.terraso.org/export/docs";
       sheetsId = "1hNw0zCOuZ9td3ueWMXNZZahEagIDeGt8ryCreyNyqGc";
     } else {
       BASE = "http://localhost:8000/export/docs";

--- a/terraso_backend/apps/export/docs/json_dynamic_tree_wp.html
+++ b/terraso_backend/apps/export/docs/json_dynamic_tree_wp.html
@@ -15,7 +15,7 @@
       BASE = "https://api.staging.terraso.net/export/docs";
       sheetsId = "1D8HTWaUkHQJZ5CQKQ7FvHwA6BjPPdGIC4YSv_LfdCDY";
     } else if (host === "landpks.terraso.org") {
-      BASE = "https://api.terraso.net/export/docs";
+      BASE = "https://api.terraso.org/export/docs";
       sheetsId = "1hNw0zCOuZ9td3ueWMXNZZahEagIDeGt8ryCreyNyqGc";
     } else {
       BASE = "http://localhost:8000/export/docs";


### PR DESCRIPTION
Change api.terraso.net to api.terraso.org

This was a typo; only affects the .html files which are copied into wordpress, doesn't change actual backend.

See in operation here: 
https://landpks.terraso.org/help/export-csv/
https://landpks.terraso.org/help/export-json/
