### PR TITLE
feat: run the local dev backend without downloading the soil ID DB

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -19,6 +19,11 @@ GUNICORN_CMD_ARGS=--worker-class gthread --threads 8
 SECRET_KEY=super-sekret-that-must-be-changed-on-serious-environments
 DATABASE_URL=postgres://postgres:postgres@db:5432/terraso_backend
 DATABASE_EXTERNAL_PORT=5432
+# Soil ID database: set SOIL_ID_DATABASE_ENABLED=false to skip starting the
+# soil-id-db container entirely. Saves ~2 GB download and avoids pulling the
+# container image. US soil matching still works; only global (HWSD) lookups
+# need it. Default is true (included via Makefile).
+# SOIL_ID_DATABASE_ENABLED=false
 SOIL_ID_DATABASE_URL=postgres://postgres:postgres@soil-id-db:5432/soil_id
 SOIL_ID_DATABASE_EXTERNAL_PORT=5433
 ALLOWED_HOSTS=*

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 DC_ENV ?= dev
 ENV_FILE ?= $(HOME)/secrets/terraso-backend/.env
-include $(ENV_FILE)
+ifneq (,$(wildcard ./.env))
+	include $(ENV_FILE)
+endif
 # Extra compose files, threaded through DC_FILE_ARG so they apply to
 # run/test/bash/lint alike. Override directly, e.g.:
 #   make run DC_EXTRA_FILES="-f docker-compose.local-soilid.yml"

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,17 @@
 DC_ENV ?= dev
 ENV_FILE ?= $(HOME)/secrets/terraso-backend/.env
+include $(ENV_FILE)
 # Extra compose files, threaded through DC_FILE_ARG so they apply to
 # run/test/bash/lint alike. Override directly, e.g.:
 #   make run DC_EXTRA_FILES="-f docker-compose.local-soilid.yml"
 DC_EXTRA_FILES ?=
+# Soil ID database: include the soil-id-db container by default. Set to
+# "false" to skip it entirely (saves ~2 GB download, faster startup).
+# US soil matching still works; only global (HWSD) lookups need it.
+SOIL_ID_DATABASE_ENABLED ?= true
+ifeq ($(SOIL_ID_DATABASE_ENABLED),true)
+	DC_EXTRA_FILES += -f docker-compose.soilid.yml
+endif
 # Convenience flag: run against a LOCAL ../soil-id-algorithm checkout (mounts it
 # and shadows the pinned soil-id release via PYTHONPATH) for an unreleased
 # soil-id change. Prefer the one-shot form so it doesn't leak into later

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,17 +8,10 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      soil-id-db:
-        condition: service_healthy
   db:
     extends:
       file: docker-compose.base.yml
       service: db
-  
-  soil-id-db:
-    extends:
-      file: docker-compose.base.yml
-      service: soil-id-db
 
 volumes:
   postgresql_data:

--- a/docker-compose.soilid.yml
+++ b/docker-compose.soilid.yml
@@ -1,0 +1,19 @@
+# Override: start the soil-id-db container alongside the web service.
+#
+# Included by default (SOIL_ID_DATABASE_ENABLED=true in Makefile).
+# Omit this file to skip the ~2 GB global soil database download entirely:
+#   make run SOIL_ID_DATABASE_ENABLED=false
+# or set SOIL_ID_DATABASE_ENABLED=false in your .env.
+#
+# US soil matching still works without it — only global (HWSD) lookups
+# need the soil-id-db. The Django app will gracefully degrade on the
+# Python side when the database isn't reachable.
+services:
+  web:
+    depends_on:
+      soil-id-db:
+        condition: service_healthy
+  soil-id-db:
+    extends:
+      file: docker-compose.base.yml
+      service: soil-id-db


### PR DESCRIPTION
## Description
Splits the Soil ID DB into a separate docker compose file, which is included conditionally based on an env var, so that dev machines which don't need it can skip the disk/memory overhead of downloading/running it.

Of note: it seems env vars from the .env were not available in the Makefile context. the `include $(ENV_FILE)` at the top of the Makefile enables this.

The default behavior in all environments will remain the same, it'll only come into effect if someone manually overrides `SOIL_ID_DATABASE_ENABLED` to `false` in their `.env`.