### PR TITLE
fix(soil_id): hard-delete soil ID cache entries from admin

### DIFF
--- a/terraso_backend/apps/soil_id/admin.py
+++ b/terraso_backend/apps/soil_id/admin.py
@@ -14,6 +14,7 @@
 # along with this program. If not, see https://www.gnu.org/licenses/.
 
 from django.contrib import admin
+from safedelete.config import HARD_DELETE
 
 from apps.soil_id.models import (
     DepthDependentSoilData,
@@ -72,7 +73,34 @@ class SoilDataAdmin(admin.ModelAdmin):
 
 @admin.register(SoilIdCache)
 class SoilIdCacheAdmin(admin.ModelAdmin):
-    list_display = ["id", "latitude", "longitude"]
+    # SoilIdCache is a SafeDeleteModel, but a soft-deleted cache row is pure dead
+    # weight: get_data() ignores it (forcing a recompute) and save_data() just
+    # revives it on the next lookup. So the admin always HARD-deletes here, to
+    # match `TRUNCATE soil_id_soilidcache` and keep the table from accumulating
+    # soft-deleted ghosts under the plain (latitude, longitude) unique constraint.
+    list_display = ["id", "latitude", "longitude", "data_region", "deleted_at"]
+    list_filter = ["data_region"]
+    actions = ["clear_all_cache"]
+
+    def get_queryset(self, request):
+        # Surface soft-deleted ghosts too, so they're visible and purgeable.
+        return SoilIdCache.all_objects.all()
+
+    def delete_queryset(self, request, queryset):
+        # Built-in "Delete selected" action.
+        queryset.delete(force_policy=HARD_DELETE)
+
+    def delete_model(self, request, obj):
+        # Per-object delete button on the change form.
+        obj.delete(force_policy=HARD_DELETE)
+
+    @admin.action(description="Clear ALL soil ID cache entries (hard delete)")
+    def clear_all_cache(self, request, queryset):
+        # Ignore the selection: clear the entire cache, including any
+        # soft-deleted rows, equivalent to a TRUNCATE.
+        total = SoilIdCache.all_objects.all().count()
+        SoilIdCache.all_objects.all().delete(force_policy=HARD_DELETE)
+        self.message_user(request, f"Cleared soil ID cache: {total} row(s) removed.")
 
 
 @admin.register(SoilDataHistory)


### PR DESCRIPTION
## Summary

tldr: This is really clean-up to hard-delete the soil id entries from Django Admin ("Soil ID Cache") instead of just soft delete; not critical but nice.  Also shows a bit more info in the admin panel.

Clearing the soil-ID cache from the Django admin now **hard-deletes** rows instead of soft-deleting them.

`SoilIdCache` inherits soft-delete from `BaseModel` (`SafeDeleteModel`), but a soft-deleted cache row is pure dead weight:
- `get_data()` uses the live manager, so a soft-deleted entry reads as a cache miss → recompute.
- `save_data()`'s `update_or_create` revives the soft-deleted ghost on the next lookup (safedelete is unique-constraint aware).

So admin "Delete selected" never actually removed anything — it just accumulated ghost rows under the plain `(latitude, longitude)` unique constraint. (The dev DB had ~10,458 soft-deleted rows vs 4 live.) The intended way to clear the cache is a hard removal, equivalent to `TRUNCATE soil_id_soilidcache`.

## Changes (`apps/soil_id/admin.py`, `SoilIdCacheAdmin`)

- `delete_queryset` / `delete_model` → force `HARD_DELETE` for the bulk action and per-object delete.
- New **"Clear ALL soil ID cache entries (hard delete)"** action — purges the entire table including pre-existing soft-deleted rows (via `all_objects`), matching a `TRUNCATE`; reports rows removed.
- `get_queryset` now lists via `all_objects` so soft-deleted ghosts are visible/purgeable; `list_display` adds `data_region` + `deleted_at`, with a `data_region` filter.

No model or schema change — soft-delete is left on the model (it's inherited from `BaseModel` like every other soil_id model; removing it would mean a base-class change + migration for negligible benefit). This PR just makes the admin's delete behavior correct.
