### PR TITLE
fix(partner-access): set explicit User-Agent to avoid Cloudflare block

### DIFF
--- a/docs/partner-access/soil_id_query.py
+++ b/docs/partner-access/soil_id_query.py
@@ -123,7 +123,13 @@ query soilMatches($latitude: Float!, $longitude: Float!, $data: SoilIdInputData!
 def _post_json(url, payload, access_token=None):
     """POST a JSON body and return (http_status, parsed_json_body)."""
     data = json.dumps(payload).encode("utf-8")
-    headers = {"Content-Type": "application/json"}
+    # Set an explicit User-Agent: the default "Python-urllib/x.y" is banned by
+    # the Cloudflare edge in front of the API (rejected with HTTP 403 "error
+    # code: 1010" before the request reaches the backend).
+    headers = {
+        "Content-Type": "application/json",
+        "User-Agent": "terraso-partner-soil-id/1.0",
+    }
     if access_token:
         headers["Authorization"] = f"Bearer {access_token}"
     request = urllib.request.Request(url, data=data, headers=headers, method="POST")

--- a/docs/partner-access/soil_id_query.sh
+++ b/docs/partner-access/soil_id_query.sh
@@ -40,6 +40,11 @@ BASE_URL="${BASE_URL%/}"
 GRAPHQL_URL="$BASE_URL/graphql/"
 TOKENS_URL="$BASE_URL/auth/tokens"
 
+# Explicit User-Agent: the Cloudflare edge in front of the API bans some
+# default agents (rejected with HTTP 403 "error code: 1010" before the request
+# reaches the backend), so identify the client explicitly.
+USER_AGENT="terraso-partner-soil-id/1.0"
+
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REQUEST_FILE="$HERE/soil_id_query_params.json"
 TOKENS_FILE="$HOME/secrets/terraso/tokens.json"
@@ -114,6 +119,7 @@ run_query() {
   local args=(
     -sS -o "$TMP_BODY" -w '%{http_code}'
     -X POST "$GRAPHQL_URL"
+    -A "$USER_AGENT"
     -H 'Content-Type: application/json'
     --data "$REQUEST_BODY"
   )
@@ -141,6 +147,7 @@ refresh_access_token() {
   local status
   status="$(curl -sS -o "$TMP_REFRESH" -w '%{http_code}' \
     -X POST "$TOKENS_URL" \
+    -A "$USER_AGENT" \
     -H 'Content-Type: application/json' \
     --data "$(jq -n --arg rt "$REFRESH_TOKEN" '{refresh_token: $rt}')")" \
     || { echo "Could not reach $TOKENS_URL" >&2; exit 1; }


### PR DESCRIPTION
## Summary

The sample partner soil-ID clients (`docs/partner-access/soil_id_query.py` and `soil_id_query.sh`) sent **no `User-Agent`**, so they fell back to the defaults `Python-urllib/x.y` / `curl/x.y`. The Cloudflare edge in front of the API bans those agents: every request was rejected with **HTTP 403 "error code: 1010"** *before* reaching the backend (so nothing appears in origin logs).

This made the partner flow fail on staging — e.g. `Token refresh failed (HTTP 403): error code: 1010`. (The first GraphQL call was blocked too; the script's `_is_auth_failure` reads a 403 as an expired token and goes to refresh, which hits the same wall.)

## Fix

Send an explicit `User-Agent: terraso-partner-soil-id/1.0` on **all** requests (query + refresh) in both scripts.

- `soil_id_query.py` — added to the `_post_json` headers.
- `soil_id_query.sh` — added a `USER_AGENT` var and `-A "$USER_AGENT"` on both curl calls.

## Verification (against staging)

Same request, only the User-Agent differs:

| User-Agent | Result |
|---|---|
| `Python-urllib/3.11` (old default) | HTTP 403, error code 1010 |
| `terraso-partner-soil-id/1.0` (this PR) | HTTP 200, normal GraphQL response |

Confirmed the real client path too: `urllib` with the new UA returns `HTTP 200 {"data":{"__typename":"Query"}}` from `api.staging.terraso.net`. Both scripts pass `py_compile` / `bash -n`.

Docs-only change (no backend code touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)