### PR TITLE
feat: move .env outside repo (~/secrets/terraso-backend/.env)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "deny": [
+      "Read(~/secrets/**)",
+      "Read(.env)",
+      "Read(.env.*)",
+      "Read(.envrc)",
+      "Bash(env*)",
+      "Bash(printenv*)",
+      "Bash(cat ~/secrets/*)",
+      "Bash(cat .env*)",
+      "Bash(echo $*)"
+    ]
+  }
+}

--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,16 @@
+# Local development env file template.
+#
+# Save your filled-in copy at ~/secrets/terraso-backend/.env (NOT inside this
+# repo). The Makefile and docker-compose.base.yml resolve env_file paths
+# against $HOME/secrets/terraso-backend/.env.  Keeping the file outside the
+# repo tree limits what AI assistants and other tools can read while browsing
+# the project.
+#
+# One-time setup:
+#   mkdir -p ~/secrets/terraso-backend
+#   cp .env.sample ~/secrets/terraso-backend/.env
+#   # then edit values
+
 ENV=development
 DEBUG=True
 PORT=8000

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,8 +78,9 @@ jobs:
 
       - name: Set up env
         run: |
-          cp .env.sample .env
-          echo "SENTRY_DSN=${{ secrets.SENTRY_DSN }}" >> .env
+          mkdir -p $HOME/secrets/terraso-backend
+          cp .env.sample $HOME/secrets/terraso-backend/.env
+          echo "SENTRY_DSN=${{ secrets.SENTRY_DSN }}" >> $HOME/secrets/terraso-backend/.env
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -109,8 +110,9 @@ jobs:
 
       - name: Set up env
         run: |
-          cp .env.sample .env
-          echo "SENTRY_DSN=${{ secrets.SENTRY_DSN }}" >> .env
+          mkdir -p $HOME/secrets/terraso-backend
+          cp .env.sample $HOME/secrets/terraso-backend/.env
+          echo "SENTRY_DSN=${{ secrets.SENTRY_DSN }}" >> $HOME/secrets/terraso-backend/.env
 
       - name: Run tests using built Docker image
         env:
@@ -159,9 +161,10 @@ jobs:
 
       - name: set up env
         run: |
-          cp .env.sample .env
-          echo "SENTRY_DSN=${{ secrets.SENTRY_DSN }}" >> .env
-          echo "SOIL_ID_DATABASE_URL=postgresql://postgres:postgres@soil-id-db:5432/soil_id" >> .env
+          mkdir -p $HOME/secrets/terraso-backend
+          cp .env.sample $HOME/secrets/terraso-backend/.env
+          echo "SENTRY_DSN=${{ secrets.SENTRY_DSN }}" >> $HOME/secrets/terraso-backend/.env
+          echo "SOIL_ID_DATABASE_URL=postgresql://postgres:postgres@soil-id-db:5432/soil_id" >> $HOME/secrets/terraso-backend/.env
 
       - name: Run integration tests
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,3 +191,24 @@ Each user has their own token per resource. Tokens are automatically deleted whe
 - Token-based export URLs set `request.user` to the token owner (the user who created the token)
 - This allows normal membership filtering to work correctly without special bypass logic
 - CORS for `/export/token/*` URLs is handled by signal in `apps/export/handlers.py`
+
+## Secrets handling
+
+The `.env` file is not in the repo. Real credentials live at
+`~/secrets/terraso-backend/.env` and are loaded at runtime by
+`docker-compose.base.yml` (via the `env_file:` directive) and by the
+Makefile (via `--env-file` for `${PORT}` etc. interpolation) — they are
+not present in your interactive shell environment.
+
+When writing or modifying code or scripts that consume environment
+variables:
+
+- Never print, log, or echo values from `os.environ` (or `process.env`).
+- Never include env values in error messages or stack traces.
+- If verifying a variable is set, print only its presence
+  (`"JWT_SECRET: set"`), never the value.
+- Don't write env values into files inside the project directory.
+- Don't read `~/secrets/**` unless explicitly asked. The
+  `.claude/settings.json` deny list enforces this for Claude Code, but
+  the same expectation applies to any code or script changes you make
+  (e.g. don't add a debug `print(settings.SECRET_KEY)` even temporarily).

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 DC_ENV ?= dev
-DC_FILE_ARG = -f docker-compose.$(DC_ENV).yml
+ENV_FILE ?= $(HOME)/secrets/terraso-backend/.env
+DC_FILE_ARG = --env-file $(ENV_FILE) -f docker-compose.$(DC_ENV).yml
 DC_RUN_CMD ?= docker compose $(DC_FILE_ARG) run --quiet-pull --rm web
 
 ifeq ($(DC_ENV),ci)

--- a/README.md
+++ b/README.md
@@ -10,13 +10,19 @@ platform.
 
 ## Running locally with Docker
 
-Set up your environment file
+Set up your environment file outside the repo (so AI assistants and other
+tools browsing the project can't read it incidentally):
 
 ```sh
-$ cp .env.sample .env
+$ mkdir -p ~/secrets/terraso-backend
+$ cp .env.sample ~/secrets/terraso-backend/.env
 ```
 
-In the `.env` file
+The Makefile and `docker-compose.base.yml` resolve `env_file:` paths
+against `$HOME/secrets/terraso-backend/.env`. Override the location by
+setting `ENV_FILE=/some/other/path` before invoking `make`.
+
+In the env file
 
 -   set values for `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`based on what you have set up in console.cloud.google.com > APIs & Services > Credentials.
 

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -7,7 +7,7 @@ services:
     command: python terraso_backend/manage.py runserver 0.0.0.0:${PORT}
     labels:
       org.techmatters.project: terraso_backend
-    env_file: .env
+    env_file: ${HOME}/secrets/terraso-backend/.env
     ports:
       - '${PORT}:${PORT}'
     stdin_open: true
@@ -20,7 +20,7 @@ services:
     image: postgis/postgis:16-master
     labels:
       org.techmatters.project: terraso_backend
-    env_file: .env
+    env_file: ${HOME}/secrets/terraso-backend/.env
     volumes:
       - postgresql_data:/var/lib/postgresql/data
     hostname: postgres


### PR DESCRIPTION
Please see https://sites.gitbook.com/preview/site_FIWnZ/technical-notes/privacy-and-security

Keeping the dev .env file inside the project tree means any tool browsing the repo (AI assistants, indexers, accidental scans) can read the secrets it contains. Move it out of the repo so the secrets aren't reachable just by walking the project directory.

- docker-compose.base.yml: env_file paths use ${HOME}/secrets/terraso-backend/.env (interpolated by Compose at load time).
- Makefile: ENV_FILE defaults to $(HOME)/secrets/terraso-backend/.env; passed to docker compose via --env-file so ${PORT} et al. still interpolate. Override with ENV_FILE=/some/path make ...
- .github/workflows/build.yml: 3 "set up env" steps now write to $HOME/secrets/terraso-backend/.env (matches local-dev path on ubuntu-latest runners).
- .env.sample / README.md: setup instructions point at the new location.

Migration for existing developers (one-time):
  mkdir -p ~/secrets/terraso-backend mv .env ~/secrets/terraso-backend/.env

Cloud Run / Render unaffected — they read env vars from their own service configs, not from any .env file in the repo.
