### PR TITLE
fix: never report to Sentry during test runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,6 @@ jobs:
         run: |
           mkdir -p $HOME/secrets/terraso-backend
           cp .env.sample $HOME/secrets/terraso-backend/.env
-          echo "SENTRY_DSN=${{ secrets.SENTRY_DSN }}" >> $HOME/secrets/terraso-backend/.env
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -112,7 +111,6 @@ jobs:
         run: |
           mkdir -p $HOME/secrets/terraso-backend
           cp .env.sample $HOME/secrets/terraso-backend/.env
-          echo "SENTRY_DSN=${{ secrets.SENTRY_DSN }}" >> $HOME/secrets/terraso-backend/.env
 
       - name: Run tests using built Docker image
         env:
@@ -163,7 +161,6 @@ jobs:
         run: |
           mkdir -p $HOME/secrets/terraso-backend
           cp .env.sample $HOME/secrets/terraso-backend/.env
-          echo "SENTRY_DSN=${{ secrets.SENTRY_DSN }}" >> $HOME/secrets/terraso-backend/.env
           echo "SOIL_ID_DATABASE_URL=postgresql://postgres:postgres@soil-id-db:5432/soil_id" >> $HOME/secrets/terraso-backend/.env
 
       - name: Run integration tests

--- a/terraso_backend/config/settings.py
+++ b/terraso_backend/config/settings.py
@@ -15,6 +15,7 @@
 import base64
 import os
 import re
+import sys
 from typing import TypedDict
 
 import django
@@ -468,7 +469,12 @@ MAPBOX_API_URL = config("MAPBOX_API_URL", default="https://api.mapbox.com")
 MAPBOX_USERNAME = config("MAPBOX_USERNAME", default="")
 MAPBOX_ACCESS_TOKEN = config("MAPBOX_ACCESS_TOKEN", default="")
 
-if config("SENTRY_DSN", default=""):
+# Never initialize Sentry under pytest: test runs (local or CI) would otherwise
+# report expected validation/permission errors and any test crashes to Sentry,
+# drowning real production signal. Test failures are surfaced by the test runner.
+_RUNNING_TESTS = "pytest" in sys.modules
+
+if config("SENTRY_DSN", default="") and not _RUNNING_TESTS:
     sentry_sdk.init(
         dsn=config("SENTRY_DSN", default=""),
         environment=config("ENV", default="development"),
@@ -482,7 +488,8 @@ if config("SENTRY_DSN", default=""):
     )
 else:
     # structlog is already set up at this point, so we can log nicely.
-    structlog.get_logger().warning("SENTRY_DSN is not defined, continuing without Sentry.")
+    reason = "running under pytest" if _RUNNING_TESTS else "SENTRY_DSN is not defined"
+    structlog.get_logger().warning(f"Continuing without Sentry ({reason}).")
 
 HUBSPOT_AUTH_TOKEN = config("HUBSPOT_AUTH_TOKEN", default="")
 HUBSPOT_PORTAL_ID = config("HUBSPOT_PORTAL_ID", default="")


### PR DESCRIPTION
## Summary

Test runs were polluting Sentry with non-problems. Whenever `SENTRY_DSN` was set, `sentry_sdk.init()` ran even under pytest, so **expected** validation/permission errors and intentional error-path tests (e.g. `test_update_depth_dependent_soil_data_constraints`, which deliberately submits invalid values) were captured as Sentry "errors" — drowning real production signal.

This wasn't just local: the repo's `SENTRY_DSN` secret is injected into the `lint`, `test-unit`, and `test-integration` CI jobs, so it happened on **every CI run**.

## Changes

- **`config/settings.py`** — guard `sentry_sdk.init()` with `"pytest" in sys.modules`, so Sentry is never initialized under pytest. Environment-independent (works regardless of where `SENTRY_DSN` comes from). Production/staging (gunicorn, not pytest) is unaffected, so client-error visibility there is preserved.
- **`.github/workflows/build.yml`** — drop the `SENTRY_DSN` injection from the `lint`/`test-unit`/`test-integration` jobs (belt-and-suspenders; those jobs don't need it).

## Why this is safe for catching real problems

Sentry is for runtime errors affecting real users in prod/staging — not test runs. A genuine crash in a unit test is already surfaced by the **test runner** (red build + traceback), which is clearer and where you want it. So nothing is lost for detection.

## Verification

- Non-test run: Sentry still initializes (`get_client().is_active()` is `True` with a DSN set).
- Under real pytest: a test asserts `not sentry_sdk.get_client().is_active()` — passes.
- No `SENTRY_DSN` references remain in `.github/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)