### PR TITLE
feat(soil-id): expose US functional similarity metrics via GraphQL

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1194,8 +1194,8 @@ six==1.17.0 \
     # via
     #   promise
     #   python-dateutil
-soil-id @ https://github.com/techmatters/soil-id-algorithm/archive/refs/tags/2026-06-26.1.zip \
-    --hash=sha256:e591e22b90db3e1ffa6ca855880842f77c4313d77c002beaac2ad13b48d6ac4d
+soil-id @ https://github.com/techmatters/soil-id-algorithm/archive/refs/tags/2026-07-20.0.zip \
+    --hash=sha256:65b5bd825c9e9ad6b6f4312f7b276b43a2b350167c97d94131aa42eea5e3f857
     # via -r requirements/base.in
 sqlparse==0.5.5 \
     --hash=sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba \

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -28,4 +28,4 @@ requests
 rules
 sentry-sdk[django]
 shapely
-soil-id @ https://github.com/techmatters/soil-id-algorithm/archive/refs/tags/2026-06-26.1.zip
+soil-id @ https://github.com/techmatters/soil-id-algorithm/archive/refs/tags/2026-07-20.0.zip

--- a/terraso_backend/apps/graphql/schema/schema.graphql
+++ b/terraso_backend/apps/graphql/schema/schema.graphql
@@ -329,6 +329,16 @@ A ranked group of soil matches based on a coordinate pair and soil data.
 type SoilMatches {
   dataRegion: SoilIdDataRegionChoices!
   matches: [SoilMatch!]!
+
+  """
+  US only. Width of the 90% prediction interval for available water storage in the top 100cm across the matched soils in the AOI. Smaller = the soils are more functionally similar. Null when unavailable (e.g. fewer than two distinct components, or global).
+  """
+  awsPiw90: Float
+
+  """
+  US only. Per-property information gain (soil input variable importance).
+  """
+  soilDataValue: [SoilDataValueEntry!]
 }
 
 """A soil match based on a coordinate pair and soil data."""
@@ -339,6 +349,18 @@ type SoilMatch {
   locationMatch: SoilMatchInfo!
   dataMatch: SoilMatchInfo
   combinedMatch: SoilMatchInfo
+}
+
+"""
+Information gain of a single simulated soil property (US only).
+
+Higher information gain = the property is more useful for distinguishing
+the matched soils from one another.
+"""
+type SoilDataValueEntry {
+  """Simulated property + depth, e.g. 'texture_0', 'rfv_class_30'."""
+  soilProperty: String!
+  informationGain: Float!
 }
 
 type GroupNode implements Node {

--- a/terraso_backend/apps/soil_id/graphql/soil_id/resolvers.py
+++ b/terraso_backend/apps/soil_id/graphql/soil_id/resolvers.py
@@ -31,6 +31,7 @@ from apps.soil_id.graphql.soil_id.types import (
     DataBasedSoilMatches,
     EcologicalSite,
     LandCapabilityClass,
+    SoilDataValueEntry,
     SoilIdDepthDependentData,
     SoilIdFailure,
     SoilIdFailureReason,
@@ -424,6 +425,33 @@ def resolve_data_based_soil_matches(soil_list_json: dict, rank_json: dict):
     return DataBasedSoilMatches(matches=ranked_matches)
 
 
+def resolve_aws_piw90(soil_list_json: dict):
+    value = soil_list_json.get("AWS_PIW90")
+    # Guard against the "Data not available" sentinel and NaN; bools are not valid here.
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    if math.isnan(value):
+        return None
+    return float(value)
+
+
+def resolve_soil_data_value(soil_list_json: dict):
+    value = soil_list_json.get("Soil Data Value")
+    if not isinstance(value, list):  # missing, or "Data not available"
+        return None
+    entries = []
+    for item in value:
+        if not isinstance(item, (list, tuple)) or len(item) != 2:
+            continue
+        soil_property, gain = item
+        if isinstance(gain, bool) or not isinstance(gain, (int, float)) or math.isnan(gain):
+            continue
+        entries.append(
+            SoilDataValueEntry(soil_property=str(soil_property), information_gain=float(gain))
+        )
+    return entries
+
+
 def resolve_soil_matches(
     data_region: SoilIdCache.DataRegion, soil_list_json: dict, rank_json: dict
 ):
@@ -434,7 +462,12 @@ def resolve_soil_matches(
                 resolve_soil_match(data_region, soil_list_json["soilList"], ranked_match)
             )
 
-    return SoilMatches(data_region=data_region, matches=ranked_matches)
+    return SoilMatches(
+        data_region=data_region,
+        matches=ranked_matches,
+        aws_piw90=resolve_aws_piw90(soil_list_json),
+        soil_data_value=resolve_soil_data_value(soil_list_json),
+    )
 
 
 # DEPRECATED

--- a/terraso_backend/apps/soil_id/graphql/soil_id/types.py
+++ b/terraso_backend/apps/soil_id/graphql/soil_id/types.py
@@ -129,11 +129,37 @@ class DataBasedSoilMatches(graphene.ObjectType):
     matches = graphene.List(graphene.NonNull(DataBasedSoilMatch), required=True)
 
 
+class SoilDataValueEntry(graphene.ObjectType):
+    """Information gain of a single simulated soil property (US only).
+
+    Higher information gain = the property is more useful for distinguishing
+    the matched soils from one another.
+    """
+
+    soil_property = graphene.String(
+        required=True,
+        description="Simulated property + depth, e.g. 'texture_0', 'rfv_class_30'.",
+    )
+    information_gain = graphene.Float(required=True)
+
+
 class SoilMatches(graphene.ObjectType):
     """A ranked group of soil matches based on a coordinate pair and soil data."""
 
     data_region = DataRegion(required=True)
     matches = graphene.List(graphene.NonNull(SoilMatch), required=True)
+    aws_piw90 = graphene.Float(
+        description=(
+            "US only. Width of the 90% prediction interval for available water "
+            "storage in the top 100cm across the matched soils in the AOI. "
+            "Smaller = the soils are more functionally similar. Null when "
+            "unavailable (e.g. fewer than two distinct components, or global)."
+        )
+    )
+    soil_data_value = graphene.List(
+        graphene.NonNull(SoilDataValueEntry),
+        description="US only. Per-property information gain (soil input variable importance).",
+    )
 
 
 class DataBasedResult(graphene.Union):


### PR DESCRIPTION
## What

Exposes US soil functional-similarity metrics through the GraphQL soil-id API:

- `awsPiw90` — available water storage functional-similarity metric (smaller = more functionally similar).
- `soilDataValue` — per-property information gain (soil input variable importance).

Both are read from the soil-id algorithm output (`AWS_PIW90` / `"Soil Data Value"`) and are **US-only**; they resolve to `null` when the underlying data is unavailable (guards against the "Data not available" sentinel, `NaN`, and bool).

## soil-id bump

Repins soil-id `2026-06-26.1` → **`2026-07-20.0`**, the tagged release that contains the functional-similarity output. (Replaces the earlier in-flight `ff30be7d` pin used during development — main now tracks a proper release tag.)

## Verification

- `make check_api_schema` — schema consistent (generated `schema.graphql` matches).
- `make lint` — ruff check/format clean, no missing migrations.
- `make test_unit` — 17 resolver tests pass (`tests/soil_id/test_graphql_resolvers.py`) against `2026-07-20.0`.

## Note

No dedicated unit tests were added for the new `awsPiw90` / `soilDataValue` fields in this PR — the passing tests are pre-existing resolver coverage. Follow-up welcome to add targeted assertions for these fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)