### PR TITLE
fix: guard .env include on the file actually included

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DC_ENV ?= dev
 ENV_FILE ?= $(HOME)/secrets/terraso-backend/.env
-ifneq (,$(wildcard ./.env))
+ifneq (,$(wildcard $(ENV_FILE)))
 	include $(ENV_FILE)
 endif
 # Extra compose files, threaded through DC_FILE_ARG so they apply to


### PR DESCRIPTION
The Makefile guarded the include on `./.env` but included `$(ENV_FILE)` `(~/secrets/terraso-backend/.env)`, a different file. Inside the Docker container `$(HOME)` is `/home/terraso` with no secrets mounted, so a stale `./.env` baked into the image made the include fail with a missing-file error. Guard on `$(wildcard $(ENV_FILE))` so the include only fires when that exact file exists (present on the host, absent in the container).

Note: I also plan to use this branch to update dependency to a new soil-id once that is in main.
