### PR TITLE
fix(story-map): guard missing admin membership field

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     -   id: pre-commit-update
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
+    rev: v0.15.15
     hooks:
     -   id: ruff-check
         args: [--fix]

--- a/terraso_backend/apps/story_map/admin.py
+++ b/terraso_backend/apps/story_map/admin.py
@@ -68,7 +68,9 @@ class CustomStoryMapForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["membership_list"].required = False
+        membership_list_field = self.fields.get("membership_list")
+        if membership_list_field is not None:
+            membership_list_field.required = False
 
 
 @admin.register(StoryMap)

--- a/terraso_backend/tests/story_map/test_admin.py
+++ b/terraso_backend/tests/story_map/test_admin.py
@@ -15,6 +15,8 @@
 
 import pytest
 from django.contrib.admin.sites import site
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 from django.test import RequestFactory, override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -190,6 +192,21 @@ def test_story_map_admin_superuser_can_edit_configuration_fields():
 
     assert "configuration" in form_fields
     assert "published_configuration" in form_fields
+
+
+def test_story_map_admin_form_init_handles_missing_membership_list_field(client):
+    admin_user = mixer.blend(User, is_staff=True, is_superuser=False)
+    story_map = mixer.blend("story_map.StoryMap")
+    story_map_content_type = ContentType.objects.get_for_model(StoryMap)
+    admin_user.user_permissions.add(
+        Permission.objects.get(codename="view_storymap", content_type=story_map_content_type)
+    )
+
+    client.force_login(admin_user)
+
+    response = client.get(reverse("admin:story_map_storymap_change", args=[story_map.pk]))
+
+    assert response.status_code == 200
 
 
 @override_settings(WEB_CLIENT_URL="http://localhost:10000")


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
Added check for membership list for story map admin

### Checklist
- [ ] Corresponding issue has been opened
- [x] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

