### PR TITLE
feat: prepare for gunicorn gthread workers to improve concurrency

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,6 +2,7 @@ ENV=development
 DEBUG=True
 PORT=8000
 WEB_CONCURRENCY=2
+GUNICORN_CMD_ARGS=--worker-class gthread --threads 8
 SECRET_KEY=super-sekret-that-must-be-changed-on-serious-environments
 DATABASE_URL=postgres://postgres:postgres@db:5432/terraso_backend
 DATABASE_EXTERNAL_PORT=5432

--- a/Makefile
+++ b/Makefile
@@ -104,19 +104,14 @@ setup-git-hooks:
 run: check_rebuild
 	@./scripts/docker.sh "$(DC_FILE_ARG)"
 
-# Run with gunicorn + gthread workers to match production threading behavior.
+# Run with gunicorn to match production threading behavior.
 # Unlike "make run", this does NOT auto-reload on code changes — restart manually.
-# Useful for testing concurrency (e.g. parallel curl requests to confirm threading).
-# Production recommendation: --workers 2 --threads 8 (16 concurrent requests).
-# Workers are OS processes (~350MB each); threads are cheap and share memory.
-# Threads help most for I/O-bound work (DB queries, external API calls).
+# Reads WEB_CONCURRENCY and GUNICORN_CMD_ARGS from .env (same values used on Render).
+# Useful for testing concurrency locally before deploying to production.
 run-gunicorn: check_rebuild
 	docker compose $(DC_FILE_ARG) run --rm -p 8000:8000 web \
 		gunicorn config.wsgi:application \
 		--bind 0.0.0.0:8000 \
-		--worker-class gthread \
-		--threads 8 \
-		--workers 2 \
 		--chdir /app/terraso_backend
 
 setup: build setup-pre-commit

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,21 @@ setup-git-hooks:
 run: check_rebuild
 	@./scripts/docker.sh "$(DC_FILE_ARG)"
 
+# Run with gunicorn + gthread workers to match production threading behavior.
+# Unlike "make run", this does NOT auto-reload on code changes — restart manually.
+# Useful for testing concurrency (e.g. parallel curl requests to confirm threading).
+# Production recommendation: --workers 2 --threads 8 (16 concurrent requests).
+# Workers are OS processes (~350MB each); threads are cheap and share memory.
+# Threads help most for I/O-bound work (DB queries, external API calls).
+run-gunicorn: check_rebuild
+	docker compose $(DC_FILE_ARG) run --rm -p 8000:8000 web \
+		gunicorn config.wsgi:application \
+		--bind 0.0.0.0:8000 \
+		--worker-class gthread \
+		--threads 8 \
+		--workers 2 \
+		--chdir /app/terraso_backend
+
 setup: build setup-pre-commit
 
 start-%:

--- a/README.md
+++ b/README.md
@@ -53,6 +53,32 @@ $ python terraso_backend/manage.py createsuperuser
 $ exit
 ```
 
+## Running with gunicorn (production-like)
+
+`make run` uses Django's single-threaded development server. To test with
+production-like concurrency, use:
+
+```sh
+$ make run-gunicorn
+```
+
+This launches gunicorn inside Docker, reading its configuration from `.env`:
+
+- `WEB_CONCURRENCY` — number of worker processes (OS-level parallelism, ~350MB each)
+- `GUNICORN_CMD_ARGS` — extra flags, e.g. `--worker-class gthread --threads 8`
+
+With `WEB_CONCURRENCY=2` and `--threads 8`, you get 2 workers x 8 threads = 16
+concurrent requests. Workers provide true parallelism; threads within a worker
+share memory and take turns on CPU (Python GIL) but can all wait on I/O (database
+queries, HTTP calls) simultaneously.
+
+These are the same env vars used on Render, so you can test locally with the exact
+values you plan to deploy.
+
+Note: gunicorn does not support hot-reload — code changes require a manual restart.
+For day-to-day development, use `make run` which auto-reloads on save. Use
+`make run-gunicorn` when you need to test concurrency or production-like behavior.
+
 ## Debugging locally with Docker
 
 To debug while running tests, just use regular Python `breakpoint()` and

--- a/terraso_backend/apps/export/fetch_data.py
+++ b/terraso_backend/apps/export/fetch_data.py
@@ -15,6 +15,7 @@
 
 import csv
 import os
+import threading
 
 import structlog
 from django.conf import settings
@@ -25,8 +26,12 @@ from .depth_helpers import depth_key, get_visible_intervals
 
 logger = structlog.get_logger(__name__)
 
-# In-memory cache for soil_id data, used to avoid external API calls during tests.
-# Keyed by site ID (string UUID).
+# Lock protecting the module-level caches below against concurrent access
+# from multiple gthread worker threads.
+_cache_lock = threading.Lock()
+
+# In-memory cache for soil_id data, only populated during tests (via cache_soil_id
+# in fixture_loader.py) to avoid external API calls. Never written to in production.
 _soil_id_cache = {}
 
 # Set to False to disable cache (for development/testing without cache)
@@ -46,31 +51,36 @@ def _load_munsell_lab_table():
     if _munsell_lab_table is not None:
         return _munsell_lab_table
 
-    try:
-        from soil_id.config import MUNSELL_RGB_LAB_PATH
+    with _cache_lock:
+        # Double-check after acquiring lock
+        if _munsell_lab_table is not None:
+            return _munsell_lab_table
 
-        path = MUNSELL_RGB_LAB_PATH
-    except ImportError:
-        path = os.path.join(os.environ.get("DATA_PATH", "Data"), "LandPKS_munsell_rgb_lab.csv")
+        try:
+            from soil_id.config import MUNSELL_RGB_LAB_PATH
 
-    table = {}
-    try:
-        with open(path, newline="") as f:
-            for row in csv.DictReader(f):
-                hue = row["hue"]
-                value = int(row["value"])
-                chroma = int(row["chroma"])
-                table[(hue, value, chroma)] = (
-                    float(row["cielab_l"]),
-                    float(row["cielab_a"]),
-                    float(row["cielab_b"]),
-                )
-    except FileNotFoundError:
-        logger.warning("Munsell-to-LAB lookup table not found", path=path)
+            path = MUNSELL_RGB_LAB_PATH
+        except ImportError:
+            path = os.path.join(os.environ.get("DATA_PATH", "Data"), "LandPKS_munsell_rgb_lab.csv")
+
         table = {}
+        try:
+            with open(path, newline="") as f:
+                for row in csv.DictReader(f):
+                    hue = row["hue"]
+                    value = int(row["value"])
+                    chroma = int(row["chroma"])
+                    table[(hue, value, chroma)] = (
+                        float(row["cielab_l"]),
+                        float(row["cielab_a"]),
+                        float(row["cielab_b"]),
+                    )
+        except FileNotFoundError:
+            logger.warning("Munsell-to-LAB lookup table not found", path=path)
+            table = {}
 
-    _munsell_lab_table = table
-    return _munsell_lab_table
+        _munsell_lab_table = table
+        return _munsell_lab_table
 
 
 def munsell_to_lab(color_hue, color_value, color_chroma):
@@ -111,18 +121,21 @@ def munsell_to_lab(color_hue, color_value, color_chroma):
 def set_soil_id_cache_enabled(enabled):
     """Enable or disable the soil_id cache."""
     global _USE_SOIL_ID_CACHE
-    _USE_SOIL_ID_CACHE = enabled
+    with _cache_lock:
+        _USE_SOIL_ID_CACHE = enabled
 
 
 def cache_soil_id(site_id, soil_id_data):
     """Store soil_id data in cache for a site."""
-    if _USE_SOIL_ID_CACHE:
-        _soil_id_cache[str(site_id)] = soil_id_data
+    with _cache_lock:
+        if _USE_SOIL_ID_CACHE:
+            _soil_id_cache[str(site_id)] = soil_id_data
 
 
 def clear_soil_id_cache():
     """Clear all cached soil_id data."""
-    _soil_id_cache.clear()
+    with _cache_lock:
+        _soil_id_cache.clear()
 
 
 def fetch_all_notes_for_site(site_id, request, page_size=settings.EXPORT_PAGE_SIZE):
@@ -278,8 +291,9 @@ def fetch_soil_id(site, request):
     site_id = site.get("id")
 
     # Check cache first (if enabled)
-    if _USE_SOIL_ID_CACHE and site_id and str(site_id) in _soil_id_cache:
-        return _soil_id_cache[str(site_id)]
+    with _cache_lock:
+        if _USE_SOIL_ID_CACHE and site_id and str(site_id) in _soil_id_cache:
+            return _soil_id_cache[str(site_id)]
 
     latitude = site.get("latitude")
     longitude = site.get("longitude")

--- a/terraso_backend/apps/soil_id/graphql/soil_id/resolvers.py
+++ b/terraso_backend/apps/soil_id/graphql/soil_id/resolvers.py
@@ -14,6 +14,7 @@
 # along with this program. If not, see https://www.gnu.org/licenses/.
 
 import math
+import threading
 import traceback
 from typing import Optional
 
@@ -47,15 +48,15 @@ from apps.soil_id.models.soil_id_cache import SoilIdCache
 
 logger = structlog.get_logger(__name__)
 
-_soil_id_database_connection = None
+_soil_id_thread_local = threading.local()
 
 
 def soil_id_database_connection():
-    global _soil_id_database_connection
-    if _soil_id_database_connection is None:
-        _soil_id_database_connection = psycopg.connect(SOIL_ID_DATABASE_URL)
-
-    return _soil_id_database_connection
+    conn = getattr(_soil_id_thread_local, "connection", None)
+    if conn is None or conn.closed:
+        conn = psycopg.connect(SOIL_ID_DATABASE_URL)
+        _soil_id_thread_local.connection = conn
+    return conn
 
 
 def resolve_texture(texture: Optional[str | float]):

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -132,7 +132,11 @@ PRIMARY_DATABASE_URL = config("DATABASE_URL", default=default_dburl)
 SOIL_ID_DATABASE_URL = config("SOIL_ID_DATABASE_URL", default=PRIMARY_DATABASE_URL)
 
 DATABASES = {
-    "default": parse_db_url(PRIMARY_DATABASE_URL),
+    "default": {
+        **parse_db_url(PRIMARY_DATABASE_URL),
+        "CONN_MAX_AGE": int(config("CONN_MAX_AGE", default="600")),
+        "CONN_HEALTH_CHECKS": True,
+    },
 }
 
 AUTHENTICATION_BACKENDS = (


### PR DESCRIPTION
Currently two workers each one thread so at most two concurrent calls to backend.

Pretty bad if doing export which can take a long time.
Might be bad for offline when client coming online does a bunch of things all at once (keeping server busy).
I say "might" because not sure how much effect in the real-world (usually the server isn't very busy at all).

This change should only affect scalability, not behavior and is not required for offline, but might improve performance.

Make shared state thread-safe for gthread worker model:
- Use threading.local() for soil ID database connection (was global shared)
- Add threading.Lock() around export caches and lazy-loaded munsell table
- Set CONN_MAX_AGE=600 with health checks for persistent thread connections
- Add make run-gunicorn target for local concurrency testing

To enable in production, set: GUNICORN_CMD_ARGS=--worker-class gthread --threads 8

With WEB_CONCURRENCY=2 and GUNICORN_CMD_ARGS=--worker-class gthread --threads 8, up to 16 calls can be handled at once, which should be plenty and this shouldn't increase our server cost at all. 

If needed, both numbers could be increased, but there are some tradeoffs; more CONCURRENCY scales well but uses ~350MB for each so eventually we'd need to play for more memory.  --threads costs almost nothing and scales well if all IO bound, but not so well for CPU work.  probably we are mostly IO bound, but not entirely, some of the algorithms for soil id, etc.