### PR TITLE
docs: clarify partner soil-ID API access guide

### DIFF
--- a/docs/partner-access/README.md
+++ b/docs/partner-access/README.md
@@ -1,4 +1,4 @@
-# Partner soil-ID access
+# Partner soil-ID API access
 
 How to call the Terraso soil-ID API as a partner, with runnable Python and
 shell examples.
@@ -8,15 +8,15 @@ shell examples.
 Terraso soil-ID is an **HTTPS GraphQL API**, so you can call it from any
 language — the examples in this directory (Python and shell) are just one way.
 
-**Authentication.** The Terraso team supplies you with a long-lived *refresh
-token*. You don't send that token on every request; instead you exchange it for
-a short-lived *access token*, then send the access token as a
+**Authentication.** The Terraso team supplies you with a long-lived _refresh
+token_. You don't send that token on every request; instead you exchange it for
+a short-lived _access token_, then send the access token as a
 `Bearer` credential on each API call. When the access token expires, you
-exchange the refresh token again for a new one. (The example scripts do this
+exchange the refresh token again for a new access token. (The example scripts do this
 automatically and cache the access token for reuse.)
 
 **Making a request.** You send a GraphQL `soilMatches` query with, at minimum, a
-**latitude and longitude**. You may optionally include **soil data** — slope,
+**latitude and longitude**. You may optionally include **soil data** — observational data about slope,
 surface cracks, and, per depth interval, texture, rock-fragment volume, and
 color. The response is a ranked set of soil matches with a variety of
 information about each. **The more soil data you supply, the more accurate the
@@ -24,11 +24,11 @@ match.**
 
 ## Files
 
-| File | Role |
-| --- | --- |
+| File                        | Role                                                                                         |
+| --------------------------- | -------------------------------------------------------------------------------------------- |
 | `soil_id_query_params.json` | The lookup input (latitude/longitude + optional soil `data`). Edit this to change the query. |
-| `soil_id_query.py` | Python example (standard library only). |
-| `soil_id_query.sh` | Shell example (requires `curl` + `jq`). Same behavior as the Python script. |
+| `soil_id_query.py`          | Python example (standard library only).                                                      |
+| `soil_id_query.sh`          | Shell example (requires `curl` + `jq`). Same behavior as the Python script.                  |
 
 Both scripts are equivalent — they run the query, automatically exchange your
 refresh token for an access token when needed, cache that access token, and
@@ -38,8 +38,15 @@ reference for your own implementation. By default they talk to
 
 ## Setup
 
-Put the refresh token you were supplied into a tokens file, kept outside this
-repository:
+You should store the long-lived refresh token securely.
+The sample script puts the refresh and access tokens in ~/secrets/terraso/tokens.json.
+The scripts read the refresh and access tokens from this file and write the access token
+back into it as `access_token`, and subsequent runs reuse it until it expires.
+
+Reminder: do not overwrite your long-lived refresh token with a new shorter-lived token.
+
+This is sample code only; depending on your specific needs, you may want to do something differently.
+To set make the sample scripts work as-is, please do the following:
 
 ```sh
 mkdir -p ~/secrets/terraso
@@ -49,13 +56,10 @@ EOF
 chmod 600 ~/secrets/terraso/tokens.json
 ```
 
-The scripts read the refresh token from this file and write the access token
-back into it as `access_token`, so subsequent runs reuse it until it expires.
-
 ## Run
 
-The response is printed to **stdout**; status/progress messages go to **stderr**,
-so the output stays clean for piping or redirecting:
+The response from both scripts (JSON) goes to **stdout** (clean for piping or a redirect);
+status/progress messages go to **stderr**
 
 ```sh
 python3 soil_id_query.py | jq             # or: ./soil_id_query.sh | jq
@@ -80,63 +84,64 @@ accepts — there are no other fields.
 
 ```json
 {
-  "latitude": -0.85497,
-  "longitude": 36.84891,
-  "data": {
-    "slope": 0.5,
-    "surfaceCracks": "NO_CRACKING",
-    "depthDependentData": [
-      {
-        "depthInterval": { "start": 0, "end": 10 },
-        "texture": "CLAY",
-        "rockFragmentVolume": "VOLUME_0_1",
-        "colorLAB": { "L": 20, "A": 30, "B": 40 }
-      },
-      {
-        "depthInterval": { "start": 10, "end": 30 },
-        "texture": "SANDY_LOAM",
-        "rockFragmentVolume": "VOLUME_1_15",
-        "colorMunsell": "7.5YR 5/4"
-      },
-      {
-        "depthInterval": { "start": 30, "end": 50 },
-        "texture": "CLAY_LOAM",
-        "rockFragmentVolume": "VOLUME_15_35",
-        "colorMunsellNumeric": { "hue": 20, "value": 4, "chroma": 3 }
-      }
-    ]
-  }
+    "latitude": -0.85497,
+    "longitude": 36.84891,
+    "data": {
+        "slope": 0.5,
+        "surfaceCracks": "NO_CRACKING",
+        "depthDependentData": [
+            {
+                "depthInterval": { "start": 0, "end": 10 },
+                "texture": "CLAY",
+                "rockFragmentVolume": "VOLUME_0_1",
+                "colorLAB": { "L": 20, "A": 30, "B": 40 }
+            },
+            {
+                "depthInterval": { "start": 10, "end": 30 },
+                "texture": "SANDY_LOAM",
+                "rockFragmentVolume": "VOLUME_1_15",
+                "colorMunsell": "7.5YR 5/4"
+            },
+            {
+                "depthInterval": { "start": 30, "end": 50 },
+                "texture": "CLAY_LOAM",
+                "rockFragmentVolume": "VOLUME_15_35",
+                "colorMunsellNumeric": { "hue": 20, "value": 4, "chroma": 3 }
+            }
+        ]
+    }
 }
 ```
 
 The three depths above each use a different color form (CIELAB, Munsell string,
 numeric Munsell) to illustrate the options — use whichever you have.
 
-| Field | Required | Notes |
-| --- | --- | --- |
-| `latitude`, `longitude` | yes | Decimal degrees (WGS84). A location-only lookup with no `data` is valid. |
-| `data.slope` | no | Slope, in percent. |
-| `data.surfaceCracks` | no | Enum (see below). |
-| `data.depthDependentData` | no | A list — one object per depth interval; add as many as you have. |
+| Field                     | Required | Notes                                                                    |
+| ------------------------- | -------- | ------------------------------------------------------------------------ |
+| `latitude`, `longitude`   | yes      | Decimal degrees (WGS84). A location-only lookup with no `data` is valid. |
+| `data.slope`              | no       | Slope, in percent.                                                       |
+| `data.surfaceCracks`      | no       | Enum (see below).                                                        |
+| `data.depthDependentData` | no       | A list — one object per depth interval; add as many as you have.         |
 
 Each object in `data.depthDependentData`:
 
-| Field | Required | Notes |
-| --- | --- | --- |
-| `depthInterval` | yes | `{ "start": <cm>, "end": <cm> }`. |
-| `texture` | no | Enum (see below). |
-| `rockFragmentVolume` | no | Enum (see below). |
-| `colorLAB` | no | CIELAB color `{ "L": <float>, "A": <float>, "B": <float> }` — all three required if present. |
-| `colorMunsell` | no | Munsell color as a string, e.g. `"7.5YR 5/4"` or `"N 5/"` (neutral). |
-| `colorMunsellNumeric` | no | Munsell color as numbers: `{ "hue": <0–100>, "value": <float>, "chroma": <float> }`. |
+| Field                 | Required | Notes                                                                                        |
+| --------------------- | -------- | -------------------------------------------------------------------------------------------- |
+| `depthInterval`       | yes      | `{ "start": <cm>, "end": <cm> }`.                                                            |
+| `texture`             | no       | Enum (see below).                                                                            |
+| `rockFragmentVolume`  | no       | Enum (see below).                                                                            |
+| `colorLAB`            | no       | CIELAB color `{ "L": <float>, "A": <float>, "B": <float> }` — all three required if present. |
+| `colorMunsell`        | no       | Munsell color as a string, e.g. `"7.5YR 5/4"` or `"N 5/"` (neutral).                         |
+| `colorMunsellNumeric` | no       | Munsell color as numbers: `{ "hue": <0–100>, "value": <float>, "chroma": <float> }`.         |
 
 **Color.** Provide it in whichever form you have. If you supply more than one,
-they are used in this order: `colorLAB`, then `colorMunsell`, then
-`colorMunsellNumeric`. A Munsell value that can't be converted to a known color
-is ignored — that depth is treated as having no color (the request still
-succeeds). **Most callers should use the `colorMunsell` string form** (e.g.
-`"7.5YR 5/4"`); the numeric form below exists mainly for data already stored
-that way.
+only the **first present** form is used — priority is `colorLAB`, then
+`colorMunsell`, then `colorMunsellNumeric` — and the others are ignored. If that
+chosen form can't be converted to a known color (e.g. an out-of-gamut Munsell
+value), the depth is treated as having no color; it does **not** fall back to
+another form you supplied (the request still succeeds). **Most callers should
+use the `colorMunsell` string form** (e.g. `"7.5YR 5/4"`); the numeric form below
+exists mainly for data already stored that way.
 
 **Numeric Munsell hue (`colorMunsellNumeric.hue`).** Only relevant if you use
 the numeric form. The hue is a single number on a 0–100 scale: the ten Munsell
@@ -144,9 +149,9 @@ hue families in order, ten units each. Compute it as `family_index × 10 +
 substep`, where `substep` is the number written before the family letters
 (`2.5`, `5`, `7.5`, or `10`):
 
-| Family | R | YR | Y | GY | G | BG | B | PB | P | RP |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Index | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 |
+| Family | R   | YR  | Y   | GY  | G   | BG  | B   | PB  | P   | RP  |
+| ------ | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Index  | 0   | 1   | 2   | 3   | 4   | 5   | 6   | 7   | 8   | 9   |
 
 Examples: `7.5YR → 1×10 + 7.5 = 17.5`; `10R → 0×10 + 10 = 10`;
 `2.5Y → 2×10 + 2.5 = 22.5`; `10YR → 1×10 + 10 = 20`. For a neutral color, use the
@@ -169,7 +174,7 @@ string form (`"N 5/"`) or set `chroma` to `0`.
   tokens file (written `chmod 600`) and in memory — do the same in your own
   code.
 - **Refresh-token rotation.** `/auth/tokens` returns a new `refresh_token`
-  alongside the `access_token`. Keep using your *original* long-lived refresh
+  alongside the `access_token`. Keep using your _original_ long-lived refresh
   token; the examples deliberately preserve it rather than the rotated one.
 - **Configuration.** `TERRASO_API_BASE_URL` (default `https://api.terraso.org`)
   is the only setting; the tokens-file path is fixed at
@@ -179,7 +184,11 @@ string form (`"N 5/"`) or set `chroma` to `0`.
   `reason` such as `DATA_UNAVAILABLE`). Each match's `soilInfo.soilSeries`
   carries the soil `name` and `description`, plus `management` guidance on
   global (non-US) matches; locations in the US also populate the US-only fields
-  (`slope`, `ecologicalSite`, `landCapabilityClass`).
+  (`slope`, `ecologicalSite`, `landCapabilityClass`). For background on what
+  these fields mean, the LandPKS [JSON export guide](https://landpks.terraso.org/help/export-json/)
+  describes similar fields — but treat it as a **glossary, not a structural
+  reference**: the export uses a post-processed format that differs from this
+  API's raw GraphQL response.
 - **Inspecting a token (optional).** Purely for debugging or curiosity, you can
   paste a token into <https://jwt.io> to see its decoded contents — there's no
   need to do this for normal use. Hovering over the `exp` field shows when that

--- a/docs/partner-access/soil_id_query.py
+++ b/docs/partner-access/soil_id_query.py
@@ -54,7 +54,7 @@ Security
 --------
 Token values are never printed, logged, or written into this repository. They
 live only in the tokens file (written ``chmod 600``, outside the repo) and in
-memory; only the soil-ID response is written next to this script.
+memory.
 
 Uses only the Python standard library — no pip install required.
 """

--- a/docs/partner-access/soil_id_query.sh
+++ b/docs/partner-access/soil_id_query.sh
@@ -31,8 +31,6 @@
 # The script fills in / refreshes "access_token". The original long-lived
 # refresh token is preserved (the rotated one from each refresh is ignored).
 #
-# Token values are never printed, logged, or written into this repository.
-#
 # Requires: bash, curl, jq.
 
 set -euo pipefail


### PR DESCRIPTION
Docs-only; no code changes.
This is for the API access work.

Clarifications to the partner soil-ID API access docs (`docs/partner-access/`), based on review feedback.

## Changes
- **Title** now names the API: "Partner soil-ID API access".
- **Authentication**: the refresh token is exchanged for a new *access* token (was ambiguous).
- **Making a request**: clarified the optional "soil data" wording.
- **Color precedence**: now states that only the **first present** form is used (priority `colorLAB` → `colorMunsell` → `colorMunsellNumeric`), the others are ignored, and that an unconvertible chosen form does **not** fall back to another supplied form. Matches `parse_color()` behavior in `resolvers.py`.
- **Result shape**: links the LandPKS [JSON export guide](https://landpks.terraso.org/help/export-json/) as a field **glossary**, with a caveat that its post-processed format differs from the raw GraphQL response.
- **Bug fix**: removed the stale docstring/comment claiming the response is written to a file next to the script — it goes to **stdout**.


