### PR TITLE
fix: backfill empty user names on subsequent sign-ins

### DIFF
--- a/terraso_backend/apps/auth/services.py
+++ b/terraso_backend/apps/auth/services.py
@@ -106,39 +106,29 @@ class AccountService:
 
         start_update_profile_image_task(user.id, profile_image_url)
 
-        if not created:
-            # Backfill empty names if the provider sent them this time (e.g. Apple
-            # Sign In after a user revokes the app from their Apple ID and re-auths
-            # — Apple only returns the name on a "first" authorization).
-            # Only fill in *empty* fields; never overwrite a name the user may have
-            # edited themselves.
-            backfill = False
-            if first_name and not user.first_name:
-                user.first_name = first_name
-                backfill = True
-            if last_name and not user.last_name:
-                user.last_name = last_name
-                backfill = True
-            if backfill:
-                user.save()
-            return user, False
+        if created:
+            self._set_default_preferences(user)
 
-        self._set_default_preferences(user)
-
-        update_name = first_name or last_name
-
-        if first_name:
+        # Populate first_name / last_name if the provider supplied them and the
+        # current value is empty. Never overwrites a non-empty name (which may
+        # have been edited by the user, or supplied on a prior sign-in).
+        # For brand-new users this trivially fills the fields; for existing
+        # users this acts as a backfill — notably for Apple Sign In, where
+        # Apple only returns the name on the very first authorization.
+        name_changed = False
+        if first_name and not user.first_name:
             user.first_name = first_name
-
-        if last_name:
+            name_changed = True
+        if last_name and not user.last_name:
             user.last_name = last_name
-
-        if update_name:
+            name_changed = True
+        if name_changed:
             user.save()
 
-        user_signup_signal.send(sender=self.__class__, user=user)
+        if created:
+            user_signup_signal.send(sender=self.__class__, user=user)
 
-        return user, True
+        return user, created
 
     def _update_profile_image(self, user, profile_image_url):
         if not profile_image_url:

--- a/terraso_backend/apps/auth/services.py
+++ b/terraso_backend/apps/auth/services.py
@@ -107,6 +107,20 @@ class AccountService:
         start_update_profile_image_task(user.id, profile_image_url)
 
         if not created:
+            # Backfill empty names if the provider sent them this time (e.g. Apple
+            # Sign In after a user revokes the app from their Apple ID and re-auths
+            # — Apple only returns the name on a "first" authorization).
+            # Only fill in *empty* fields; never overwrite a name the user may have
+            # edited themselves.
+            backfill = False
+            if first_name and not user.first_name:
+                user.first_name = first_name
+                backfill = True
+            if last_name and not user.last_name:
+                user.last_name = last_name
+                backfill = True
+            if backfill:
+                user.save()
             return user, False
 
         self._set_default_preferences(user)

--- a/terraso_backend/apps/auth/views.py
+++ b/terraso_backend/apps/auth/views.py
@@ -383,6 +383,31 @@ class TokenExchangeView(View):
         except TokenExchangeException as e:
             return self._token_error(e)
 
+        # Reject early if the JWT didn't include an email claim. Some providers
+        # (notably Apple in certain degraded auth states; Microsoft in some
+        # tenant configurations) can return a valid id_token that omits email,
+        # in which case we have nothing to identify or create the user with.
+        # Until we add a sub-based fallback lookup, the only correct response
+        # is a 4xx so the client gets a clear error instead of a 500.
+        if not payload.get("email"):
+            logger.warning(
+                "token_exchange_rejected",
+                reason="missing_email",
+                provider=contents.get("provider"),
+                iss=payload.get("iss"),
+                sub=payload.get("sub"),
+            )
+            return JsonResponse(
+                {
+                    "error": "missing_email",
+                    "detail": (
+                        "The provider's id_token did not include an email claim. "
+                        "Cannot identify or create a user without an email."
+                    ),
+                },
+                status=400,
+            )
+
         # Allow client-supplied names to override or fill in JWT-derived names.
         # Apple's id_token never includes name claims; the iOS Sign in with Apple
         # SDK only exposes the user's name on the *very first* authorization,

--- a/terraso_backend/apps/auth/views.py
+++ b/terraso_backend/apps/auth/views.py
@@ -383,6 +383,19 @@ class TokenExchangeView(View):
         except TokenExchangeException as e:
             return self._token_error(e)
 
+        # Allow client-supplied names to override or fill in JWT-derived names.
+        # Apple's id_token never includes name claims; the iOS Sign in with Apple
+        # SDK only exposes the user's name on the *very first* authorization,
+        # via the credential's fullName property. The mobile app captures it
+        # then and forwards it here as first_name/last_name in the request body.
+        # Combined with the backfill in AccountService._persist_user, this lets
+        # us populate the name on either a brand-new user or an existing user
+        # whose name field is currently empty.
+        if first_name := contents.get("first_name"):
+            payload["given_name"] = first_name
+        if last_name := contents.get("last_name"):
+            payload["family_name"] = last_name
+
         user, created = self._create_or_fetch_user(**payload)
         access_token, refresh_token = terraso_login(request, user)
         resp_payload = {

--- a/terraso_backend/tests/auth/test_token_exchange.py
+++ b/terraso_backend/tests/auth/test_token_exchange.py
@@ -179,3 +179,80 @@ def test_token_exchange_is_new_account_false(client, private_key, payload):
     contents = resp.json()
     assert contents["is_new_account"] is False
     assert User.objects.filter(email="existinguser@example.org").count() == 1
+
+
+def test_token_exchange_client_supplied_names_new_user(client, private_key, payload):
+    """Client-supplied first_name/last_name are used when creating a new user.
+    Simulates the mobile Apple Sign In flow: Apple's JWT has no name claims, so
+    the mobile app captures fullName from the credential and sends it alongside."""
+    # Strip name claims from JWT to mimic Apple's id_token (which never has them)
+    payload["email"] = "appleuser@example.org"
+    del payload["given_name"]
+    del payload["family_name"]
+
+    resp = client.post(
+        reverse("apps.auth:token-exchange"),
+        content_type="application/json",
+        data={
+            "jwt": sign_payload(payload, private_key),
+            "provider": "example",
+            "first_name": "Jane",
+            "last_name": "Appleseed",
+        },
+    )
+    contents = resp.json()
+    assert contents["is_new_account"] is True
+    user = User.objects.get(email="appleuser@example.org")
+    assert user.first_name == "Jane"
+    assert user.last_name == "Appleseed"
+
+
+def test_token_exchange_client_supplied_names_backfill_existing(client, private_key, payload):
+    """Client-supplied names backfill an existing user whose name fields are empty.
+    This is the post-revoke Apple Sign In path: the user already exists but came in
+    via a previous Apple sign-in that didn't capture the name."""
+    payload["email"] = "nameless@example.org"
+    del payload["given_name"]
+    del payload["family_name"]
+    User.objects.create(email="nameless@example.org", first_name="", last_name="")
+
+    resp = client.post(
+        reverse("apps.auth:token-exchange"),
+        content_type="application/json",
+        data={
+            "jwt": sign_payload(payload, private_key),
+            "provider": "example",
+            "first_name": "Jane",
+            "last_name": "Appleseed",
+        },
+    )
+    assert resp.json()["is_new_account"] is False
+    user = User.objects.get(email="nameless@example.org")
+    assert user.first_name == "Jane"
+    assert user.last_name == "Appleseed"
+
+
+def test_token_exchange_client_supplied_names_do_not_overwrite_existing(
+    client, private_key, payload
+):
+    """Client-supplied names must NOT overwrite a non-empty name on an existing user.
+    Users may have edited their name in-app — we never clobber their choice."""
+    payload["email"] = "named@example.org"
+    del payload["given_name"]
+    del payload["family_name"]
+    User.objects.create(email="named@example.org", first_name="Existing", last_name="Name")
+
+    resp = client.post(
+        reverse("apps.auth:token-exchange"),
+        content_type="application/json",
+        data={
+            "jwt": sign_payload(payload, private_key),
+            "provider": "example",
+            "first_name": "Should",
+            "last_name": "Not Win",
+        },
+    )
+    assert resp.json()["is_new_account"] is False
+    user = User.objects.get(email="named@example.org")
+    assert user.first_name == "Existing"
+    assert user.last_name == "Name"


### PR DESCRIPTION
Previously _persist_user only wrote first_name/last_name when creating a brand-new user, so any user whose name was missing on first signup (notably Apple Sign In users, where Apple only returns the name on the very first authorization) was stuck with an empty name forever — even if a later sign-in via Google/Microsoft/Apple-after-revoke supplied the name.

Now, on every sign-in, if the provider sends a name and the existing user record's corresponding field is empty, we fill it in. We never overwrite a non-empty name, so users who have edited their name in the app are unaffected.

Todo: may still want to figure out why Apple doesn't return the name more often, and this might not be fixable, so we should consider adding a way for the user to edit.  But that is separate from this PR.