### PR TITLE
feat: add server-side PostHog analytics

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -90,3 +90,9 @@ EXPORT_PAGE_SIZE=50
 # "names"   - include GraphQL operation name in request_started/request_finished logs
 # "full"    - also include input variables (request_started) and response (request_finished)
 GRAPHQL_LOG_LEVEL="names"
+
+# PostHog product analytics (server-side). Disabled unless POSTHOG_ENABLED is
+# true AND POSTHOG_API_KEY is set. Use the same project key as the mobile client.
+POSTHOG_API_KEY=
+POSTHOG_HOST=https://us.i.posthog.com
+POSTHOG_ENABLED=false

--- a/docs/posthog.md
+++ b/docs/posthog.md
@@ -1,0 +1,109 @@
+# PostHog Analytics (server-side)
+
+Server-side PostHog event capture from terraso-backend, on the **same PostHog
+project as the mobile client** so events merge onto one person and one
+DAU/WAU/MAU. Implemented in `apps/core/analytics.py`; hooked into auth, export,
+soil-id, and the user/site/project delete mutations.
+
+> Code comments reference the section numbers below (`§4`, `§5`). Keep them stable.
+
+---
+
+## 1. Config
+
+`settings.py` (prettyconf `config()`), values from `~/secrets/terraso-backend/.env`:
+
+- `POSTHOG_API_KEY` (default `""`) — same project key as mobile. Never committed.
+- `POSTHOG_HOST` (default `https://us.i.posthog.com`, PostHog Cloud US).
+- `POSTHOG_ENABLED` (default `false`).
+
+Capture is a **no-op unless `POSTHOG_ENABLED` is true AND `POSTHOG_API_KEY` is
+set**. Tests hard-disable it via an autouse fixture in `tests/conftest.py`, so
+dev/test/CI never emit regardless of `.env`.
+
+`analytics.capture()` is **fail-safe / fire-and-forget**: wrapped in try/except,
+batches and sends on a background thread, and must never break a request.
+
+---
+
+## 2. Identity & person properties
+
+- `distinct_id` = the **Terraso user UUID** (`User.id`) — same key mobile uses, so
+  backend + mobile events land on the same person.
+- Person props via `$set` (`analytics.user_person_properties(user)`): `email`,
+  `email_domain`, `name` — matching mobile. Attached wherever we have `request.user`.
+- **Token-based exports** resolve to the token **owner** via `_setup_token_user()`
+  (`apps/export/views.py`), so `request.user` is always a real `User` — no
+  anonymous/marker id needed.
+
+Every backend event also carries `source: "backend"` and `platform` (= deploy
+environment: `development`/`staging`/`production`, same key/values as mobile).
+
+---
+
+## 3. Division of labor with mobile
+
+**No duplication** — each event has exactly one home. The backend captures only
+the gaps mobile can't cover:
+
+- **Server-only / lifecycle** events mobile can't see (refreshes, deletes).
+- **Direct-to-backend** actions (`soil_id_lookup`, `export_file_download`) that
+  also occur via web, partner API, shared links, and direct GraphQL — the backend
+  is the only place that sees *every* one.
+
+Backend does **not** emit: `login`, `site_created`, `project_created`,
+`team_member_added`, `site_transfer` (mobile owns these).
+
+> `soil_id_lookup` / `export_file_download` currently overlap mobile's copies.
+> Backend is intended to be their single home; mobile's copies get retired later
+> (§6). Don't double-count in insights meanwhile — split by `source`.
+
+---
+
+## 4. Backend events
+
+| Event | Hook point | Properties (besides `source`/`platform` + `$set`) |
+|---|---|---|
+| `session_refreshed` | `RefreshAccessTokenView` (`apps/auth/views.py`) | `service_account` (bool) — active-user heartbeat (§5) |
+| `soil_id_lookup` | `resolve_soil_id_result()` (`apps/soil_id/graphql/soil_id/resolvers.py`) | `latitude`, `longitude`, `status`, `data_region`, `has_input_data`, `match_count`, `cache_hit` |
+| `export_file_download` | export views (`apps/export/views.py`) | `resource_type` (USER/PROJECT/SITE), `resource_name`, `format`, `via` (token/id) |
+| `site_deleted` | `SiteDeleteMutation` | `site_name`, `in_project` (bool) |
+| `project_deleted` | `ProjectDeleteMutation` | `project_name`, `transferred_sites` (bool) |
+| `user_created` | OAuth first sign-up / `TokenExchangeView` / `UserAddMutation` | `auth_provider` (google/apple/microsoft/admin) |
+| `user_deleted` | `UserDeleteMutation` | — (name/email on `$set`) |
+
+> **PII note:** `export_file_download.resource_name` is a person's name/email when
+> `resource_type == USER`. Accepted for now.
+
+`soil_id_lookup` computes `cache_hit` before the lookup warms the cache, and only
+runs that extra (index-only) query when `analytics.is_enabled()`.
+
+Phase-2 candidates: `soil_data_recorded`, `story_map_created`/`published`,
+`export_token_created`, `login_failed`/`signup_failed`.
+
+---
+
+## 5. Active users via `session_refreshed`
+
+An active client hits `/auth/tokens` ~once per access-token lifetime, giving
+PostHog's built-in DAU/WAU/MAU a heartbeat that covers **all** clients (incl.
+web) — something mobile can't see.
+
+- Resolution tracks `JWT_ACCESS_EXP_DELTA_SECONDS`. Treat it as a **lower bound**:
+  the longer the TTL, the more active sessions go uncounted (a still-valid token
+  triggers no refresh). Render is currently 1 day, planned 2h — shorter is better.
+- Partner long-lived refresh tokens are tagged `service_account: true` (set in
+  `apps/core/admin.py:create_partner_refresh_token`) so service accounts can be
+  filtered out of human active-user counts.
+
+---
+
+## 6. Open items
+
+1. **Retire mobile's `soil_id_lookup` / `export_file_download`** (mobile cleanup)
+   once the backend owns them, to avoid double-counting.
+2. **GDPR person-deletion** — optionally call PostHog's delete-person API on user
+   hard-delete (phase-2 nicety).
+3. **Mobile `login` quirk:** mobile overloads `platform` with the OS on its
+   `login` event; backend always sets `platform` = environment. Worth aligning
+   mobile later (move OS to its own `os` property).

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,10 @@ attrs==25.4.0 \
     #   cattrs
     #   fiona
     #   requests-cache
+backoff==2.2.1 \
+    --hash=sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba \
+    --hash=sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8
+    # via posthog
 boto3==1.42.15 \
     --hash=sha256:94aabb83e3be3e2ea5ffa530cd5e221e8f4eb65f8d126d097e03d1ab80e5c5ce \
     --hash=sha256:d673c9b6bb9e293e028e354de6701351f1881e3fbeb25d739dd33c4940a30929
@@ -324,6 +328,10 @@ cryptography==46.0.3 \
     # via
     #   jwcrypto
     #   pyjwt
+distro==1.9.0 \
+    --hash=sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed \
+    --hash=sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2
+    # via posthog
 dj-database-url==3.0.1 \
     --hash=sha256:43950018e1eeea486bf11136384aec0fe55b29fe6fd8a44553231b85661d9383 \
     --hash=sha256:8994961efb888fc6bf8c41550870c91f6f7691ca751888ebaa71442b7f84eff8
@@ -761,6 +769,10 @@ platformdirs==4.5.1 \
     # via
     #   requests-cache
     #   soil-id
+posthog==7.19.1 \
+    --hash=sha256:a51a09dcda9c9dd4c19802c3028d234ddd67fd6ac5e946ad873157eea36bf969 \
+    --hash=sha256:e0375837d9e0590c7dc58828524a1c4545ae5f596e5b947de47be8dde0435313
+    # via -r requirements/base.in
 prettyconf==2.3.0 \
     --hash=sha256:9c83eb90472522b0f2bc196f7d561ff8c26a1833f838cc32f948ea4d3973cb64 \
     --hash=sha256:d73e025b25ffb188227c88f15755a7e6bfe57203700a9b6f45146b7d6bc55c67

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -18,6 +18,7 @@ graphene-django
 httpx
 openpyxl
 pandas
+posthog
 prettyconf
 psycopg
 pyjwt[crypto]

--- a/terraso_backend/apps/auth/views.py
+++ b/terraso_backend/apps/auth/views.py
@@ -31,6 +31,8 @@ from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.urls import reverse
 from django.views import View
 
+from apps.core import analytics
+
 from .constants import (
     OAUTH_COOKIE_MAX_AGE_SECONDS,
     OAUTH_COOKIE_NAME,
@@ -152,6 +154,14 @@ class AbstractCallbackView(View):
         except Exception as exc:
             logger.exception("Error attempting create access and refresh tokens")
             return HttpResponse(f"Error: {exc}", status=400)
+
+        if created_with_service:
+            analytics.capture(
+                distinct_id=user.id,
+                event="user_created",
+                properties={"auth_provider": created_with_service},
+                set_props=analytics.user_person_properties(user),
+            )
 
         origin = self.state["origin"]
         redirect_uri = self.state["redirectUrl"]
@@ -310,6 +320,16 @@ class RefreshAccessTokenView(View):
 
         access_token, refresh_token = terraso_login(self.request, user)
 
+        # Active-user heartbeat: an active client refreshes once per access-token
+        # lifetime, so this powers PostHog DAU/WAU/MAU (see docs/posthog.md §5). Tag
+        # service accounts so they can be filtered out of human active-user counts.
+        analytics.capture(
+            distinct_id=user.id,
+            event="session_refreshed",
+            properties={"service_account": bool(refresh_payload.get("service_account"))},
+            set_props=analytics.user_person_properties(user),
+        )
+
         return JsonResponse(
             {
                 "access_token": access_token,
@@ -445,6 +465,15 @@ class TokenExchangeView(View):
             )
 
         access_token, refresh_token = terraso_login(request, user)
+
+        if created:
+            analytics.capture(
+                distinct_id=user.id,
+                event="user_created",
+                properties={"auth_provider": contents.get("provider")},
+                set_props=analytics.user_person_properties(user),
+            )
+
         resp_payload = {
             "rtoken": refresh_token,
             "atoken": access_token,

--- a/terraso_backend/apps/core/admin.py
+++ b/terraso_backend/apps/core/admin.py
@@ -40,10 +40,12 @@ def create_partner_refresh_token(user, ttl: timedelta) -> str:
     # Revoke by unchecking "Active" on the user: RefreshAccessTokenView rejects
     # refresh for inactive users, so no new access tokens can be minted (existing
     # access tokens expire within JWT_ACCESS_EXP_DELTA_SECONDS).
+    # `service_account` marks this as a long-lived partner/service credential so
+    # analytics can exclude it from human active-user counts (see docs/posthog.md §5).
     return JWTService().create_token(
         user,
         expiration=int(ttl.total_seconds()),
-        extra_payload={"refresh": True},
+        extra_payload={"refresh": True, "service_account": True},
     )
 
 

--- a/terraso_backend/apps/core/analytics.py
+++ b/terraso_backend/apps/core/analytics.py
@@ -1,0 +1,110 @@
+# Copyright © 2026 Technology Matters
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see https://www.gnu.org/licenses/.
+
+"""Thin, fail-safe wrapper around PostHog for server-side product analytics.
+
+Every call here is fire-and-forget: analytics must never break a request. When
+``POSTHOG_ENABLED`` is false or no API key is configured (dev/test/CI), all
+functions are no-ops and the PostHog client is never even constructed.
+
+Conventions (see docs/posthog.md):
+- ``distinct_id`` is the Terraso user UUID, matching the mobile client, so backend
+  and mobile events land on the same person.
+- Every event carries ``source: "backend"`` and ``platform`` = the deploy
+  environment (``settings.ENV``), reusing the mobile client's ``platform`` key so
+  one PostHog filter spans both sources.
+- Person properties (email / email_domain / name) are attached via ``$set``,
+  mirroring the mobile client's ``identify()`` call.
+"""
+
+import structlog
+from django.conf import settings
+
+logger = structlog.get_logger(__name__)
+
+# Lazily-constructed singleton PostHog client. Stays None while analytics is
+# disabled or if construction fails (we retry on the next call in that case).
+_client = None
+
+
+def is_enabled() -> bool:
+    """True only when analytics is switched on and an API key is present."""
+    return bool(getattr(settings, "POSTHOG_ENABLED", False) and settings.POSTHOG_API_KEY)
+
+
+def _get_client():
+    global _client
+    if _client is not None:
+        return _client
+    try:
+        from posthog import Posthog
+
+        _client = Posthog(
+            project_api_key=settings.POSTHOG_API_KEY,
+            host=settings.POSTHOG_HOST,
+        )
+    except Exception:
+        # Never let analytics setup break the app; try again next time.
+        logger.exception("posthog_client_init_failed")
+        _client = None
+    return _client
+
+
+def capture(distinct_id, event, properties=None, set_props=None):
+    """Send one event to PostHog. No-op unless analytics is enabled. Never raises.
+
+    Args:
+        distinct_id: the person identifier (Terraso user UUID). Falsy → skipped.
+        event: the snake_case event name (reuse mobile's names where they overlap).
+        properties: event-specific properties; ``source``/``platform`` are added here.
+        set_props: person properties to merge onto the profile via ``$set``.
+    """
+    if not is_enabled() or not distinct_id:
+        return
+    try:
+        client = _get_client()
+        if client is None:
+            return
+        props = {
+            "source": "backend",
+            "platform": settings.ENV,
+            **(properties or {}),
+        }
+        if set_props:
+            props["$set"] = set_props
+        client.capture(distinct_id=str(distinct_id), event=event, properties=props)
+    except Exception:
+        # Fire-and-forget: a failed capture must never affect the request.
+        # NB: structlog reserves the `event` kwarg for the log message, so the
+        # event name is passed under a different key.
+        logger.exception("posthog_capture_failed", event_name=event)
+
+
+def user_person_properties(user):
+    """Standard person properties for a user, mirroring the mobile client.
+
+    Returns ``{email, email_domain, name}`` (name/email_domain omitted when empty),
+    or None if there's no user.
+    """
+    if user is None:
+        return None
+    email = getattr(user, "email", "") or ""
+    props = {"email": email}
+    if "@" in email:
+        props["email_domain"] = email.rsplit("@", 1)[-1]
+    name = f"{getattr(user, 'first_name', '')} {getattr(user, 'last_name', '')}".strip()
+    if name:
+        props["name"] = name
+    return props

--- a/terraso_backend/apps/export/views.py
+++ b/terraso_backend/apps/export/views.py
@@ -15,8 +15,11 @@
 
 from urllib.parse import quote, unquote
 
+import structlog
 from django.contrib.auth import get_user_model
 from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
+
+from apps.core import analytics
 
 from .fetch_data import fetch_all_notes_for_site, fetch_site_data, fetch_soil_id
 from .fetch_lists import fetch_all_sites, fetch_project_list, fetch_user_owned_sites
@@ -24,6 +27,8 @@ from .formatters import sites_to_csv
 from .html_pages import export_page_html, invalid_token_page
 from .models import ExportToken
 from .transformers import transform_site_data
+
+logger = structlog.get_logger(__name__)
 
 
 def _resolve_export_token(token):
@@ -233,14 +238,55 @@ def _validate_output_format(output_format):
     return None
 
 
-def _export_sites_response(all_sites, output_format, filename):
+def _capture_export_download(request, resource_type, resource_name, output_format, via):
+    """Emit the `export_file_download` event. Best-effort; never raises.
+
+    The backend serves *every* export — shared token links, web, direct URLs — so it
+    is the single source of truth for export usage (see docs/posthog.md §4). For token-based
+    exports `request.user` is the token owner (set by `_setup_token_user`), so we always
+    have a real user to attribute to.
+    """
+    try:
+        user = getattr(request, "user", None)
+        authed = getattr(user, "is_authenticated", False)
+        analytics.capture(
+            distinct_id=getattr(user, "id", None),
+            event="export_file_download",
+            properties={
+                "resource_type": resource_type,  # USER, PROJECT, or SITE
+                "resource_name": resource_name,
+                "format": output_format,
+                "via": via,
+            },
+            set_props=analytics.user_person_properties(user) if authed else None,
+        )
+    except Exception:
+        logger.exception("export_file_download analytics capture failed")
+
+
+def _export_sites_response(
+    all_sites,
+    output_format,
+    filename,
+    request=None,
+    resource_type=None,
+    resource_name=None,
+    via=None,
+):
     """Helper function to generate export response for a list of sites.
 
     Args:
         all_sites: List of site data dicts
         output_format: "raw", "json", or "csv" (must be validated by caller)
         filename: Base filename for Content-Disposition header
+        request: the Django request (enables analytics capture when provided)
+        resource_type: PROJECT / SITE / USER, for analytics
+        resource_name: name of the exported project/site/user, for analytics
+        via: "token" or "id", for analytics
     """
+    if request is not None:
+        _capture_export_download(request, resource_type, resource_name, output_format, via)
+
     # Determine file format (raw uses json file extension)
     format = "json" if output_format == "raw" else output_format
 
@@ -323,7 +369,15 @@ def project_export(request, project_token, project_name, format):
     _setup_token_user(request, export_token)
     filename = _get_resource_name(export_token) or unquote(project_name)
     all_sites = _export_project_sites(export_token.resource_id, request, output_format)
-    return _export_sites_response(all_sites, output_format, filename)
+    return _export_sites_response(
+        all_sites,
+        output_format,
+        filename,
+        request=request,
+        resource_type="PROJECT",
+        resource_name=filename,
+        via="token",
+    )
 
 
 def site_export(request, site_token, site_name, format):
@@ -341,7 +395,15 @@ def site_export(request, site_token, site_name, format):
     _setup_token_user(request, export_token)
     filename = _get_resource_name(export_token) or unquote(site_name)
     all_sites = _export_single_site(export_token.resource_id, request, output_format)
-    return _export_sites_response(all_sites, output_format, filename)
+    return _export_sites_response(
+        all_sites,
+        output_format,
+        filename,
+        request=request,
+        resource_type="SITE",
+        resource_name=filename,
+        via="token",
+    )
 
 
 def user_owned_sites_export(request, user_token, user_name, format):
@@ -359,7 +421,15 @@ def user_owned_sites_export(request, user_token, user_name, format):
     _setup_token_user(request, export_token)
     display_name = _get_resource_name(export_token) or unquote(user_name)
     all_sites = _export_user_owned_sites(export_token.resource_id, request, output_format)
-    return _export_sites_response(all_sites, output_format, f"{display_name}_owned_sites")
+    return _export_sites_response(
+        all_sites,
+        output_format,
+        f"{display_name}_owned_sites",
+        request=request,
+        resource_type="USER",
+        resource_name=display_name,
+        via="token",
+    )
 
 
 def user_all_sites_export(request, user_token, user_name, format):
@@ -377,7 +447,15 @@ def user_all_sites_export(request, user_token, user_name, format):
     _setup_token_user(request, export_token)
     display_name = _get_resource_name(export_token) or unquote(user_name)
     all_sites = _export_user_all_sites(export_token.resource_id, request, output_format)
-    return _export_sites_response(all_sites, output_format, f"{display_name}_and_projects")
+    return _export_sites_response(
+        all_sites,
+        output_format,
+        f"{display_name}_and_projects",
+        request=request,
+        resource_type="USER",
+        resource_name=display_name,
+        via="token",
+    )
 
 
 # ID-based exports (authenticated, enforce permissions)
@@ -401,7 +479,15 @@ def project_export_by_id(request, project_id, project_name, format):
         filename = unquote(project_name)
 
     all_sites = _export_project_sites(project_id, request, output_format)
-    return _export_sites_response(all_sites, output_format, filename)
+    return _export_sites_response(
+        all_sites,
+        output_format,
+        filename,
+        request=request,
+        resource_type="PROJECT",
+        resource_name=filename,
+        via="id",
+    )
 
 
 def site_export_by_id(request, site_id, site_name, format):
@@ -422,7 +508,15 @@ def site_export_by_id(request, site_id, site_name, format):
         filename = unquote(site_name)
 
     all_sites = _export_single_site(site_id, request, output_format)
-    return _export_sites_response(all_sites, output_format, filename)
+    return _export_sites_response(
+        all_sites,
+        output_format,
+        filename,
+        request=request,
+        resource_type="SITE",
+        resource_name=filename,
+        via="id",
+    )
 
 
 def user_owned_sites_export_by_id(request, user_id, user_name, format):
@@ -443,7 +537,15 @@ def user_owned_sites_export_by_id(request, user_id, user_name, format):
         display_name = unquote(user_name)
 
     all_sites = _export_user_owned_sites(user_id, request, output_format)
-    return _export_sites_response(all_sites, output_format, f"{display_name}_owned_sites")
+    return _export_sites_response(
+        all_sites,
+        output_format,
+        f"{display_name}_owned_sites",
+        request=request,
+        resource_type="USER",
+        resource_name=display_name,
+        via="id",
+    )
 
 
 def user_all_sites_export_by_id(request, user_id, user_name, format):
@@ -464,7 +566,15 @@ def user_all_sites_export_by_id(request, user_id, user_name, format):
         display_name = unquote(user_name)
 
     all_sites = _export_user_all_sites(user_id, request, output_format)
-    return _export_sites_response(all_sites, output_format, f"{display_name}_and_projects")
+    return _export_sites_response(
+        all_sites,
+        output_format,
+        f"{display_name}_and_projects",
+        request=request,
+        resource_type="USER",
+        resource_name=display_name,
+        via="id",
+    )
 
 
 # HTML landing pages for export links

--- a/terraso_backend/apps/graphql/schema/sites.py
+++ b/terraso_backend/apps/graphql/schema/sites.py
@@ -21,6 +21,7 @@ from graphene import relay
 from graphene_django import DjangoObjectType
 from graphene_django.filter import TypedFilter
 
+from apps.core import analytics
 from apps.project_management.graphql.projects import ProjectNode
 from apps.project_management.models import Project, Site, sites
 from apps.project_management.permission_rules import Context
@@ -270,6 +271,14 @@ class SiteDeleteMutation(BaseDeleteMutation):
             cls.not_allowed(MutationTypes.DELETE)
 
         result = super().mutate_and_get_payload(root, info, **kwargs)
+
+        analytics.capture(
+            distinct_id=user.id,
+            event="site_deleted",
+            properties={"site_name": site.name, "in_project": site.project_id is not None},
+            set_props=analytics.user_person_properties(user),
+        )
+
         return result
 
 

--- a/terraso_backend/apps/graphql/schema/users.py
+++ b/terraso_backend/apps/graphql/schema/users.py
@@ -22,6 +22,7 @@ from graphene_django import DjangoObjectType
 
 from apps.auth.services import JWTService
 from apps.collaboration.models import Membership
+from apps.core import analytics
 from apps.core.hubspot import create_account_deletion_ticket
 from apps.core.models import User, UserPreference
 from apps.core.models.users import USER_PREFS_KEY_ACCOUNT_DELETION, USER_PREFS_KEYS
@@ -175,6 +176,13 @@ class UserAddMutation(BaseAdminMutation):
             kwargs.pop("email"), password=kwargs.pop("password"), **kwargs
         )
 
+        analytics.capture(
+            distinct_id=user.id,
+            event="user_created",
+            properties={"auth_provider": "admin"},
+            set_props=analytics.user_person_properties(user),
+        )
+
         return cls(user=user)
 
 
@@ -239,7 +247,15 @@ class UserDeleteMutation(BaseDeleteMutation):
                 model_name=User.__name__, operation=MutationTypes.DELETE
             )
 
-        return super().mutate_and_get_payload(root, info, **kwargs)
+        result = super().mutate_and_get_payload(root, info, **kwargs)
+
+        analytics.capture(
+            distinct_id=_id,
+            event="user_deleted",
+            set_props=analytics.user_person_properties(request_user),
+        )
+
+        return result
 
 
 class UserPreferenceUpdate(BaseAuthenticatedMutation):

--- a/terraso_backend/apps/project_management/graphql/projects.py
+++ b/terraso_backend/apps/project_management/graphql/projects.py
@@ -28,6 +28,7 @@ from apps.collaboration.graphql.memberships import (
     MembershipNodeMixin,
 )
 from apps.collaboration.models import Membership
+from apps.core import analytics
 from apps.core.models import User
 from apps.graphql.schema.commons import (
     BaseAuthenticatedMutation,
@@ -230,6 +231,16 @@ class ProjectDeleteMutation(BaseDeleteMutation):
                 site.project = transfer_project
             Site.objects.bulk_update(project_sites, ["project"])
         result = super().mutate_and_get_payload(root, info, **kwargs)
+
+        analytics.capture(
+            distinct_id=user.id,
+            event="project_deleted",
+            properties={
+                "project_name": project.name,
+                "transferred_sites": "transfer_project_id" in kwargs,
+            },
+            set_props=analytics.user_person_properties(user),
+        )
 
         return result
 

--- a/terraso_backend/apps/soil_id/graphql/soil_id/resolvers.py
+++ b/terraso_backend/apps/soil_id/graphql/soil_id/resolvers.py
@@ -25,6 +25,7 @@ from django.views.decorators.debug import sensitive_variables
 from soil_id import global_soil, us_soil
 from soil_id.utils import find_region_for_location
 
+from apps.core import analytics
 from apps.soil_id.graphql.soil_id.types import (
     DataBasedSoilMatch,
     DataBasedSoilMatches,
@@ -471,7 +472,62 @@ def resolve_data_based_result(
         return SoilIdFailure(reason=SoilIdFailureReason.ALGORITHM_FAILURE)
 
 
+def _capture_soil_id_lookup(info, latitude, longitude, data, result, cache_hit):
+    """Emit the `soil_id_lookup` event. Best-effort; never raises (see docs/posthog.md §4).
+
+    The backend sees *every* lookup — app, web, partner API, direct GraphQL — so it's
+    the single source of truth for soil-ID usage.
+    """
+    try:
+        user = getattr(getattr(info, "context", None), "user", None)
+        if isinstance(result, SoilMatches):
+            status, match_count = "matches", len(result.matches or [])
+        elif isinstance(result, SoilIdFailure):
+            status, match_count = "failure", 0
+        else:
+            status, match_count = "unknown", 0
+        region = getattr(result, "data_region", None)
+        properties = {
+            "latitude": latitude,
+            "longitude": longitude,
+            "status": status,
+            "data_region": getattr(region, "value", None),
+            "has_input_data": data is not None,
+            "match_count": match_count,
+        }
+        if cache_hit is not None:
+            properties["cache_hit"] = cache_hit
+        authed = getattr(user, "is_authenticated", False)
+        analytics.capture(
+            distinct_id=getattr(user, "id", None),
+            event="soil_id_lookup",
+            properties=properties,
+            set_props=analytics.user_person_properties(user) if authed else None,
+        )
+    except Exception:
+        logger.exception("soil_id_lookup analytics capture failed")
+
+
 def resolve_soil_id_result(
+    _parent, _info, latitude: float, longitude: float, data: Optional[SoilIdInputData] = None
+):
+    # Determine cache_hit before the lookup warms the cache; only pay for the
+    # extra (cheap, index-only) query when analytics is actually enabled.
+    cache_hit = None
+    if analytics.is_enabled():
+        try:
+            cache_hit = SoilIdCache.objects.filter(
+                latitude=SoilIdCache.round_coordinate(latitude),
+                longitude=SoilIdCache.round_coordinate(longitude),
+            ).exists()
+        except Exception:
+            cache_hit = None
+    result = _compute_soil_id_result(_parent, _info, latitude, longitude, data)
+    _capture_soil_id_lookup(_info, latitude, longitude, data, result, cache_hit)
+    return result
+
+
+def _compute_soil_id_result(
     _parent, _info, latitude: float, longitude: float, data: Optional[SoilIdInputData] = None
 ):
     try:

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -335,6 +335,14 @@ JWT_REFRESH_EXP_DELTA_SECONDS = config(
 )
 JWT_ISS = config("JWT_ISS", default="https://terraso.org")
 
+# PostHog product analytics (server-side event capture). Disabled by default;
+# fully a no-op unless POSTHOG_ENABLED is true AND POSTHOG_API_KEY is set, so
+# dev/test/CI never emit. Uses the same project key as the mobile client so
+# events merge onto one person/project. See apps/core/analytics.py and docs/posthog.md.
+POSTHOG_API_KEY = config("POSTHOG_API_KEY", default="")
+POSTHOG_HOST = config("POSTHOG_HOST", default="https://us.i.posthog.com")
+POSTHOG_ENABLED = config("POSTHOG_ENABLED", default=False, cast=config.boolean)
+
 PROFILE_IMAGES_S3_BUCKET = config("PROFILE_IMAGES_S3_BUCKET", default="")
 PROFILE_IMAGES_BASE_URL = f"https://{PROFILE_IMAGES_S3_BUCKET}"
 

--- a/terraso_backend/tests/conftest.py
+++ b/terraso_backend/tests/conftest.py
@@ -39,6 +39,18 @@ from tests.utils import add_soil_data_to_site
 pytestmark = pytest.mark.django_db
 
 
+@pytest.fixture(autouse=True)
+def _disable_analytics(settings):
+    """Hard-disable PostHog for every test so no real analytics events are ever
+    emitted, regardless of the POSTHOG_* values in the environment / .env. Tests
+    run under the production `config.settings`, which reads these from the env, so
+    without this an enabled local/CI .env would send fixture data to PostHog.
+    Tests that want to assert capture behaviour mock `apps.core.analytics` directly.
+    """
+    settings.POSTHOG_ENABLED = False
+    settings.POSTHOG_API_KEY = ""
+
+
 @pytest.fixture
 def users():
     return mixer.cycle(5).blend(User)

--- a/terraso_backend/tests/core/test_analytics.py
+++ b/terraso_backend/tests/core/test_analytics.py
@@ -1,0 +1,117 @@
+# Copyright © 2026 Technology Matters
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see https://www.gnu.org/licenses/.
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from apps.core import analytics
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def reset_client():
+    # Each test starts with no cached client.
+    analytics._client = None
+    yield
+    analytics._client = None
+
+
+def test_is_enabled_requires_flag_and_key(settings):
+    settings.POSTHOG_ENABLED = False
+    settings.POSTHOG_API_KEY = ""
+    assert analytics.is_enabled() is False
+
+    settings.POSTHOG_ENABLED = True
+    settings.POSTHOG_API_KEY = ""
+    assert analytics.is_enabled() is False
+
+    settings.POSTHOG_ENABLED = False
+    settings.POSTHOG_API_KEY = "phc_key"
+    assert analytics.is_enabled() is False
+
+    settings.POSTHOG_ENABLED = True
+    settings.POSTHOG_API_KEY = "phc_key"
+    assert analytics.is_enabled() is True
+
+
+def test_capture_is_noop_when_disabled(settings):
+    settings.POSTHOG_ENABLED = False
+    settings.POSTHOG_API_KEY = ""
+    with mock.patch.object(analytics, "_get_client") as get_client:
+        analytics.capture(distinct_id="user-1", event="session_refreshed")
+        get_client.assert_not_called()
+
+
+def test_capture_skips_when_no_distinct_id(settings):
+    settings.POSTHOG_ENABLED = True
+    settings.POSTHOG_API_KEY = "phc_key"
+    with mock.patch.object(analytics, "_get_client") as get_client:
+        analytics.capture(distinct_id=None, event="session_refreshed")
+        get_client.assert_not_called()
+
+
+def test_capture_stamps_source_and_platform(settings):
+    settings.POSTHOG_ENABLED = True
+    settings.POSTHOG_API_KEY = "phc_key"
+    settings.ENV = "staging"
+    client = mock.Mock()
+    with mock.patch.object(analytics, "_get_client", return_value=client):
+        analytics.capture(
+            distinct_id="user-1",
+            event="soil_id_lookup",
+            properties={"status": "matches"},
+            set_props={"email": "a@b.org"},
+        )
+    client.capture.assert_called_once()
+    kwargs = client.capture.call_args.kwargs
+    assert kwargs["distinct_id"] == "user-1"
+    assert kwargs["event"] == "soil_id_lookup"
+    assert kwargs["properties"]["source"] == "backend"
+    assert kwargs["properties"]["platform"] == "staging"
+    assert kwargs["properties"]["status"] == "matches"
+    assert kwargs["properties"]["$set"] == {"email": "a@b.org"}
+
+
+def test_capture_never_raises(settings):
+    settings.POSTHOG_ENABLED = True
+    settings.POSTHOG_API_KEY = "phc_key"
+    client = mock.Mock()
+    client.capture.side_effect = RuntimeError("network down")
+    with mock.patch.object(analytics, "_get_client", return_value=client):
+        # Must swallow the error — analytics can never break a request.
+        analytics.capture(distinct_id="user-1", event="session_refreshed")
+
+
+def test_user_person_properties():
+    user = SimpleNamespace(email="Jane@Example.ORG", first_name="Jane", last_name="Doe")
+    props = analytics.user_person_properties(user)
+    assert props == {
+        "email": "Jane@Example.ORG",
+        "email_domain": "Example.ORG",
+        "name": "Jane Doe",
+    }
+
+
+def test_user_person_properties_omits_blank_name():
+    user = SimpleNamespace(email="x@y.org", first_name="", last_name="")
+    props = analytics.user_person_properties(user)
+    assert props == {"email": "x@y.org", "email_domain": "y.org"}
+
+
+def test_user_person_properties_none():
+    assert analytics.user_person_properties(None) is None


### PR DESCRIPTION
## Summary

Adds server-side PostHog product analytics to the backend as the single source of truth for **server-only** and **direct-to-backend** events that the mobile client can't see (token refreshes, deletes, and every soil-ID lookup / export — including web, partner API, shared links, and direct GraphQL).

Events use the **same PostHog project as mobile** (distinct_id = `User.id`), so backend and mobile events merge onto one person and one DAU/WAU/MAU.

## What's included

- **`apps/core/analytics.py`** — a thin, fail-safe, fire-and-forget `capture()` wrapper around the `posthog` lib. Stamps `source: "backend"` + `platform` (environment) on every event.
- **Hook points:**
  - `auth/views.py` — `user_created` (OAuth first sign-up / token exchange) and `session_refreshed` (active-user heartbeat)
  - `export/views.py` — `export_file_download`
  - `soil_id/.../resolvers.py` — `soil_id_lookup` (with `cache_hit`)
  - `users.py` / `sites.py` / `projects.py` — `user_created` (admin add), `user_deleted`, `site_deleted`, `project_deleted`
- **Partner refresh tokens** tagged `service_account` so service accounts can be excluded from human active-user counts.
- **`docs/posthog.md`** — design notes and event reference (code comments point here via `§4`/`§5`).

## Safety

- Disabled by default: a **no-op unless `POSTHOG_ENABLED` is true AND `POSTHOG_API_KEY` is set**.
- Hard-disabled in tests via an autouse fixture in `conftest.py`, so dev/test/CI never emit regardless of `.env`.
- Every capture call is wrapped so analytics can never break a request.

## Test plan

- [ ] `make test_unit` (incl. new `tests/core/test_analytics.py`)
- [ ] Verify events arrive from **staging** once `POSTHOG_*` are configured there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)