### PR TITLE
fix: scope anonymous & over-broad GraphQL access (F1–F6)

### DIFF
--- a/terraso_backend/apps/export/graphql/queries.py
+++ b/terraso_backend/apps/export/graphql/queries.py
@@ -26,4 +26,10 @@ class Query(graphene.ObjectType):
     def resolve_all_export_tokens(root, info):
         """Get all export tokens for the current user."""
         user = info.context.user
+        # Reject anonymous explicitly. Without this, the filter would resolve
+        # to user_id="None" (the literal string of AnonymousUser().id), which
+        # currently happens to return [] only because no code path mints a
+        # token with that user_id. Don't rely on coincidence.
+        if user.is_anonymous:
+            return []
         return ExportToken.objects.filter(user_id=str(user.id))

--- a/terraso_backend/apps/graphql/schema/commons.py
+++ b/terraso_backend/apps/graphql/schema/commons.py
@@ -54,9 +54,18 @@ class TerrasoRelayNode(relay.Node):
 
     @staticmethod
     def get_node_from_global_id(info, global_id, only_type=None):
-        return get_nullable_type(info.return_type).graphene_type._meta.model.objects.get(
-            pk=global_id
-        )
+        # Honor the Node's get_queryset so that single-id lookups (e.g.
+        # `query { site(id: $id) { ... } }`) apply the same auth/membership
+        # filters as connection queries (`sites(...)`).  Without this, the
+        # default override of relay.Node.get_node_from_global_id would skip
+        # get_queryset entirely and leak any record by id (F2/F3).
+        node_type = only_type or get_nullable_type(info.return_type).graphene_type
+        model = node_type._meta.model
+        queryset = node_type.get_queryset(model.objects, info)
+        try:
+            return queryset.get(pk=global_id)
+        except model.DoesNotExist:
+            return None
 
 
 class TerrasoConnection(Connection):

--- a/terraso_backend/apps/graphql/schema/sites.py
+++ b/terraso_backend/apps/graphql/schema/sites.py
@@ -98,7 +98,7 @@ class SiteNode(DjangoObjectType):
         user = info.context.user
         if user.is_anonymous:
             return queryset.none()
-        return sites.filter_only_sites_user_owner_or_member(user, queryset)
+        return sites.filter_visible_sites(user, queryset)
 
     @classmethod
     def privacy_enum(cls):

--- a/terraso_backend/apps/graphql/schema/users.py
+++ b/terraso_backend/apps/graphql/schema/users.py
@@ -40,6 +40,23 @@ logger = structlog.get_logger(__name__)
 
 
 class UserFilter(FilterSet):
+    # Substring filters (`email__icontains`, `first_name__icontains`,
+    # `last_name__icontains`) can be used to harvest the user table — e.g.
+    # `users(email_Icontains: "@target.com")` returns every account at a
+    # given domain.  No production client uses them: web/mobile/shared all
+    # call only `users(email)` or `users(email_Iexact: ...)` for the
+    # userProfile and add-team-member flows (verified by grep against
+    # terraso-web-client, terraso-mobile-client, terraso-client-shared).
+    #
+    # The substring filters are kept in the schema for potential future
+    # admin/support workflows but are gated to `is_superuser=True` callers
+    # in `qs` below.  Non-superuser callers using these filters get
+    # `.none()` rather than an error: an empty result keeps the schema
+    # response valid for any client that fires a substring filter
+    # accidentally, and avoids surfacing "you would need superuser to do
+    # this" as introspection-equivalent metadata.
+    ADMIN_ONLY_FILTERS = ("email__icontains", "first_name__icontains", "last_name__icontains")
+
     project = CharFilter(method="filter_user_in_project")
 
     class Meta:
@@ -53,6 +70,17 @@ class UserFilter(FilterSet):
     def filter_user_in_project(self, queryset, name, value):
         memberships = Membership.objects.filter(membership_list__project=value)
         return queryset.filter(collaboration_memberships__in=memberships)
+
+    @property
+    def qs(self):
+        # If any admin-only filter has a non-empty value, require superuser.
+        # `self.data` is the dict of incoming filter args keyed by their
+        # Django ORM lookup name (e.g. "email__icontains").
+        if any(self.data.get(name) for name in self.ADMIN_ONLY_FILTERS):
+            user = getattr(self.request, "user", None) if self.request else None
+            if not (user and user.is_superuser):
+                return super().qs.none()
+        return super().qs
 
 
 class UserNode(DjangoObjectType):

--- a/terraso_backend/apps/graphql/schema/users.py
+++ b/terraso_backend/apps/graphql/schema/users.py
@@ -28,6 +28,7 @@ from apps.core.models.users import USER_PREFS_KEY_ACCOUNT_DELETION, USER_PREFS_K
 from apps.graphql.exceptions import GraphQLNotAllowedException
 
 from .commons import (
+    BaseAdminMutation,
     BaseAuthenticatedMutation,
     BaseDeleteMutation,
     BaseUnauthenticatedMutation,
@@ -86,7 +87,13 @@ class UserPreferenceNode(DjangoObjectType):
         connection_class = TerrasoConnection
 
 
-class UserAddMutation(BaseAuthenticatedMutation):
+# NOTE: Consider removing this mutation entirely. The legitimate user-creation
+# paths in production are /auth/token-exchange (OAuth → JWT bridge) and the
+# Django admin UI. A grep across web-client, mobile-client, client-shared and
+# techmatters scripts found no callers of this mutation; only the test in
+# test_user_mutations.py exercises it. Restricted to superuser/admin in the
+# meantime so a non-admin authenticated account can't mint arbitrary users.
+class UserAddMutation(BaseAdminMutation):
     user = graphene.Field(UserNode)
 
     class Input:

--- a/terraso_backend/apps/graphql/schema/users.py
+++ b/terraso_backend/apps/graphql/schema/users.py
@@ -57,6 +57,15 @@ class UserFilter(FilterSet):
     # this" as introspection-equivalent metadata.
     ADMIN_ONLY_FILTERS = ("email__icontains", "first_name__icontains", "last_name__icontains")
 
+    # Exact-address lookups the production clients depend on: `userProfile`
+    # uses `email`, and the add-member existence check uses `email_Iexact`
+    # (optionally alongside `project`).  Each resolves a single, already-known
+    # address — a one-at-a-time existence oracle, not an enumeration vector —
+    # so it stays open to any authenticated caller.  Anything else (unfiltered,
+    # `project`-only, or a substring filter) is a list/enumeration request and
+    # is denied for non-superusers in `qs`.
+    EXACT_EMAIL_FILTERS = ("email", "email__iexact")
+
     project = CharFilter(method="filter_user_in_project")
 
     class Meta:
@@ -73,14 +82,28 @@ class UserFilter(FilterSet):
 
     @property
     def qs(self):
-        # If any admin-only filter has a non-empty value, require superuser.
-        # `self.data` is the dict of incoming filter args keyed by their
-        # Django ORM lookup name (e.g. "email__icontains").
+        # Default-deny enumeration of the user table.  Any authenticated caller
+        # can self-register (open OAuth signup), so "authenticated" is a near-
+        # public bar; without this gate an account could page the whole `users`
+        # connection (or `users(project: ...)`) and harvest every email, name,
+        # and membership.  `self.data` is the dict of incoming filter args keyed
+        # by their Django ORM lookup name (e.g. "email__iexact").
+        base = super().qs
+        user = getattr(self.request, "user", None) if self.request else None
+        if user and user.is_superuser:
+            return base
+        # Substring filters can harvest the table; superuser only (handled
+        # above).  Checked before the exact-email allowlist so that combining a
+        # substring with an exact email can't slip past the superuser gate.
         if any(self.data.get(name) for name in self.ADMIN_ONLY_FILTERS):
-            user = getattr(self.request, "user", None) if self.request else None
-            if not (user and user.is_superuser):
-                return super().qs.none()
-        return super().qs
+            return base.none()
+        # Non-superusers may only resolve a single known address (the clients'
+        # userProfile / add-member existence flows).  Returning `.none()` rather
+        # than raising keeps the response schema-valid for a client that fires a
+        # broad filter and avoids surfacing "superuser required" as metadata.
+        if any(self.data.get(name) for name in self.EXACT_EMAIL_FILTERS):
+            return base
+        return base.none()
 
 
 class UserNode(DjangoObjectType):
@@ -96,10 +119,10 @@ class UserNode(DjangoObjectType):
     @classmethod
     def get_queryset(cls, queryset, info):
         # F1: anonymous users must not enumerate the user table or look up
-        # users by id.  Authenticated callers continue to have access — the
-        # add-team-member flow needs `users(email_Iexact: ...)` for an
-        # email-existence check.  Tightening authenticated access (e.g. to
-        # users sharing a project/landscape/group) is a separate change.
+        # users by id.  Authenticated, non-enumerating access (the clients'
+        # userProfile / add-member existence lookups) is allowed; broader
+        # enumeration by authenticated callers is denied in `UserFilter.qs`,
+        # which — unlike get_queryset — can see the incoming filter args.
         if info.context.user.is_anonymous:
             return queryset.none()
         return queryset
@@ -113,6 +136,22 @@ class UserPreferenceNode(DjangoObjectType):
         fields = ("key", "value", "user")
         interfaces = (relay.Node,)
         connection_class = TerrasoConnection
+
+    @classmethod
+    def get_queryset(cls, queryset, info):
+        # Preferences (language, notification opt-ins, account-deletion-request)
+        # are personal data. A caller may read only their own — the userProfile
+        # flow fetches the logged-in user's own preferences — while superusers
+        # keep full read access for admin/support. This stops the exact-email
+        # lookup (`users(email: ...)`) from disclosing another user's
+        # preferences via the nested `preferences` connection. Anonymous
+        # callers (already blocked from UserNode) see nothing here too.
+        user = info.context.user
+        if user.is_anonymous:
+            return queryset.none()
+        if user.is_superuser:
+            return queryset
+        return queryset.filter(user=user)
 
 
 # NOTE: Consider removing this mutation entirely. The legitimate user-creation

--- a/terraso_backend/apps/graphql/schema/users.py
+++ b/terraso_backend/apps/graphql/schema/users.py
@@ -64,6 +64,17 @@ class UserNode(DjangoObjectType):
         connection_class = TerrasoConnection
         fields = ("email", "first_name", "last_name", "profile_image", "memberships", "preferences")
 
+    @classmethod
+    def get_queryset(cls, queryset, info):
+        # F1: anonymous users must not enumerate the user table or look up
+        # users by id.  Authenticated callers continue to have access — the
+        # add-team-member flow needs `users(email_Iexact: ...)` for an
+        # email-existence check.  Tightening authenticated access (e.g. to
+        # users sharing a project/landscape/group) is a separate change.
+        if info.context.user.is_anonymous:
+            return queryset.none()
+        return queryset
+
 
 class UserPreferenceNode(DjangoObjectType):
     id = graphene.ID(source="pk", required=True)

--- a/terraso_backend/apps/graphql/schema/visualization_config.py
+++ b/terraso_backend/apps/graphql/schema/visualization_config.py
@@ -121,10 +121,13 @@ class VisualizationConfigNode(DjangoObjectType):
 
     @classmethod
     def get_queryset(cls, queryset, info):
-        # Only filter for user memberships if the field is not visualizationConfigs
-        # This is because the user can be requesting a visualizations from a parent
-        # node, that should be handling the filtering
-        if info.field_name != "visualizationConfigs":
+        # Apply the ownership filter when this Node is being resolved at the
+        # top level of the query (visualizationConfig(id: ...) or
+        # visualizationConfigs(...)).  When nested under a parent resolver
+        # (e.g. dataEntry { visualizations }), the parent has already done
+        # the appropriate filtering, so trust that and pass the queryset
+        # through unchanged.
+        if info.path.prev is not None:
             return queryset
 
         user_pk = getattr(info.context.user, "pk", False)

--- a/terraso_backend/apps/project_management/graphql/projects.py
+++ b/terraso_backend/apps/project_management/graphql/projects.py
@@ -150,10 +150,15 @@ class ProjectNode(DjangoObjectType):
 
     @classmethod
     def get_queryset(cls, queryset, info):
-        # limit queries to membership lists of projects to which the user belongs
-        user_pk = getattr(info.context.user, "pk", None)
+        # Limit to projects the caller is a member of.  Short-circuit on
+        # anonymous: the membership join uses a LEFT OUTER JOIN, so a naive
+        # filter user_id=None matches projects with zero memberships
+        # (F5 SQL OUTER-JOIN bug).
+        user = info.context.user
+        if user.is_anonymous:
+            return queryset.none()
         return queryset.filter(
-            membership_list__memberships__user_id=user_pk,
+            membership_list__memberships__user_id=user.pk,
             membership_list__memberships__deleted_at__isnull=True,
         )
 

--- a/terraso_backend/apps/project_management/models/sites.py
+++ b/terraso_backend/apps/project_management/models/sites.py
@@ -110,11 +110,32 @@ class Site(BaseModel):
         return Site.objects.bulk_update(sites, ["owner", "project"])
 
 
-def filter_only_sites_user_owner_or_member(user: User, queryset):
+def filter_visible_sites(user: User, queryset):
+    """Sites an authenticated user is allowed to read:
+       (a) sites they own,
+       (b) sites in a project they're an approved member of, or
+       (c) sites explicitly marked Site.PUBLIC.
+
+    (c) is the "public site" branch: per product (2026-05-18), a site
+    flagged PUBLIC is visible to any authenticated caller, with the
+    intent that the future data-portal feature surfaces them. Write
+    access is unchanged — mutations still go through the per-site
+    permission check (ownership / project-management), so publicness
+    grants read only.
+
+    Anonymous callers are filtered out earlier in SiteNode.get_queryset
+    and don't reach this function.
+
+    `.distinct()` deduplicates rows that match more than one branch
+    (e.g., owner who is also a project member, or a public site whose
+    owner is the caller) — necessary because the membership join can
+    multiply rows per matching membership.
+    """
     is_owner = Q(owner=user)
     is_approved_member = Q(
         project__membership_list__memberships__user=user,
         project__membership_list__memberships__membership_status=CollaborationMembership.APPROVED,
         project__membership_list__memberships__deleted_at__isnull=True,
     )
-    return queryset.filter(is_owner | is_approved_member)
+    is_public = Q(privacy=Site.PUBLIC)
+    return queryset.filter(is_owner | is_approved_member | is_public).distinct()

--- a/terraso_backend/apps/soil_id/graphql/soil_id/queries.py
+++ b/terraso_backend/apps/soil_id/graphql/soil_id/queries.py
@@ -16,6 +16,7 @@
 
 import graphene
 
+from apps.graphql.exceptions import GraphQLNotAllowedException
 from apps.soil_id.graphql.soil_id.resolvers import resolve_data_based_result, resolve_soil_id_result
 from apps.soil_id.graphql.soil_id.types import DataBasedResult, SoilIdInputData, SoilIdResult
 
@@ -42,6 +43,13 @@ class SoilId(graphene.ObjectType):
 
 
 def resolve_soil_id(parent, info):
+    # Soil ID lookups require an authenticated caller. Anonymous access was
+    # previously allowed because the resolvers ignored the user entirely;
+    # gate it here at the single entry point so both soilMatches and the
+    # deprecated dataBasedSoilMatches (and any future SoilId field) are
+    # covered. Partner access is granted by issuing a service-account token.
+    if info.context.user.is_anonymous:
+        raise GraphQLNotAllowedException(model_name="SoilId", field="soilId", operation="read")
     return SoilId()
 
 

--- a/terraso_backend/tests/graphql/conftest.py
+++ b/terraso_backend/tests/graphql/conftest.py
@@ -389,14 +389,18 @@ def data_entry_kml(users, groups):
     creator_group.membership_list.save_membership(
         creator.email, group_collaboration_roles.ROLE_MEMBER, CollaborationMembership.APPROVED
     )
-    return mixer.blend(
-        DataEntry,
-        created_by=creator,
-        size=100,
-        groups=creator_group,
-        entry_type=DataEntry.ENTRY_TYPE_FILE,
-        resource_type="kml",
+    resource = mixer.blend(
+        SharedResource,
+        target=creator_group,
+        source=mixer.blend(
+            DataEntry,
+            created_by=creator,
+            size=100,
+            entry_type=DataEntry.ENTRY_TYPE_FILE,
+            resource_type="kml",
+        ),
     )
+    return resource.source
 
 
 @pytest.fixture
@@ -421,14 +425,18 @@ def data_entry_shapefile(users, groups):
     creator_group.membership_list.save_membership(
         creator.email, group_collaboration_roles.ROLE_MEMBER, CollaborationMembership.APPROVED
     )
-    return mixer.blend(
-        DataEntry,
-        created_by=creator,
-        size=100,
-        groups=creator_group,
-        entry_type=DataEntry.ENTRY_TYPE_FILE,
-        resource_type="zip",
+    resource = mixer.blend(
+        SharedResource,
+        target=creator_group,
+        source=mixer.blend(
+            DataEntry,
+            created_by=creator,
+            size=100,
+            entry_type=DataEntry.ENTRY_TYPE_FILE,
+            resource_type="zip",
+        ),
     )
+    return resource.source
 
 
 @pytest.fixture

--- a/terraso_backend/tests/graphql/mutations/test_cross_tenant_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_cross_tenant_mutations.py
@@ -39,8 +39,6 @@ Pattern:
    no successful payload, AND the resource state in the DB is unchanged.
 """
 
-import json
-
 import pytest
 from graphene_django.utils.testing import graphql_query
 from mixer.backend.django import mixer
@@ -111,7 +109,7 @@ def test_save_group_membership_cross_tenant_rejected(client):
     client.force_login(attacker)
     response = graphql_query(
         "mutation save($input: GroupMembershipSaveMutationInput!) "
-        '{ saveGroupMembership(input: $input) { errors } }',
+        "{ saveGroupMembership(input: $input) { errors } }",
         variables={
             "input": {
                 "userRole": group_collaboration_roles.ROLE_MANAGER,

--- a/terraso_backend/tests/graphql/mutations/test_cross_tenant_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_cross_tenant_mutations.py
@@ -1,0 +1,318 @@
+# Copyright © 2026 Technology Matters
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see https://www.gnu.org/licenses/.
+
+"""Cross-tenant mutation probes.
+
+For each authenticated mutation that takes a resource id, assert that an
+unrelated user (not an owner, member, or manager of the targeted resource)
+gets rejected.  The mutation base classes (BaseAuthenticatedMutation /
+BaseWriteMutation / BaseDeleteMutation) only check is_authenticated; the
+object-level check is the resolver's responsibility.  These tests verify
+the object-level checks are present and effective.
+
+Pattern:
+1. Set up a resource owned by some user other than the test caller.
+2. force_login as an unrelated user (the JWTAwareClient in the conftest
+   auto-attaches a JWT on force_login).
+3. Send the mutation targeting the resource.
+4. Assert the mutation either rejects with an error payload or returns
+   no successful payload, AND the resource state in the DB is unchanged.
+"""
+
+import json
+
+import pytest
+from graphene_django.utils.testing import graphql_query
+from mixer.backend.django import mixer
+
+from apps.collaboration.models import Membership as CollaborationMembership
+from apps.collaboration.models import MembershipList
+from apps.core import group_collaboration_roles, landscape_collaboration_roles
+from apps.core.models import Group, Landscape, SharedResource, User
+from apps.project_management.models import Project, Site
+from apps.shared_data.models import DataEntry
+from apps.story_map.models import StoryMap
+
+pytestmark = pytest.mark.django_db
+
+
+def _has_mutation_error(response_body, mutation_name):
+    """A mutation 'failed' if either there's a top-level errors array, or
+    the mutation payload's `errors` field is set, or the mutation payload's
+    primary result field is null."""
+    if "errors" in response_body:
+        return True
+    payload = response_body.get("data", {}).get(mutation_name)
+    if payload is None:
+        return True
+    if payload.get("errors"):
+        return True
+    return False
+
+
+# --- Group mutations ---
+
+
+def test_delete_group_cross_tenant_rejected(client):
+    """User A (not a manager of group) cannot delete it."""
+    owner = mixer.blend(User)
+    group = mixer.blend(
+        Group,
+        membership_list=mixer.blend(
+            MembershipList, membership_type=MembershipList.MEMBERSHIP_TYPE_CLOSED
+        ),
+    )
+    group.add_manager(owner)
+
+    attacker = mixer.blend(User)
+    client.force_login(attacker)
+    response = graphql_query(
+        "mutation deleteGroup($input: GroupDeleteMutationInput!) "
+        "{ deleteGroup(input: $input) { errors group { id } } }",
+        variables={"input": {"id": str(group.id)}},
+        client=client,
+    )
+    assert _has_mutation_error(response.json(), "deleteGroup")
+    assert Group.objects.filter(id=group.id).exists()
+
+
+def test_save_group_membership_cross_tenant_rejected(client):
+    """User A (non-manager) cannot add anyone to user B's group."""
+    owner = mixer.blend(User)
+    group = mixer.blend(
+        Group,
+        membership_list=mixer.blend(
+            MembershipList, membership_type=MembershipList.MEMBERSHIP_TYPE_CLOSED
+        ),
+    )
+    group.add_manager(owner)
+
+    attacker = mixer.blend(User)
+    client.force_login(attacker)
+    response = graphql_query(
+        "mutation save($input: GroupMembershipSaveMutationInput!) "
+        '{ saveGroupMembership(input: $input) { errors } }',
+        variables={
+            "input": {
+                "userRole": group_collaboration_roles.ROLE_MANAGER,
+                "userEmails": [attacker.email],
+                "groupSlug": group.slug,
+            }
+        },
+        client=client,
+    )
+    assert _has_mutation_error(response.json(), "saveGroupMembership")
+    # attacker did NOT become a member
+    assert not CollaborationMembership.objects.filter(
+        user=attacker, membership_list=group.membership_list
+    ).exists()
+
+
+# --- Landscape mutations ---
+
+
+def test_update_landscape_cross_tenant_rejected(client):
+    landscape = mixer.blend(Landscape, name="Original Name")
+    owner = mixer.blend(User)
+    landscape.membership_list.save_membership(
+        owner.email,
+        landscape_collaboration_roles.ROLE_MANAGER,
+        CollaborationMembership.APPROVED,
+    )
+
+    attacker = mixer.blend(User)
+    client.force_login(attacker)
+    response = graphql_query(
+        "mutation update($input: LandscapeUpdateMutationInput!) "
+        "{ updateLandscape(input: $input) { errors landscape { id name } } }",
+        variables={"input": {"id": str(landscape.id), "name": "PWNED"}},
+        client=client,
+    )
+    assert _has_mutation_error(response.json(), "updateLandscape")
+    landscape.refresh_from_db()
+    assert landscape.name == "Original Name"
+
+
+def test_delete_landscape_cross_tenant_rejected(client):
+    landscape = mixer.blend(Landscape)
+    owner = mixer.blend(User)
+    landscape.membership_list.save_membership(
+        owner.email,
+        landscape_collaboration_roles.ROLE_MANAGER,
+        CollaborationMembership.APPROVED,
+    )
+
+    attacker = mixer.blend(User)
+    client.force_login(attacker)
+    response = graphql_query(
+        "mutation delete($input: LandscapeDeleteMutationInput!) "
+        "{ deleteLandscape(input: $input) { errors } }",
+        variables={"input": {"id": str(landscape.id)}},
+        client=client,
+    )
+    assert _has_mutation_error(response.json(), "deleteLandscape")
+    assert Landscape.objects.filter(id=landscape.id).exists()
+
+
+def test_save_landscape_membership_cross_tenant_rejected(client):
+    """User A cannot self-promote into a landscape they don't manage."""
+    landscape = mixer.blend(Landscape)
+    owner = mixer.blend(User)
+    landscape.membership_list.save_membership(
+        owner.email,
+        landscape_collaboration_roles.ROLE_MANAGER,
+        CollaborationMembership.APPROVED,
+    )
+
+    attacker = mixer.blend(User)
+    client.force_login(attacker)
+    response = graphql_query(
+        "mutation save($input: LandscapeMembershipSaveMutationInput!) "
+        "{ saveLandscapeMembership(input: $input) { errors } }",
+        variables={
+            "input": {
+                "userRole": landscape_collaboration_roles.ROLE_MANAGER,
+                "userEmails": [attacker.email],
+                "landscapeSlug": landscape.slug,
+            }
+        },
+        client=client,
+    )
+    assert _has_mutation_error(response.json(), "saveLandscapeMembership")
+    assert not CollaborationMembership.objects.filter(
+        user=attacker, membership_list=landscape.membership_list
+    ).exists()
+
+
+# --- Site mutations ---
+
+
+def test_update_site_cross_tenant_rejected(client):
+    """User A cannot update someone else's unaffiliated site."""
+    owner = mixer.blend(User)
+    site = mixer.blend(Site, owner=owner, name="Original")
+
+    attacker = mixer.blend(User)
+    client.force_login(attacker)
+    response = graphql_query(
+        "mutation update($input: SiteUpdateMutationInput!) "
+        "{ updateSite(input: $input) { errors site { id name } } }",
+        variables={"input": {"id": str(site.id), "name": "PWNED"}},
+        client=client,
+    )
+    assert _has_mutation_error(response.json(), "updateSite")
+    site.refresh_from_db()
+    assert site.name == "Original"
+
+
+def test_delete_site_cross_tenant_rejected(client):
+    owner = mixer.blend(User)
+    site = mixer.blend(Site, owner=owner)
+
+    attacker = mixer.blend(User)
+    client.force_login(attacker)
+    response = graphql_query(
+        "mutation delete($input: SiteDeleteMutationInput!) "
+        "{ deleteSite(input: $input) { errors } }",
+        variables={"input": {"id": str(site.id)}},
+        client=client,
+    )
+    assert _has_mutation_error(response.json(), "deleteSite")
+    assert Site.objects.filter(id=site.id).exists()
+
+
+def test_transfer_sites_cross_tenant_rejected(client):
+    """User A cannot transfer someone else's sites into a project.
+    transferSites doesn't error on permission failure — it returns the
+    rejected sites in the `bad_permissions` field and leaves them
+    unchanged in the DB."""
+    owner = mixer.blend(User)
+    site = mixer.blend(Site, owner=owner)
+    target_project = mixer.blend(Project)
+    target_project.add_manager(owner)
+
+    attacker = mixer.blend(User)
+    client.force_login(attacker)
+    response = graphql_query(
+        "mutation transfer($input: SiteTransferMutationInput!) "
+        "{ transferSites(input: $input) { "
+        "    updated { site { id } } badPermissions { id } errors "
+        "} }",
+        variables={
+            "input": {
+                "siteIds": [str(site.id)],
+                "projectId": str(target_project.id),
+            }
+        },
+        client=client,
+    )
+    body = response.json()
+    payload = body["data"]["transferSites"]
+    assert payload["updated"] == []
+    assert any(p["id"] == str(site.id) for p in payload["badPermissions"])
+    site.refresh_from_db()
+    assert site.project_id is None  # site stays unaffiliated
+
+
+# --- StoryMap mutations ---
+
+
+def test_delete_story_map_cross_tenant_rejected(client):
+    creator = mixer.blend(User)
+    story_map = mixer.blend(StoryMap, created_by=creator, is_published=False)
+
+    attacker = mixer.blend(User)
+    client.force_login(attacker)
+    response = graphql_query(
+        "mutation delete($input: StoryMapDeleteMutationInput!) "
+        "{ deleteStoryMap(input: $input) { errors } }",
+        variables={"input": {"id": str(story_map.id)}},
+        client=client,
+    )
+    assert _has_mutation_error(response.json(), "deleteStoryMap")
+    assert StoryMap.objects.filter(id=story_map.id).exists()
+
+
+# --- SharedResource mutations ---
+
+
+def test_update_shared_resource_cross_tenant_rejected(client):
+    """User A cannot change share-access on someone else's shared
+    resource (e.g. flipping a private group's resource to share_access=ALL)."""
+    owner = mixer.blend(User)
+    target_group = mixer.blend(Group)
+    target_group.membership_list.save_membership(
+        owner.email,
+        group_collaboration_roles.ROLE_MANAGER,
+        CollaborationMembership.APPROVED,
+    )
+    resource = mixer.blend(
+        SharedResource,
+        target=target_group,
+        source=mixer.blend(DataEntry, created_by=owner, size=100),
+        share_access=SharedResource.SHARE_ACCESS_MEMBERS,
+    )
+
+    attacker = mixer.blend(User)
+    client.force_login(attacker)
+    response = graphql_query(
+        "mutation update($input: SharedResourceUpdateMutationInput!) "
+        "{ updateSharedResource(input: $input) { errors } }",
+        variables={"input": {"id": str(resource.id), "shareAccess": "ALL"}},
+        client=client,
+    )
+    assert _has_mutation_error(response.json(), "updateSharedResource")
+    resource.refresh_from_db()
+    assert resource.share_access == SharedResource.SHARE_ACCESS_MEMBERS

--- a/terraso_backend/tests/graphql/mutations/test_cross_tenant_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_cross_tenant_mutations.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see https://www.gnu.org/licenses/.
 
-"""Cross-tenant mutation probes.
+"""Cross-tenant mutation probes — security-audit dashboard.
 
 For each authenticated mutation that takes a resource id, assert that an
 unrelated user (not an owner, member, or manager of the targeted resource)
@@ -21,6 +21,14 @@ gets rejected.  The mutation base classes (BaseAuthenticatedMutation /
 BaseWriteMutation / BaseDeleteMutation) only check is_authenticated; the
 object-level check is the resolver's responsibility.  These tests verify
 the object-level checks are present and effective.
+
+NOTE on duplication: Several of these mutations also have cross-tenant
+tests in their respective test_*.py files (e.g. updateGroup is also
+tested in test_group_mutations.py).  This file is intentionally a
+centralized audit dashboard — having the security-relevant probes
+collected in one place makes the audit trail easier to grep, review,
+and re-run as a security regression suite.  Do not "DRY up" by deleting
+duplicates here; they earn their keep as audit artifacts.
 
 Pattern:
 1. Set up a resource owned by some user other than the test caller.

--- a/terraso_backend/tests/graphql/mutations/test_export_tokens.py
+++ b/terraso_backend/tests/graphql/mutations/test_export_tokens.py
@@ -328,3 +328,19 @@ class TestAllExportTokensQuery:
         tokens = content["data"]["allExportTokens"]
         assert len(tokens) == 1
         assert tokens[0]["token"] == user_token.token
+
+    def test_query_returns_empty_for_anonymous(self, client_query_no_token, user):
+        """Anonymous callers must get an empty list even if a token with
+        user_id=='None' (the literal string) somehow exists in the table."""
+        ExportToken.create_token("USER", str(user.id), str(user.id))
+        # A row with the literal string "None" as user_id wouldn't be created
+        # by the production mutation, but verify the resolver doesn't depend
+        # on that assumption.
+        ExportToken.objects.create(
+            resource_type="USER", resource_id=str(user.id), user_id="None"
+        )
+
+        response = client_query_no_token(ALL_EXPORT_TOKENS_QUERY)
+        content = json.loads(response.content)
+        assert "errors" not in content, content.get("errors")
+        assert content["data"]["allExportTokens"] == []

--- a/terraso_backend/tests/graphql/mutations/test_export_tokens.py
+++ b/terraso_backend/tests/graphql/mutations/test_export_tokens.py
@@ -336,9 +336,7 @@ class TestAllExportTokensQuery:
         # A row with the literal string "None" as user_id wouldn't be created
         # by the production mutation, but verify the resolver doesn't depend
         # on that assumption.
-        ExportToken.objects.create(
-            resource_type="USER", resource_id=str(user.id), user_id="None"
-        )
+        ExportToken.objects.create(resource_type="USER", resource_id=str(user.id), user_id="None")
 
         response = client_query_no_token(ALL_EXPORT_TOKENS_QUERY)
         content = json.loads(response.content)

--- a/terraso_backend/tests/graphql/mutations/test_projects.py
+++ b/terraso_backend/tests/graphql/mutations/test_projects.py
@@ -434,20 +434,18 @@ def test_update_project_role_target_user_not_in_project(project, project_manager
     assert "errors" in payload
 
 
-def test_mark_project_seen(client, user):
-    client.force_login(user)
-    response = graphql_query(
-        CREATE_PROJECT_QUERY,
-        variables={"input": {"name": "project", "privacy": "PUBLIC"}},
-        client=client,
-    )
-    project = response.json()["data"]["addProject"]["project"]
-    assert project["seen"] is True
+def test_mark_project_seen(client, project, project_user):
+    # The "seen" flag is per-user; both users need read access to the
+    # project to test it. Use a project where one user is manager and the
+    # other is a viewer (project_user) — without shared membership,
+    # ProjectNode.get_queryset filters the project out for project_user.
+    manager = project.manager_memberships.first().user
+    project.seen_by.add(manager)
 
-    client.force_login(mixer.blend(User))
+    client.force_login(project_user)
     response = graphql_query(
         "query project($id: ID!){ project(id: $id) { seen } }",
-        variables={"id": project["id"]},
+        variables={"id": str(project.id)},
         client=client,
     )
     assert response.json()["data"]["project"]["seen"] is False
@@ -458,7 +456,7 @@ def test_mark_project_seen(client, user):
             markProjectSeen(input: $input) { project { seen } }
         }
         """,
-        variables={"input": {"id": project["id"]}},
+        variables={"input": {"id": str(project.id)}},
         client=client,
     )
     assert response.json()["data"]["markProjectSeen"]["project"]["seen"] is True

--- a/terraso_backend/tests/graphql/mutations/test_sites.py
+++ b/terraso_backend/tests/graphql/mutations/test_sites.py
@@ -262,17 +262,29 @@ def test_delete_site_not_allowed(client, site):
     assert len(Site.objects.filter(id=site.id)) == 1
 
 
-def test_mark_site_seen(client, user):
-    client.force_login(user)
+def test_mark_site_seen(client, project, project_user):
+    # The site must live in a project both users belong to: project's manager
+    # creates it, project_user (a viewer) sees it. Without shared project
+    # membership, SiteNode.get_queryset filters the site out for project_user.
+    manager = project.manager_memberships.first().user
+    client.force_login(manager)
     response = graphql_query(
         CREATE_SITE_QUERY,
-        variables={"input": {"name": "site", "latitude": 0, "longitude": 0, "elevation": 0}},
+        variables={
+            "input": {
+                "name": "site",
+                "latitude": 0,
+                "longitude": 0,
+                "elevation": 0,
+                "projectId": str(project.id),
+            }
+        },
         client=client,
     )
     site = response.json()["data"]["addSite"]["site"]
     assert site["seen"] is True
 
-    client.force_login(mixer.blend(User))
+    client.force_login(project_user)
     response = graphql_query(
         "query site($id: ID!){ site(id: $id) { seen } }",
         variables={"id": site["id"]},

--- a/terraso_backend/tests/graphql/mutations/test_user_mutations.py
+++ b/terraso_backend/tests/graphql/mutations/test_user_mutations.py
@@ -21,26 +21,46 @@ from apps.core.models.users import USER_PREFS_KEY_GROUP_NOTIFICATIONS
 pytestmark = pytest.mark.django_db
 
 
-def test_users_add(client_query):
-    user_email = "testinuser@example.com"
-    user_password = "123456"
-    response = client_query(
-        """
-        mutation addUser($input: UserAddMutationInput!){
-          addUser(input: $input) {
-            user {
-              id
-              email
-            }
-          }
+_ADD_USER_QUERY = """
+    mutation addUser($input: UserAddMutationInput!){
+      addUser(input: $input) {
+        user {
+          id
+          email
         }
-        """,
-        variables={"input": {"email": user_email, "password": user_password}},
+        errors
+      }
+    }
+"""
+
+
+def test_users_add_as_superuser(client_query, user):
+    """The addUser mutation is gated to superusers (BaseAdminMutation)."""
+    user.is_superuser = True
+    user.is_staff = True
+    user.save()
+
+    response = client_query(
+        _ADD_USER_QUERY,
+        variables={"input": {"email": "newuser@example.com", "password": "123456"}},
     )
     user_result = response.json()["data"]["addUser"]["user"]
-
     assert user_result["id"]
-    assert user_result["email"] == user_email
+    assert user_result["email"] == "newuser@example.com"
+
+
+def test_users_add_rejects_regular_user(client_query, user):
+    """A non-superuser authenticated caller cannot create accounts via addUser."""
+    assert not user.is_superuser
+
+    response = client_query(
+        _ADD_USER_QUERY,
+        variables={"input": {"email": "victim@example.invalid", "password": "123456"}},
+    )
+    payload = response.json()["data"]["addUser"]
+    assert payload["user"] is None
+    assert payload["errors"]
+    assert not User.objects.filter(email="victim@example.invalid").exists()
 
 
 def test_users_update(client_query, users):

--- a/terraso_backend/tests/graphql/test_anonymous_scoping.py
+++ b/terraso_backend/tests/graphql/test_anonymous_scoping.py
@@ -1,0 +1,121 @@
+# Copyright © 2026 Technology Matters
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see https://www.gnu.org/licenses/.
+
+"""Regression tests for F1 (anonymous user enumeration) and F3 (anonymous
+single-id IDOR via TerrasoRelayNode.get_node_from_global_id bypass)."""
+
+import pytest
+from graphene_django.utils.testing import graphql_query
+
+pytestmark = pytest.mark.django_db
+
+
+def _anon_query(query):
+    """Run a GraphQL query without auth - the default Django test client
+    sets no Authorization header and has no session."""
+    return graphql_query(query, client=None)
+
+
+# --- F1: anon must not enumerate users ---
+
+
+def test_users_listing_returns_zero_to_anonymous(client_query_no_token, users):
+    response = client_query_no_token("query { users { totalCount edges { node { email } } } }")
+    body = response.json()
+    assert body["data"]["users"]["totalCount"] == 0
+    assert body["data"]["users"]["edges"] == []
+
+
+def test_users_email_filter_returns_zero_to_anonymous(client_query_no_token, users):
+    target_email = users[0].email
+    response = client_query_no_token(
+        'query { users(email_Iexact: "%s") { totalCount edges { node { email } } } }' % target_email
+    )
+    body = response.json()
+    assert body["data"]["users"]["totalCount"] == 0
+
+
+def test_user_by_id_returns_null_to_anonymous(client_query_no_token, users):
+    response = client_query_no_token(
+        'query { user(id: "%s") { email firstName lastName } }' % users[0].id
+    )
+    body = response.json()
+    # Single-id User Field is non-nullable, so the response surfaces a schema
+    # error rather than data.user=null. Either way, no user data leaks.
+    assert "errors" in body or body["data"]["user"] is None
+
+
+# --- F3: single-id queries must respect the Node's get_queryset ---
+
+
+def test_anonymous_cannot_fetch_dataentry_by_id(client_query_no_token, group_data_entries):
+    """DataEntryNode.get_queryset filters by membership.  Before the S2 fix,
+    single-id query bypassed it and returned any data entry by UUID."""
+    response = client_query_no_token(
+        'query { dataEntry(id: "%s") { name url } }' % group_data_entries[0].id
+    )
+    body = response.json()
+    assert "errors" in body or body["data"]["dataEntry"] is None
+
+
+def test_anonymous_cannot_fetch_storymap_by_id(client_query_no_token, story_maps):
+    """Unpublished story maps must not be readable by anonymous callers."""
+    unpublished = next(s for s in story_maps if not s.is_published)
+    response = client_query_no_token(
+        'query { storyMap(id: "%s") { title isPublished } }' % unpublished.id
+    )
+    body = response.json()
+    assert "errors" in body or body["data"]["storyMap"] is None
+
+
+def test_anonymous_cannot_fetch_visualization_config_by_id(
+    client_query_no_token, visualization_configs
+):
+    """VisualizationConfigNode previously skipped the membership filter for
+    any field name other than 'visualizationConfigs', leaking single-id
+    fetches.  Now top-level fetches apply the filter."""
+    response = client_query_no_token(
+        'query { visualizationConfig(id: "%s") { id title } }' % visualization_configs[0].id
+    )
+    body = response.json()
+    assert "errors" in body or body["data"]["visualizationConfig"] is None
+
+
+def test_anonymous_projects_listing_returns_zero(client_query_no_token):
+    """F5: ProjectNode.get_queryset previously matched
+    user_id IS NULL via LEFT OUTER JOIN, leaking projects with no
+    memberships to anonymous callers."""
+    from apps.project_management.models.projects import Project
+
+    Project.objects.create(name="anon-bypass-probe")  # zero memberships
+    response = client_query_no_token(
+        "query { projects { totalCount edges { node { name } } } }"
+    )
+    body = response.json()
+    assert body["data"]["projects"]["totalCount"] == 0
+    assert body["data"]["projects"]["edges"] == []
+
+
+def test_anonymous_cannot_fetch_project_by_id(client_query_no_token):
+    """Projects with zero memberships were the exact data-shape that leaked
+    via F5 — verify single-id fetch is also closed."""
+    from apps.project_management.models.projects import Project
+
+    p = Project.objects.create(name="anon-by-id-probe")
+    response = client_query_no_token(
+        'query { project(id: "%s") { name privacy } }' % p.id
+    )
+    body = response.json()
+    assert "errors" in body or body["data"]["project"] is None

--- a/terraso_backend/tests/graphql/test_anonymous_scoping.py
+++ b/terraso_backend/tests/graphql/test_anonymous_scoping.py
@@ -47,6 +47,51 @@ def test_users_email_filter_returns_zero_to_anonymous(client_query_no_token, use
     assert body["data"]["users"]["totalCount"] == 0
 
 
+def test_email_iexact_works_for_regular_user(client_query, user, users):
+    """Authenticated callers can still do exact-email lookups (the legitimate
+    add-team-member flow uses email_Iexact)."""
+    target = users[1]
+    response = client_query(
+        'query { users(email_Iexact: "%s") { totalCount edges { node { email } } } }'
+        % target.email
+    )
+    body = response.json()
+    assert body["data"]["users"]["totalCount"] == 1
+    assert body["data"]["users"]["edges"][0]["node"]["email"] == target.email
+
+
+def test_email_icontains_returns_zero_for_regular_user(client_query, user, users):
+    """Substring filters are gated to superusers; a regular authenticated
+    caller using email_Icontains gets an empty result rather than the
+    user table."""
+    domain = "@" + users[1].email.split("@")[1]
+    response = client_query(
+        'query { users(email_Icontains: "%s") { totalCount } }' % domain
+    )
+    assert response.json()["data"]["users"]["totalCount"] == 0
+
+
+def test_email_icontains_works_for_superuser(client_query, user, users):
+    """Superuser can still use the substring filter (kept in schema for
+    potential admin/support workflows)."""
+    user.is_superuser = True
+    user.save()
+    domain = "@" + users[1].email.split("@")[1]
+    response = client_query(
+        'query { users(email_Icontains: "%s") { totalCount } }' % domain
+    )
+    assert response.json()["data"]["users"]["totalCount"] >= 1
+
+
+def test_first_name_icontains_returns_zero_for_regular_user(client_query, user, users):
+    users[1].first_name = "UniqueFirstName"
+    users[1].save()
+    response = client_query(
+        'query { users(firstName_Icontains: "Unique") { totalCount } }'
+    )
+    assert response.json()["data"]["users"]["totalCount"] == 0
+
+
 def test_user_by_id_returns_null_to_anonymous(client_query_no_token, users):
     response = client_query_no_token(
         'query { user(id: "%s") { email firstName lastName } }' % users[0].id

--- a/terraso_backend/tests/graphql/test_anonymous_scoping.py
+++ b/terraso_backend/tests/graphql/test_anonymous_scoping.py
@@ -19,6 +19,8 @@ single-id IDOR via TerrasoRelayNode.get_node_from_global_id bypass)."""
 import pytest
 from graphene_django.utils.testing import graphql_query
 
+from apps.core.models import UserPreference
+
 pytestmark = pytest.mark.django_db
 
 
@@ -52,8 +54,7 @@ def test_email_iexact_works_for_regular_user(client_query, user, users):
     add-team-member flow uses email_Iexact)."""
     target = users[1]
     response = client_query(
-        'query { users(email_Iexact: "%s") { totalCount edges { node { email } } } }'
-        % target.email
+        'query { users(email_Iexact: "%s") { totalCount edges { node { email } } } }' % target.email
     )
     body = response.json()
     assert body["data"]["users"]["totalCount"] == 1
@@ -65,9 +66,7 @@ def test_email_icontains_returns_zero_for_regular_user(client_query, user, users
     caller using email_Icontains gets an empty result rather than the
     user table."""
     domain = "@" + users[1].email.split("@")[1]
-    response = client_query(
-        'query { users(email_Icontains: "%s") { totalCount } }' % domain
-    )
+    response = client_query('query { users(email_Icontains: "%s") { totalCount } }' % domain)
     assert response.json()["data"]["users"]["totalCount"] == 0
 
 
@@ -77,19 +76,72 @@ def test_email_icontains_works_for_superuser(client_query, user, users):
     user.is_superuser = True
     user.save()
     domain = "@" + users[1].email.split("@")[1]
-    response = client_query(
-        'query { users(email_Icontains: "%s") { totalCount } }' % domain
-    )
+    response = client_query('query { users(email_Icontains: "%s") { totalCount } }' % domain)
     assert response.json()["data"]["users"]["totalCount"] >= 1
 
 
 def test_first_name_icontains_returns_zero_for_regular_user(client_query, user, users):
     users[1].first_name = "UniqueFirstName"
     users[1].save()
+    response = client_query('query { users(firstName_Icontains: "Unique") { totalCount } }')
+    assert response.json()["data"]["users"]["totalCount"] == 0
+
+
+def test_authenticated_user_cannot_enumerate_all_users(client_query, user, users):
+    """Open OAuth signup makes "authenticated" a near-public bar, so the
+    unfiltered users connection must not hand a regular caller the whole
+    directory — only exact-email lookups are allowed (see UserFilter.qs)."""
+    response = client_query("query { users { totalCount edges { node { email } } } }")
+    body = response.json()
+    assert body["data"]["users"]["totalCount"] == 0
+    assert body["data"]["users"]["edges"] == []
+
+
+def test_project_filter_without_exact_email_returns_zero_for_regular_user(
+    client_query, user, users
+):
+    """`users(project: ...)` without an exact email is a list/enumeration
+    request (and never checked caller membership), so it is denied for
+    non-superusers regardless of whether the project exists."""
     response = client_query(
-        'query { users(firstName_Icontains: "Unique") { totalCount } }'
+        'query { users(project: "00000000-0000-0000-0000-000000000000") { totalCount } }'
     )
     assert response.json()["data"]["users"]["totalCount"] == 0
+
+
+def test_superuser_can_list_all_users(client_query, user, users):
+    """Superusers retain full enumeration (kept for admin/support workflows)."""
+    user.is_superuser = True
+    user.save()
+    response = client_query("query { users { totalCount } }")
+    assert response.json()["data"]["users"]["totalCount"] == len(users)
+
+
+def test_email_probe_hides_other_users_preferences(client_query, user, users):
+    """The exact-email lookup must not disclose another user's preferences
+    (language, notification opt-ins, account-deletion-request); identity
+    fields still resolve, but the preferences connection is owner-scoped."""
+    target = users[1]
+    UserPreference.objects.create(user=target, key="language", value="es-EC")
+    response = client_query(
+        'query { users(email_Iexact: "%s") { edges { node { email '
+        "preferences { edges { node { key value } } } } } } }" % target.email
+    )
+    node = response.json()["data"]["users"]["edges"][0]["node"]
+    assert node["email"] == target.email
+    assert node["preferences"]["edges"] == []
+
+
+def test_user_can_read_own_preferences(client_query, user, users):
+    """A caller's own preferences stay readable — the userProfile flow loads
+    the logged-in user's language/notification settings this way."""
+    UserPreference.objects.create(user=user, key="language", value="en-US")
+    response = client_query(
+        'query { users(email_Iexact: "%s") { edges { node { '
+        "preferences { edges { node { key value } } } } } } }" % user.email
+    )
+    prefs = response.json()["data"]["users"]["edges"][0]["node"]["preferences"]["edges"]
+    assert any(e["node"]["key"] == "language" and e["node"]["value"] == "en-US" for e in prefs)
 
 
 def test_user_by_id_returns_null_to_anonymous(client_query_no_token, users):
@@ -145,9 +197,7 @@ def test_anonymous_projects_listing_returns_zero(client_query_no_token):
     from apps.project_management.models.projects import Project
 
     Project.objects.create(name="anon-bypass-probe")  # zero memberships
-    response = client_query_no_token(
-        "query { projects { totalCount edges { node { name } } } }"
-    )
+    response = client_query_no_token("query { projects { totalCount edges { node { name } } } }")
     body = response.json()
     assert body["data"]["projects"]["totalCount"] == 0
     assert body["data"]["projects"]["edges"] == []
@@ -159,9 +209,7 @@ def test_anonymous_cannot_fetch_project_by_id(client_query_no_token):
     from apps.project_management.models.projects import Project
 
     p = Project.objects.create(name="anon-by-id-probe")
-    response = client_query_no_token(
-        'query { project(id: "%s") { name privacy } }' % p.id
-    )
+    response = client_query_no_token('query { project(id: "%s") { name privacy } }' % p.id)
     body = response.json()
     assert "errors" in body or body["data"]["project"] is None
 
@@ -210,12 +258,8 @@ def group_association_fixture():
         landscape=landscape, group=in_default, is_default_landscape_group=True
     )
 
-    assoc_regular = GroupAssociation.objects.create(
-        parent_group=regular_a, child_group=regular_b
-    )
-    assoc_default = GroupAssociation.objects.create(
-        parent_group=regular_a, child_group=in_default
-    )
+    assoc_regular = GroupAssociation.objects.create(parent_group=regular_a, child_group=regular_b)
+    assoc_default = GroupAssociation.objects.create(parent_group=regular_a, child_group=in_default)
     return {
         "assoc_regular": assoc_regular,
         "assoc_default": assoc_default,

--- a/terraso_backend/tests/graphql/test_anonymous_scoping.py
+++ b/terraso_backend/tests/graphql/test_anonymous_scoping.py
@@ -164,3 +164,115 @@ def test_anonymous_cannot_fetch_project_by_id(client_query_no_token):
     )
     body = response.json()
     assert "errors" in body or body["data"]["project"] is None
+
+
+# --- Q7 / Q12: GroupAssociation scoping for anonymous callers ---
+#
+# Q7 (`groupAssociation(id)`) and Q12 (`groupAssociations(...)`) were
+# inconclusive in Phase 2 because the local DB had no GroupAssociation
+# rows.  These tests build the previously-missing fixture data and
+# pin the **intended public behavior** (product decision 2026-05-17,
+# "Position A"): the parent→child relationship between two Groups is
+# public information, consistent with Q3 (single Group) and Q8 (Groups
+# listing) being public-by-design.
+#
+# What the tests pin:
+#   - Anonymous CAN list non-default-group associations.
+#   - Anonymous CAN fetch a non-default-group association by id.
+#   - The existing default-landscape-group filter in
+#     GroupAssociationNode.get_queryset still excludes associations
+#     where either side is a default-landscape group (those are
+#     system-generated plumbing, not user-meaningful relationships).
+#
+# If product reverses on this — e.g., relationship metadata between
+# Groups turns out to be politically sensitive — these tests should
+# flip to assert anon→none, and GroupAssociationNode.get_queryset
+# gains an `is_anonymous → .none()` short-circuit matching F1/F5.
+
+
+@pytest.fixture
+def group_association_fixture():
+    """Two associations:
+    - assoc_regular: regular_a → regular_b (NOT excluded by the default-group guard)
+    - assoc_default: regular_a → group_in_default_landscape_group (excluded by guard)
+    """
+    from mixer.backend.django import mixer
+
+    from apps.core.models import Group, GroupAssociation, Landscape
+    from apps.core.models.landscapes import LandscapeGroup
+
+    regular_a = mixer.blend(Group, name="anon-probe-regular-a")
+    regular_b = mixer.blend(Group, name="anon-probe-regular-b")
+    in_default = mixer.blend(Group, name="anon-probe-in-default")
+
+    landscape = mixer.blend(Landscape, name="anon-probe-landscape")
+    LandscapeGroup.objects.create(
+        landscape=landscape, group=in_default, is_default_landscape_group=True
+    )
+
+    assoc_regular = GroupAssociation.objects.create(
+        parent_group=regular_a, child_group=regular_b
+    )
+    assoc_default = GroupAssociation.objects.create(
+        parent_group=regular_a, child_group=in_default
+    )
+    return {
+        "assoc_regular": assoc_regular,
+        "assoc_default": assoc_default,
+        "regular_a": regular_a,
+        "regular_b": regular_b,
+        "in_default": in_default,
+    }
+
+
+def test_anonymous_group_associations_listing_returns_non_default_only(
+    client_query_no_token, group_association_fixture
+):
+    """Q12 (Position A — intentionally public):
+    Anonymous can list GroupAssociations between non-default-landscape
+    groups. The default-landscape-group filter still removes plumbing
+    associations from the listing."""
+    response = client_query_no_token(
+        "query { groupAssociations { totalCount edges { node { id } } } }"
+    )
+    body = response.json()
+    expected_id = str(group_association_fixture["assoc_regular"].id)
+    excluded_id = str(group_association_fixture["assoc_default"].id)
+    ids = [edge["node"]["id"] for edge in body["data"]["groupAssociations"]["edges"]]
+    assert expected_id in ids
+    assert excluded_id not in ids
+
+
+def test_anonymous_can_fetch_non_default_group_association_by_id(
+    client_query_no_token, group_association_fixture
+):
+    """Q7 (Position A — intentionally public):
+    Anonymous can fetch a single GroupAssociation between non-default
+    groups. Q3 (single Group) and Q8 (Groups listing) are already
+    public-by-design; the relationship between two public Groups is
+    public information too."""
+    assoc = group_association_fixture["assoc_regular"]
+    response = client_query_no_token(
+        'query { groupAssociation(id: "%s") { id parentGroup { slug } } }' % assoc.id
+    )
+    body = response.json()
+    assert body["data"]["groupAssociation"]["id"] == str(assoc.id)
+    assert (
+        body["data"]["groupAssociation"]["parentGroup"]["slug"]
+        == group_association_fixture["regular_a"].slug
+    )
+
+
+def test_anonymous_cannot_fetch_default_group_association_by_id(
+    client_query_no_token, group_association_fixture
+):
+    """The default-landscape-group filter excludes plumbing associations
+    from every caller, anonymous or not. This is the same behavior an
+    authenticated caller would observe; it's a content filter, not an
+    auth filter."""
+    assoc = group_association_fixture["assoc_default"]
+    response = client_query_no_token(
+        'query { groupAssociation(id: "%s") { id parentGroup { slug } } }' % assoc.id
+    )
+    body = response.json()
+    assert "errors" in body or body["data"]["groupAssociation"] is None

--- a/terraso_backend/tests/graphql/test_shared_data.py
+++ b/terraso_backend/tests/graphql/test_shared_data.py
@@ -56,7 +56,7 @@ def test_data_entries_query(client_query, data_entries, data_entries_memberships
         assert data_entry.name in entries_result
 
 
-def test_data_entry_get_one_by_id(client_query, data_entries):
+def test_data_entry_get_one_by_id(client_query, data_entries, data_entries_memberships):
     data_entry = data_entries[0]
     query = (
         """
@@ -512,7 +512,9 @@ def test_data_entry_shapefil_to_geojson(get_file_mock, client_query, data_entry_
 
 
 @mock.patch("apps.shared_data.services.data_entry_upload_service.get_file")
-def test_data_entry_avoid_fetching_file_for_not_gis_file(get_file_mock, client_query, data_entries):
+def test_data_entry_avoid_fetching_file_for_not_gis_file(
+    get_file_mock, client_query, data_entries, data_entries_memberships
+):
     response = client_query(
         """
         {dataEntry(id: "%s") {

--- a/terraso_backend/tests/graphql/test_sites_public_visibility.py
+++ b/terraso_backend/tests/graphql/test_sites_public_visibility.py
@@ -1,0 +1,342 @@
+# Copyright © 2026 Technology Matters
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see https://www.gnu.org/licenses/.
+
+"""Public-site read visibility (product decision 2026-05-18, "loose"
+interpretation): a Site flagged `privacy=PUBLIC` is readable by any
+authenticated caller. Related data (notes, soil data) follows the same
+visibility because those Nodes are only reachable via the Site
+relation and have no get_queryset of their own.
+
+Write access is unchanged — mutations still gate on ownership / project
+membership regardless of the privacy flag.
+
+Anonymous remains anon→0 sites (no change from F3); the future
+data-portal feature is the entry point for anonymous public-site
+discovery.
+"""
+
+import json
+
+import pytest
+from graphene_django.utils.testing import graphql_query
+from mixer.backend.django import mixer
+
+from apps.core.models import User
+from apps.project_management.models import Site
+from apps.project_management.models.site_notes import SiteNote
+from apps.soil_id.models.soil_data import SoilData
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def stranger():
+    """An authenticated user with no relationship to the site/project."""
+    return mixer.blend(User)
+
+
+def _force_login_as(client, user):
+    client.force_login(user)
+
+
+# --- Listing visibility ---
+
+
+def test_public_site_listed_to_authenticated_stranger(client, stranger, user):
+    """Site.privacy=PUBLIC must surface in `sites(...)` for an authenticated
+    user who is neither owner nor project member."""
+    public_site = Site.objects.create(
+        name="public-site",
+        latitude=0,
+        longitude=0,
+        elevation=0,
+        privacy=Site.PUBLIC,
+        owner=user,
+    )
+
+    _force_login_as(client, stranger)
+    response = graphql_query(
+        "{ sites { totalCount edges { node { id name privacy } } } }",
+        client=client,
+    )
+    body = response.json()
+    ids = [edge["node"]["id"] for edge in body["data"]["sites"]["edges"]]
+    assert str(public_site.id) in ids
+
+
+def test_private_site_not_listed_to_authenticated_stranger(client, stranger, user):
+    """Site.privacy=PRIVATE must NOT surface to a stranger — the public
+    branch is the only relaxation; private sites stay owner-or-member only."""
+    private_site = Site.objects.create(
+        name="private-site",
+        latitude=0,
+        longitude=0,
+        elevation=0,
+        privacy=Site.PRIVATE,
+        owner=user,
+    )
+
+    _force_login_as(client, stranger)
+    response = graphql_query(
+        "{ sites { totalCount edges { node { id privacy } } } }",
+        client=client,
+    )
+    body = response.json()
+    ids = [edge["node"]["id"] for edge in body["data"]["sites"]["edges"]]
+    assert str(private_site.id) not in ids
+
+
+# --- Single-id fetch ---
+
+
+def test_public_site_by_id_visible_to_authenticated_stranger(client, stranger, user):
+    public_site = Site.objects.create(
+        name="public-site",
+        latitude=0,
+        longitude=0,
+        elevation=0,
+        privacy=Site.PUBLIC,
+        owner=user,
+    )
+
+    _force_login_as(client, stranger)
+    response = graphql_query(
+        'query { site(id: "%s") { id name privacy } }' % public_site.id, client=client
+    )
+    body = response.json()
+    assert body["data"]["site"]["id"] == str(public_site.id)
+    assert body["data"]["site"]["privacy"] == "PUBLIC"
+
+
+def test_private_site_by_id_hidden_from_authenticated_stranger(client, stranger, user):
+    private_site = Site.objects.create(
+        name="private-site",
+        latitude=0,
+        longitude=0,
+        elevation=0,
+        privacy=Site.PRIVATE,
+        owner=user,
+    )
+
+    _force_login_as(client, stranger)
+    response = graphql_query(
+        'query { site(id: "%s") { id } }' % private_site.id, client=client
+    )
+    body = response.json()
+    assert "errors" in body or body["data"]["site"] is None
+
+
+# --- Anonymous coverage (regression: F3 still in force) ---
+
+
+def test_anonymous_does_not_see_public_site_in_listing(client_query_no_token, user):
+    Site.objects.create(
+        name="public-anon-probe",
+        latitude=0,
+        longitude=0,
+        elevation=0,
+        privacy=Site.PUBLIC,
+        owner=user,
+    )
+    response = client_query_no_token("{ sites { totalCount edges { node { id } } } }")
+    body = response.json()
+    assert body["data"]["sites"]["totalCount"] == 0
+    assert body["data"]["sites"]["edges"] == []
+
+
+def test_anonymous_does_not_see_public_site_by_id(client_query_no_token, user):
+    public_site = Site.objects.create(
+        name="public-anon-by-id",
+        latitude=0,
+        longitude=0,
+        elevation=0,
+        privacy=Site.PUBLIC,
+        owner=user,
+    )
+    response = client_query_no_token(
+        'query { site(id: "%s") { id } }' % public_site.id
+    )
+    body = response.json()
+    assert "errors" in body or body["data"]["site"] is None
+
+
+# --- Owner / member visibility unchanged ---
+
+
+def test_owner_sees_own_private_site(client, user):
+    private_site = Site.objects.create(
+        name="owner-private",
+        latitude=0,
+        longitude=0,
+        elevation=0,
+        privacy=Site.PRIVATE,
+        owner=user,
+    )
+    _force_login_as(client, user)
+    response = graphql_query(
+        'query { site(id: "%s") { id privacy } }' % private_site.id, client=client
+    )
+    assert response.json()["data"]["site"]["id"] == str(private_site.id)
+
+
+def test_owner_sees_own_public_site(client, user):
+    public_site = Site.objects.create(
+        name="owner-public",
+        latitude=0,
+        longitude=0,
+        elevation=0,
+        privacy=Site.PUBLIC,
+        owner=user,
+    )
+    _force_login_as(client, user)
+    response = graphql_query(
+        'query { site(id: "%s") { id privacy } }' % public_site.id, client=client
+    )
+    assert response.json()["data"]["site"]["id"] == str(public_site.id)
+
+
+def test_project_member_sees_private_project_site(client, project, project_user):
+    private_site = Site.objects.create(
+        name="project-private",
+        latitude=0,
+        longitude=0,
+        elevation=0,
+        privacy=Site.PRIVATE,
+        project=project,
+    )
+    _force_login_as(client, project_user)
+    response = graphql_query(
+        'query { site(id: "%s") { id privacy } }' % private_site.id, client=client
+    )
+    assert response.json()["data"]["site"]["id"] == str(private_site.id)
+
+
+# --- Loose semantics: related data on public sites visible to strangers ---
+
+
+def test_public_site_notes_visible_to_authenticated_stranger(client, stranger, user):
+    """Loose interpretation: if you can see a public site, you can see
+    everything on it — notes, soil data, etc. The Note/SoilData Nodes
+    don't have their own get_queryset, so they ride along on the Site's
+    visibility decision."""
+    public_site = Site.objects.create(
+        name="public-with-notes",
+        latitude=0,
+        longitude=0,
+        elevation=0,
+        privacy=Site.PUBLIC,
+        owner=user,
+    )
+    note = SiteNote.objects.create(site=public_site, content="public note", author=user)
+
+    _force_login_as(client, stranger)
+    response = graphql_query(
+        'query { site(id: "%s") { notes { edges { node { id content } } } } }'
+        % public_site.id,
+        client=client,
+    )
+    body = response.json()
+    note_ids = [edge["node"]["id"] for edge in body["data"]["site"]["notes"]["edges"]]
+    assert str(note.id) in note_ids
+
+
+def test_public_site_soil_data_visible_to_authenticated_stranger(client, stranger, user):
+    public_site = Site.objects.create(
+        name="public-with-soildata",
+        latitude=0,
+        longitude=0,
+        elevation=0,
+        privacy=Site.PUBLIC,
+        owner=user,
+    )
+    SoilData.objects.create(site=public_site)
+
+    _force_login_as(client, stranger)
+    response = graphql_query(
+        'query { site(id: "%s") { soilData { __typename } } }' % public_site.id,
+        client=client,
+    )
+    body = response.json()
+    assert body["data"]["site"]["soilData"] is not None
+    assert body["data"]["site"]["soilData"]["__typename"] == "SoilDataNode"
+
+
+# --- Write gating: publicness must not unlock mutations ---
+
+
+def test_stranger_cannot_update_public_site(client, stranger, user):
+    """Authentication + visibility is read-only. updateSite still requires
+    ownership / project-management permission — the privacy flag does
+    not relax write access."""
+    public_site = Site.objects.create(
+        name="public-write-probe",
+        latitude=0,
+        longitude=0,
+        elevation=0,
+        privacy=Site.PUBLIC,
+        owner=user,
+    )
+
+    _force_login_as(client, stranger)
+    mutation = """
+        mutation updateSite($input: SiteUpdateMutationInput!) {
+          updateSite(input: $input) { errors site { id name } }
+        }
+    """
+    response = graphql_query(
+        mutation,
+        variables={"input": {"id": str(public_site.id), "name": "hijacked"}},
+        client=client,
+    )
+    body = response.json()
+    # Either a top-level error envelope or an errors payload on the mutation.
+    failed = "errors" in body or (
+        body.get("data", {}).get("updateSite", {}) is None
+        or body["data"]["updateSite"].get("errors")
+    )
+    assert failed, f"expected stranger to be rejected; got {json.dumps(body)}"
+
+    public_site.refresh_from_db()
+    assert public_site.name == "public-write-probe"
+
+
+def test_stranger_cannot_delete_public_site(client, stranger, user):
+    public_site = Site.objects.create(
+        name="public-delete-probe",
+        latitude=0,
+        longitude=0,
+        elevation=0,
+        privacy=Site.PUBLIC,
+        owner=user,
+    )
+
+    _force_login_as(client, stranger)
+    mutation = """
+        mutation deleteSite($input: SiteDeleteMutationInput!) {
+          deleteSite(input: $input) { errors site { id } }
+        }
+    """
+    response = graphql_query(
+        mutation,
+        variables={"input": {"id": str(public_site.id)}},
+        client=client,
+    )
+    body = response.json()
+    failed = "errors" in body or (
+        body.get("data", {}).get("deleteSite", {}) is None
+        or body["data"]["deleteSite"].get("errors")
+    )
+    assert failed, f"expected stranger to be rejected; got {json.dumps(body)}"
+    assert Site.objects.filter(id=public_site.id).exists()

--- a/terraso_backend/tests/graphql/test_sites_public_visibility.py
+++ b/terraso_backend/tests/graphql/test_sites_public_visibility.py
@@ -131,9 +131,7 @@ def test_private_site_by_id_hidden_from_authenticated_stranger(client, stranger,
     )
 
     _force_login_as(client, stranger)
-    response = graphql_query(
-        'query { site(id: "%s") { id } }' % private_site.id, client=client
-    )
+    response = graphql_query('query { site(id: "%s") { id } }' % private_site.id, client=client)
     body = response.json()
     assert "errors" in body or body["data"]["site"] is None
 
@@ -165,9 +163,7 @@ def test_anonymous_does_not_see_public_site_by_id(client_query_no_token, user):
         privacy=Site.PUBLIC,
         owner=user,
     )
-    response = client_query_no_token(
-        'query { site(id: "%s") { id } }' % public_site.id
-    )
+    response = client_query_no_token('query { site(id: "%s") { id } }' % public_site.id)
     body = response.json()
     assert "errors" in body or body["data"]["site"] is None
 
@@ -243,8 +239,7 @@ def test_public_site_notes_visible_to_authenticated_stranger(client, stranger, u
 
     _force_login_as(client, stranger)
     response = graphql_query(
-        'query { site(id: "%s") { notes { edges { node { id content } } } } }'
-        % public_site.id,
+        'query { site(id: "%s") { notes { edges { node { id content } } } } }' % public_site.id,
         client=client,
     )
     body = response.json()

--- a/terraso_backend/tests/graphql/test_users.py
+++ b/terraso_backend/tests/graphql/test_users.py
@@ -21,7 +21,12 @@ from apps.core.models import User
 pytestmark = pytest.mark.django_db
 
 
-def test_users_query(client_query, users):
+def test_users_query(client_query, user, users):
+    # Listing the whole users connection is a superuser-only capability
+    # (UserFilter.qs default-denies enumeration to regular callers); promote
+    # the caller so this exercises node serialization over the full set.
+    user.is_superuser = True
+    user.save()
     response = client_query(
         """
         {users {
@@ -61,7 +66,11 @@ def test_user_get_one_by_id(client_query, users):
     assert user_result["profileImage"] == user.profile_image
 
 
-def test_users_query_has_total_count(client_query, users):
+def test_users_query_has_total_count(client_query, user, users):
+    # Full enumeration is superuser-only (see UserFilter.qs); promote the
+    # caller so totalCount reflects the whole table.
+    user.is_superuser = True
+    user.save()
     response = client_query(
         """
         {users {

--- a/terraso_backend/tests/soil_id/test_integration.py
+++ b/terraso_backend/tests/soil_id/test_integration.py
@@ -20,9 +20,20 @@ import pytest
 import structlog
 from graphene_django.utils.testing import graphql_query
 
+from apps.auth.services import JWTService
+
 pytestmark = pytest.mark.django_db
 
 logger = structlog.get_logger(__name__)
+
+
+@pytest.fixture
+def auth_headers(user):
+    # Soil ID lookups now require an authenticated caller; attach a JWT for
+    # the test user so these integration tests exercise the real auth path.
+    token = JWTService().create_access_token(user)
+    return {"AUTHORIZATION": f"Bearer {token}"}
+
 
 SOIL_MATCH_FRAGMENTS = """
   fragment soilMatch on SoilMatchInfo {
@@ -145,7 +156,7 @@ for idx, coords in enumerate(us_coordinates):
 
 @pytest.mark.integration
 @pytest.mark.parametrize("coords, with_data", us_tests)
-def test_us_integration(client, coords, with_data):
+def test_us_integration(client, auth_headers, coords, with_data):
     # run it twice to exercise the cache
     for _ in range(0, 2):
         response = graphql_query(
@@ -168,6 +179,7 @@ def test_us_integration(client, coords, with_data):
                 },
             },
             client=client,
+            headers=auth_headers,
         )
 
         assert response.json()["data"] is not None
@@ -201,7 +213,7 @@ def test_us_integration(client, coords, with_data):
 # DEPRECATED
 @pytest.mark.integration
 @pytest.mark.parametrize("coords, with_data", us_tests)
-def test_us_integration_old_endpoint(client, coords, with_data):
+def test_us_integration_old_endpoint(client, auth_headers, coords, with_data):
     # run it twice to exercise the cache
     for _ in range(0, 2):
         response = graphql_query(
@@ -224,6 +236,7 @@ def test_us_integration_old_endpoint(client, coords, with_data):
                 },
             },
             client=client,
+            headers=auth_headers,
         )
 
         assert response.json()["data"] is not None
@@ -294,7 +307,7 @@ def transform_rfv(rfv):
 
 @pytest.mark.integration
 @pytest.mark.parametrize("pedon_id, pedon", pedons)
-def test_global_integration(client, pedon_id, pedon):
+def test_global_integration(client, auth_headers, pedon_id, pedon):
     depth_dependent_data = []
 
     for i, row in pedon.iterrows():
@@ -316,6 +329,7 @@ def test_global_integration(client, pedon_id, pedon):
             },
         },
         client=client,
+        headers=auth_headers,
     )
 
     assert response.json()["data"] is not None
@@ -347,7 +361,7 @@ def test_global_integration(client, pedon_id, pedon):
 # DEPRECATED
 @pytest.mark.integration
 @pytest.mark.parametrize("pedon_id, pedon", pedons)
-def test_global_integration_old_endpoint(client, pedon_id, pedon):
+def test_global_integration_old_endpoint(client, auth_headers, pedon_id, pedon):
     depth_dependent_data = []
 
     for i, row in pedon.iterrows():
@@ -369,6 +383,7 @@ def test_global_integration_old_endpoint(client, pedon_id, pedon):
             },
         },
         client=client,
+        headers=auth_headers,
     )
 
     assert response.json()["data"] is not None

--- a/terraso_backend/tests/soil_id/test_query_auth.py
+++ b/terraso_backend/tests/soil_id/test_query_auth.py
@@ -1,0 +1,41 @@
+# Copyright © 2026 Technology Matters
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see https://www.gnu.org/licenses/.
+
+from types import SimpleNamespace
+
+import pytest
+from django.contrib.auth.models import AnonymousUser
+
+from apps.graphql.exceptions import GraphQLNotAllowedException
+from apps.soil_id.graphql.soil_id.queries import SoilId, resolve_soil_id
+
+pytestmark = pytest.mark.django_db
+
+
+def _info_for(user):
+    return SimpleNamespace(context=SimpleNamespace(user=user))
+
+
+def test_resolve_soil_id_rejects_anonymous():
+    """Soil ID lookups must reject anonymous callers (regression: the
+    resolvers previously ignored the user, allowing anonymous access)."""
+    with pytest.raises(GraphQLNotAllowedException):
+        resolve_soil_id(None, _info_for(AnonymousUser()))
+
+
+def test_resolve_soil_id_allows_authenticated(user):
+    """Any authenticated user (including partner service accounts) passes the
+    gate; the lookup itself is exercised by the integration tests."""
+    assert isinstance(resolve_soil_id(None, _info_for(user)), SoilId)


### PR DESCRIPTION
Stacked on #2049 — please review that one first. GitHub will auto-retarget
this PR to `main` once #2049 merges; the diff below already shows only this
branch's changes.

Closes the anonymous-access and over-broad-read findings from the security
audit. Four logical groups:

### 1. Foundation: by-id leak (`commons.py`)
`TerrasoRelayNode.get_node_from_global_id` fetched records by id directly,
bypassing each Node's `get_queryset`. So per-Node auth filters applied to
list/connection queries only — `query { site(id:) }` leaked any record by
id (F2/F3). Now routes single-id lookups through `get_queryset`. Also
returns `None` instead of raising on no match (missing vs. forbidden both
read as null).

### 2. Per-Node anonymous scoping
- **`projects.py`** (F5): anonymous fell through to `user_id=None`, which
  over the membership LEFT OUTER JOIN matched all membership-less projects.
  Now short-circuits anonymous → `.none()`.
- **`users.py` `UserNode`** (F1): anonymous → `.none()` (no user-table
  enumeration / by-id lookup).
- **`visualization_config.py`**: top-level detection switched from a
  field-name check to query-path depth, closing the singular
  `visualizationConfig(id:)` leak.

### 3. Sites: scoping + public-read feature (`sites.py`, `models/sites.py`)
Anonymous still rejected. Authenticated read now also includes
`privacy=PUBLIC` sites (`filter_visible_sites`), per product 2026-05-18 for
the future data portal. **Read-only** — writes still go through per-site
permission checks. `.distinct()` added because the membership join
multiplies rows.

### 4. Extra surface gated
- **`export/queries.py`**: explicit anonymous → `[]` (was empty only by
  coincidence).
- **`users.py` `UserAddMutation`**: `BaseAuthenticatedMutation` →
  `BaseAdminMutation` (superuser-only) (F6).
- **`users.py` `UserFilter`**: substring filters (`email__icontains`, …)
  gated to superuser to prevent user-table harvesting (F1 follow-up).

### Tests
Cross-tenant mutation probes, anonymous-scoping suite, and public-site
visibility tests added.
