### PR TITLE
fix(docker): fail fast + retry when GDAL 3.11.3 snapshot is unreachable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,19 @@ ENV AWS_CLI_VERSION=2.8.12
 # Add Debian snapshot archive for GDAL 3.11.3 (frozen version for reproducible builds)
 # Using snapshot ensures system GDAL matches Python gdal==3.11.3 bindings
 RUN printf 'Types: deb\nURIs: http://snapshot.debian.org/archive/debian/20250822T205752Z/\nSuites: sid\nComponents: main\nCheck-Valid-Until: no\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n' > /etc/apt/sources.list.d/snapshot.sources && \
-    echo 'Package: libgdal-dev gdal-bin libgdal34t64\nPin: version 3.11.3*\nPin-Priority: 1000' > /etc/apt/preferences.d/gdal-pinned
+    echo 'Package: libgdal-dev gdal-bin libgdal34t64\nPin: version 3.11.3*\nPin-Priority: 1000' > /etc/apt/preferences.d/gdal-pinned && \
+    printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\n' > /etc/apt/apt.conf.d/80-retries
 
 RUN apt-get update && \
+    # Fail fast if the GDAL 3.11.3 snapshot was unreachable. snapshot.debian.org
+    # is flaky (503 TooManyRequests); when it is, apt silently falls back to
+    # trixie's libgdal 3.10.3 and the Python gdal==3.11.3 build breaks much later
+    # with a confusing "requires at least libgdal 3.11.3" error. Abort loudly
+    # here instead, so the fix (retry the build) is obvious.
+    apt-cache policy libgdal-dev | grep -q 'Candidate: 3\.11\.3' || { \
+        echo "ERROR: system libgdal 3.11.3 is unavailable — the Debian snapshot fetch likely failed (snapshot.debian.org 503). Retry the build." >&2; \
+        apt-cache policy libgdal-dev >&2; \
+        exit 1; } && \
     apt-get install -q -y --no-install-recommends \
                      build-essential libpq-dev dnsutils libmagic-dev mailcap gettext \
                      libkml-dev libgdal-dev gdal-bin unzip curl ca-certificates && \


### PR DESCRIPTION
## Problem

Fresh local Docker builds (`make build` / `make run-local-soilid`) intermittently fail with:

```
Exception: Python bindings of GDAL 3.11.3 require at least libgdal 3.11.3, but 3.10.3 was found
```

The Dockerfile pins **system libgdal to 3.11.3** from a Debian snapshot to match the Python `gdal==3.11.3` binding. But `snapshot.debian.org` is flaky and returns **503 TooManyRequests**. When the fetch fails, `apt-get update` only warns, and `apt-get install libgdal-dev` **silently falls back to Debian trixie's libgdal 3.10.3**. The build then continues and only fails ~5 minutes later at the `pip` GDAL build, with a confusing error.

Confirmed root cause (fresh resolve):
```
W: Failed to fetch http://snapshot.debian.org/.../sid/InRelease  TooManyRequests 503
libgdal-dev  Candidate: 3.10.3+dfsg-1
```

CI doesn't hit this because it reuses the cached image layer and never re-contacts the snapshot server — so this is latent for everyone doing a clean local build.

## Change (Dockerfile only, no version bump)

- **Fail fast:** after `apt-get update`, assert that `libgdal-dev`'s candidate is `3.11.3`; if not, abort the build immediately with a clear message ("snapshot fetch likely failed — retry the build") instead of installing 3.10.3 and blowing up later.
- **Retry the flaky source:** `Acquire::Retries "5"` + a 30s http timeout, so a transient 503 is retried before giving up.

The pinned version is unchanged; this only makes the failure **loud and early** and **less frequent**.

## Notes

- This doesn't make snapshot.debian.org reliable — when it's fully down, the build still can't get 3.11.3 (by design; it now says so clearly). Retrying, or building against the ghcr CI layer cache, remains the workaround.
- Can't fully build-test locally right now because snapshot.debian.org is currently 503-ing (which is exactly the case this handles). The added check is standard `apt-cache policy` + shell; CI's cached build path is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)