### PR TITLE
feat: compress visualization config geojson objects (with backfill)

### DIFF
--- a/terraso_backend/apps/shared_data/management/commands/compress_existing_geojson.py
+++ b/terraso_backend/apps/shared_data/management/commands/compress_existing_geojson.py
@@ -1,0 +1,188 @@
+# Copyright © 2026 Technology Matters
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see https://www.gnu.org/licenses/.
+
+import gzip
+import json
+
+from botocore.exceptions import ClientError
+from django.core.files.base import ContentFile
+from django.core.management.base import BaseCommand
+
+from apps.shared_data.models import VisualizationConfig
+from apps.shared_data.services import GEOJSON_CONTENT_TYPE, geojson_upload_service
+
+
+class Command(BaseCommand):
+    """Compress existing generated layer GeoJSON objects in S3 in place.
+
+    Compression is encoded as per-object HTTP metadata (Content-Encoding:
+    gzip), not as a key rename or a DB flag: browsers and mapbox-gl
+    transparently decompress, keys stay identical, persisted references
+    (VisualizationConfig.geojson_s3_key, story-map configuration JSON,
+    presigned URLs) remain valid, and plain and gzipped objects can coexist
+    while the backfill is in progress.
+
+    Idempotency: an object whose Content-Encoding is already gzip is skipped on
+    the head_object alone.
+
+    Scope of enumeration: keys come from VisualizationConfig.geojson_s3_key, so
+    objects orphaned by a deleted row are not reachable by this command.
+    """
+
+    help = (
+        "gzip-compresses existing generated layer GeoJSON objects (geojson/...) in "
+        "S3 in place, setting Content-Encoding: gzip and Cache-Control without "
+        "renaming keys"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report what would change without writing anything",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        stats = {
+            "scanned": 0,
+            "compressed": 0,
+            "would_compress": 0,
+            "already": 0,
+            "missing": 0,
+            "invalid": 0,
+            "failed": 0,
+            "bytes_before": 0,
+            "bytes_after": 0,
+        }
+
+        for key in self._visualization_config_keys():
+            stats["scanned"] += 1
+            self._process_key(stats, key, dry_run)
+
+        self._print_summary(stats, dry_run)
+
+    def _visualization_config_keys(self):
+        """Yield generated layer GeoJSON object keys from the DB."""
+        queryset = VisualizationConfig.objects.filter(geojson_s3_key__isnull=False).exclude(
+            geojson_s3_key=""
+        )
+        for config in queryset.only("id", "geojson_s3_key").iterator():
+            yield config.geojson_s3_key
+
+    def _process_key(self, stats, key, dry_run):
+        storage = geojson_upload_service.storage
+        client = storage.bucket.meta.client
+        try:
+            head = client.head_object(Bucket=storage.bucket_name, Key=key)
+        except ClientError as error:
+            if self._is_missing(error):
+                stats["missing"] += 1
+                self.stdout.write(f"SKIP {key}: object missing from S3")
+            else:
+                stats["failed"] += 1
+                self.stdout.write(self.style.ERROR(f"ERROR {key}: {error}"))
+            return
+        except Exception as error:
+            stats["failed"] += 1
+            self.stdout.write(self.style.ERROR(f"ERROR {key}: {error}"))
+            return
+
+        if head.get("ContentEncoding") == "gzip":
+            stats["already"] += 1
+            return
+
+        try:
+            plaintext = storage.open(key, "rb").read()
+            json.loads(plaintext)  # raises for anything that is not JSON
+        except Exception:
+            stats["invalid"] += 1
+            self.stdout.write(self.style.WARNING(f"SKIP {key}: stored bytes are not valid JSON"))
+            return
+
+        stats["bytes_before"] += head["ContentLength"]
+
+        if dry_run:
+            # Preview through the storage's own compressor so the reported size
+            # is exactly what a real run would write (deterministic: level 6,
+            # mtime=0).
+            compressed = storage._gzip_content(ContentFile(plaintext)).read()
+            stats["would_compress"] += 1
+            stats["bytes_after"] += len(compressed)
+            self.stdout.write(
+                f"WOULD COMPRESS {key}: {head['ContentLength']} -> {len(compressed)} bytes"
+            )
+            return
+
+        try:
+            # Hand the plaintext to overwrite(): the storage compresses exactly
+            # once and tags it with the same metadata as the write path
+            # (_get_write_parameters is the single source of truth).
+            storage.overwrite(key, ContentFile(plaintext))
+
+            # Verify what actually landed.
+            stored = storage.open(key, "rb").read()
+            if gzip.decompress(stored) != plaintext:
+                raise ValueError("stored object does not gunzip back to the original content")
+            stored_head = client.head_object(Bucket=storage.bucket_name, Key=key)
+            if stored_head.get("ContentEncoding") != "gzip":
+                raise ValueError("stored object is missing Content-Encoding: gzip")
+            if stored_head.get("ContentType") != GEOJSON_CONTENT_TYPE:
+                raise ValueError(
+                    f"stored object Content-Type {stored_head.get('ContentType')!r} "
+                    f"!= expected {GEOJSON_CONTENT_TYPE!r}"
+                )
+        except Exception as error:
+            stats["failed"] += 1
+            self.stdout.write(self.style.ERROR(f"ERROR {key}: {error}"))
+            return
+
+        stats["compressed"] += 1
+        stats["bytes_after"] += len(stored)
+        self.stdout.write(
+            f"COMPRESSED {key}: {head['ContentLength']} -> {len(stored)} bytes "
+            f"(content_type={stored_head['ContentType']})"
+        )
+
+    @staticmethod
+    def _is_missing(error):
+        return error.response.get("Error", {}).get("Code") in ("404", "NoSuchKey")
+
+    def _print_summary(self, stats, dry_run):
+        action = "Would compress" if dry_run else "Compressed"
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"\n{action}: {stats['would_compress'] if dry_run else stats['compressed']} "
+                f"| Scanned: {stats['scanned']} "
+                f"| Already compressed: {stats['already']} "
+                f"| Missing: {stats['missing']} "
+                f"| Invalid: {stats['invalid']} "
+                f"| Failed: {stats['failed']}"
+            )
+        )
+        before = stats["bytes_before"]
+        after = stats["bytes_after"]
+        if before:
+            reduction = (1 - after / before) * 100
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Storage bytes: {before} -> {after} "
+                    f"({before - after} saved, {reduction:.1f}% reduction)"
+                )
+            )
+        else:
+            self.stdout.write(self.style.SUCCESS("Storage bytes: 0 -> 0 (nothing to rewrite)"))
+        if dry_run:
+            self.stdout.write(self.style.WARNING("Dry run: no objects were written"))

--- a/terraso_backend/apps/shared_data/services.py
+++ b/terraso_backend/apps/shared_data/services.py
@@ -15,8 +15,10 @@
 
 from django.conf import settings
 
-from apps.storage.s3 import TerrasoFileStorage
+from apps.storage.s3 import ExactKeyWriteStorageMixin, GzipStorageMixin, TerrasoFileStorage
 from apps.storage.services import UploadService
+
+GEOJSON_CONTENT_TYPE = "application/geo+json"
 
 
 class DataEntryFileStorage(TerrasoFileStorage):
@@ -31,9 +33,14 @@ class DataEntryUploadService(UploadService):
 data_entry_upload_service = DataEntryUploadService()
 
 
-class GeoJsonFileStorage(TerrasoFileStorage):
+class GeoJsonFileStorage(GzipStorageMixin, ExactKeyWriteStorageMixin, TerrasoFileStorage):
     bucket_name = settings.DATA_ENTRY_FILE_S3_BUCKET
     querystring_expire = 86400  # 24-hour signed URL expiry
+
+    def _get_write_parameters(self, name, content=None):
+        params = super()._get_write_parameters(name, content)
+        params["ContentType"] = GEOJSON_CONTENT_TYPE
+        return params
 
 
 class GeoJsonUploadService(UploadService):

--- a/terraso_backend/apps/storage/s3.py
+++ b/terraso_backend/apps/storage/s3.py
@@ -13,8 +13,16 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see https://www.gnu.org/licenses/.
 
+import gzip
+
 from django.conf import settings
+from django.core.files.base import ContentFile
 from storages.backends.s3boto3 import S3Boto3Storage
+
+# gzip level for compressed objects, pinned below gzip's default of 9
+# as levels beyond 6 can start taking seconds of CPU time for very
+# little compression gains
+GZIP_COMPRESS_LEVEL = 6
 
 
 class TerrasoFileStorage(S3Boto3Storage):
@@ -27,6 +35,41 @@ class TerrasoFileStorage(S3Boto3Storage):
     """
 
     custom_domain = None
+
+
+class GzipStorageMixin:
+    """Gzip-compresses every object the storage writes."""
+
+    def _gzip_content(self, content):
+        if content.seekable():
+            content.seek(0)
+        # mtime=0 keeps the output deterministic: identical input produces
+        # identical bytes (good for caching).
+        return ContentFile(
+            gzip.compress(content.read(), compresslevel=GZIP_COMPRESS_LEVEL, mtime=0)
+        )
+
+    def _save(self, name, content):
+        return super()._save(name, self._gzip_content(content))
+
+    def _get_write_parameters(self, name, content=None):
+        params = super()._get_write_parameters(name, content)
+        params["ContentEncoding"] = "gzip"
+        return params
+
+
+class ExactKeyWriteStorageMixin:
+    """Adds ``overwrite()``, a write that keeps the exact key it was given.
+
+    TEMPORARY CODE: its only caller is the ``compress_existing_geojson``
+    backfill command, which runs once per bucket. Delete this mixin together
+    with that command once the backfill has run in production -- nothing else
+    here is expected to outlive it.
+    """
+
+    def overwrite(self, name, content):
+        """Write ``content`` to exactly ``name``, even if that key already exists."""
+        return self._save(name, content)
 
 
 class ProfileImageStorage(TerrasoFileStorage):

--- a/terraso_backend/tests/shared_data/test_compress_existing_geojson.py
+++ b/terraso_backend/tests/shared_data/test_compress_existing_geojson.py
@@ -1,0 +1,293 @@
+# Copyright © 2026 Technology Matters
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see https://www.gnu.org/licenses/.
+
+import gzip
+import io
+import json
+import uuid
+
+import boto3
+import pytest
+from django.conf import settings
+from django.core.management import call_command
+from mixer.backend.django import mixer
+from moto import mock_aws
+
+from apps.shared_data.models import DataEntry, VisualizationConfig
+from apps.shared_data.services import GEOJSON_CONTENT_TYPE, geojson_upload_service
+from apps.storage.s3 import GZIP_COMPRESS_LEVEL
+
+pytestmark = pytest.mark.django_db
+
+SAMPLE_GEOJSON = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [-0.1805502450716432, -78.48306234911033],
+            },
+            "properties": {"title": "sample point"},
+        }
+    ],
+}
+SAMPLE_GEOJSON_BYTES = json.dumps(SAMPLE_GEOJSON).encode("utf-8")
+
+
+def _s3_client():
+    return boto3.client("s3", region_name=settings.AWS_S3_REGION_NAME)
+
+
+def _bucket_name():
+    return settings.DATA_ENTRY_FILE_S3_BUCKET
+
+
+def _head_object(key):
+    return _s3_client().head_object(Bucket=_bucket_name(), Key=key)
+
+
+def _read_object(key):
+    return _s3_client().get_object(Bucket=_bucket_name(), Key=key)["Body"].read()
+
+
+def _ensure_bucket():
+    """Create the S3 bucket inside the active moto mock context.
+
+    Must run inside the test body (not in a fixture): pytest resolves
+    fixtures before the mock_aws-decorated function executes, so bucket
+    creation in a fixture would hit real AWS instead of moto.
+    """
+    kwargs = {}
+    if settings.AWS_S3_REGION_NAME != "us-east-1":
+        kwargs["CreateBucketConfiguration"] = {"LocationConstraint": settings.AWS_S3_REGION_NAME}
+    _s3_client().create_bucket(Bucket=_bucket_name(), **kwargs)
+
+
+def _put_plain_object(key, body, content_type="application/geo+json", extra=None):
+    """Store a pre-compression object: plain bytes, no Content-Encoding."""
+    kwargs = {"Bucket": _bucket_name(), "Key": key, "Body": body}
+    if content_type is not None:
+        kwargs["ContentType"] = content_type
+    if extra:
+        kwargs.update(extra)
+    _s3_client().put_object(**kwargs)
+
+
+def _gzip_bytes(data):
+    buffer = io.BytesIO()
+    with gzip.GzipFile(fileobj=buffer, mode="wb") as gz:
+        gz.write(data)
+    return buffer.getvalue()
+
+
+def _run_command(*args, **kwargs):
+    output = io.StringIO()
+    call_command("compress_existing_geojson", *args, stdout=output, **kwargs)
+    return output
+
+
+def _generated_key():
+    return f"geojson/vc-{uuid.uuid4().hex[:8]}/layer.geojson"
+
+
+def _make_visualization_config(key):
+    return mixer.blend(
+        VisualizationConfig,
+        size=1,
+        geojson_s3_key=key,
+        data_entry=mixer.blend(DataEntry, url="https://example.com/unused/file.csv"),
+    )
+
+
+@mock_aws
+def test_generated_geojson_object_is_compressed_in_place():
+    """Headline: a plain generated GeoJSON object referenced by a
+    VisualizationConfig.geojson_s3_key becomes gzip-encoded at the same key,
+    with correct HTTP metadata, and gunzips to byte-identical content."""
+    _ensure_bucket()
+    key = _generated_key()
+    _put_plain_object(key, SAMPLE_GEOJSON_BYTES)
+    _make_visualization_config(key)
+
+    output = _run_command()
+
+    metadata = _head_object(key)
+    assert metadata["ContentEncoding"] == "gzip"
+    assert metadata["ContentType"] == GEOJSON_CONTENT_TYPE
+    assert metadata["ContentLength"] < len(SAMPLE_GEOJSON_BYTES)
+
+    raw = _read_object(key)
+    assert gzip.decompress(raw) == SAMPLE_GEOJSON_BYTES
+
+    # No renamed copies: the exact key is the only object in the bucket.
+    keys = [obj["Key"] for obj in _s3_client().list_objects_v2(Bucket=_bucket_name())["Contents"]]
+    assert keys == [key]
+
+    assert "Scanned: 1" in output.getvalue()
+    assert "Compressed: 1" in output.getvalue()
+    assert "0.0% reduction" not in output.getvalue()
+
+
+@mock_aws
+def test_second_run_is_idempotent():
+    _ensure_bucket()
+    key = _generated_key()
+    _put_plain_object(key, SAMPLE_GEOJSON_BYTES)
+    _make_visualization_config(key)
+
+    _run_command()
+    after_first = _head_object(key)
+    first_bytes = _read_object(key)
+
+    output = _run_command()
+
+    assert "Compressed: 0" in output.getvalue()
+    assert "Already compressed: 1" in output.getvalue()
+
+    after_second = _head_object(key)
+    assert after_second["ContentEncoding"] == "gzip"
+    assert after_second["ETag"] == after_first["ETag"]
+    assert after_second["ContentLength"] == after_first["ContentLength"]
+    assert _read_object(key) == first_bytes
+
+
+@mock_aws
+def test_dry_run_writes_nothing_but_reports_the_same_plan():
+    _ensure_bucket()
+    key = _generated_key()
+    _put_plain_object(key, SAMPLE_GEOJSON_BYTES)
+    _make_visualization_config(key)
+
+    output = _run_command("--dry-run")
+
+    assert "Would compress: 1" in output.getvalue()
+    assert "Compressed: 1" not in output.getvalue()
+    assert "dry" in output.getvalue().lower()
+
+    # Nothing was written: still plain, no metadata, same ETag.
+    metadata = _head_object(key)
+    assert "ContentEncoding" not in metadata
+    assert metadata["ContentLength"] == len(SAMPLE_GEOJSON_BYTES)
+    assert _read_object(key) == SAMPLE_GEOJSON_BYTES
+    assert len(_s3_client().list_objects_v2(Bucket=_bucket_name())["Contents"]) == 1
+
+
+@mock_aws
+def test_missing_and_invalid_objects_are_skipped_and_run_continues():
+    """Also pins the consequence of the header-only idempotency check: an
+    object whose body is gzip but whose Content-Encoding does not say so is no
+    longer decoded-and-repaired. That state is not producible by any code here,
+    so the command just declines to touch it (invalid, bytes untouched) instead
+    of downloading and sniffing every body to defend against it."""
+    _ensure_bucket()
+    good_key = _generated_key()
+    _put_plain_object(good_key, SAMPLE_GEOJSON_BYTES)
+    _make_visualization_config(good_key)
+
+    missing_key = _generated_key()
+    _make_visualization_config(missing_key)  # no object in S3
+
+    invalid_plain_key = _generated_key()
+    _put_plain_object(invalid_plain_key, b"this is not json at all \x00\x01")
+    _make_visualization_config(invalid_plain_key)
+
+    gzip_body_without_header_key = _generated_key()
+    gzip_body = _gzip_bytes(b"not json either")  # fixed bytes: GzipFile stamps mtime
+    _put_plain_object(gzip_body_without_header_key, gzip_body)
+    _make_visualization_config(gzip_body_without_header_key)
+
+    output = _run_command()
+
+    text = output.getvalue()
+    assert "Compressed: 1" in text
+    assert "Missing: 1" in text
+    assert "Invalid: 2" in text
+    assert "Failed: 0" in text
+    assert missing_key in text
+    assert invalid_plain_key in text
+    assert gzip_body_without_header_key in text
+
+    # Skipped means untouched: not rewritten, not given a gzip header.
+    assert _read_object(gzip_body_without_header_key) == gzip_body
+    assert "ContentEncoding" not in _head_object(gzip_body_without_header_key)
+    assert _read_object(invalid_plain_key) == b"this is not json at all \x00\x01"
+
+
+@mock_aws
+def test_backfilled_object_serves_gunzipable_bytes_and_signed_url():
+    """After the backfill, the object under the unchanged key is a gzip body
+    that gunzips to the original GeoJSON — which is exactly what the browser /
+    mapbox-gl client decoding Content-Encoding receives — and the signed-URL
+    generator still points at the same key. The backend never byte-reads
+    these objects, so the client-side decode is simulated here."""
+    _ensure_bucket()
+    key = _generated_key()
+    vc = _make_visualization_config(key)
+    _put_plain_object(key, SAMPLE_GEOJSON_BYTES)
+
+    _run_command()
+
+    raw = _read_object(vc.geojson_s3_key)
+    assert json.loads(gzip.decompress(raw)) == SAMPLE_GEOJSON
+    assert vc.geojson_s3_key in geojson_upload_service.get_signed_url(vc.geojson_s3_key)
+
+
+@mock_aws
+def test_object_is_compressed_exactly_once_with_canonical_bytes():
+    """The stored object must be exactly one gzip pass over the original
+    plaintext with the canonical write-path settings (level 6, mtime=0): a
+    second compression pass would change the bytes, waste CPU and break the
+    byte-identical rewrite guarantee."""
+    _ensure_bucket()
+    view = SAMPLE_GEOJSON_BYTES
+    key = _generated_key()
+    _put_plain_object(key, view)
+    _make_visualization_config(key)
+
+    _run_command()
+
+    stored = _read_object(key)
+    assert stored == gzip.compress(view, compresslevel=GZIP_COMPRESS_LEVEL, mtime=0)
+    assert gzip.decompress(stored) == view
+
+
+@mock_aws
+def test_content_type_is_canonicalized_on_backfill():
+    """One canonical rule for both write paths: every generated layer object
+    is served as application/geo+json, whatever Content-Type it was stored
+    with (or none). Preserving the old value created a fresh-write vs
+    backfilled divergence and forced a shared-singleton override race in
+    overwrite()."""
+    _ensure_bucket()
+    # A generated object that an older writer stored as application/json.
+    json_type_key = f"geojson/vc-{uuid.uuid4().hex[:8]}/layer.json"
+    _put_plain_object(json_type_key, b'{"a": 1}', content_type="application/json")
+    _make_visualization_config(json_type_key)
+    # Old generated object stored without any Content-Type (S3 stores a default).
+    no_type_key = _generated_key()
+    _put_plain_object(no_type_key, SAMPLE_GEOJSON_BYTES, content_type=None)
+    _make_visualization_config(no_type_key)
+
+    _run_command()
+
+    json_metadata = _head_object(json_type_key)
+    assert json_metadata["ContentEncoding"] == "gzip"
+    assert json_metadata["ContentType"] == GEOJSON_CONTENT_TYPE
+    assert gzip.decompress(_read_object(json_type_key)) == b'{"a": 1}'
+
+    no_type_metadata = _head_object(no_type_key)
+    assert no_type_metadata["ContentEncoding"] == "gzip"
+    assert no_type_metadata["ContentType"] == GEOJSON_CONTENT_TYPE

--- a/terraso_backend/tests/shared_data/test_geojson_compression.py
+++ b/terraso_backend/tests/shared_data/test_geojson_compression.py
@@ -1,0 +1,181 @@
+# Copyright © 2026 Technology Matters
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see https://www.gnu.org/licenses/.
+
+import gzip
+import json
+import uuid
+
+import boto3
+import pytest
+import requests
+from django.conf import settings
+from django.core.files.base import ContentFile
+from django.test import override_settings
+from moto import mock_aws
+
+from apps.shared_data.services import GeoJsonFileStorage, geojson_upload_service
+from apps.storage.s3 import GZIP_COMPRESS_LEVEL
+
+pytestmark = pytest.mark.django_db
+
+SAMPLE_GEOJSON = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [-0.1805502450716432, -78.48306234911033],
+            },
+            "properties": {"title": "sample point"},
+        }
+    ],
+}
+SAMPLE_GEOJSON_BYTES = json.dumps(SAMPLE_GEOJSON).encode("utf-8")
+EMPTY_FEATURE_COLLECTION = {"type": "FeatureCollection", "features": []}
+
+
+def _s3_client():
+    return boto3.client("s3", region_name=settings.AWS_S3_REGION_NAME)
+
+
+def _read_object(key):
+    return (
+        _s3_client().get_object(Bucket=settings.DATA_ENTRY_FILE_S3_BUCKET, Key=key)["Body"].read()
+    )
+
+
+def _head_object(key):
+    return _s3_client().head_object(Bucket=settings.DATA_ENTRY_FILE_S3_BUCKET, Key=key)
+
+
+def _ensure_bucket():
+    """Create the S3 bucket inside the active moto mock context.
+
+    Must run inside the test body (not in a fixture): pytest resolves
+    fixtures before the mock_aws-decorated function executes, so bucket
+    creation in a fixture would hit real AWS instead of moto.
+    """
+    bucket_name = settings.DATA_ENTRY_FILE_S3_BUCKET
+    kwargs = {}
+    if settings.AWS_S3_REGION_NAME != "us-east-1":
+        kwargs["CreateBucketConfiguration"] = {"LocationConstraint": settings.AWS_S3_REGION_NAME}
+    _s3_client().create_bucket(Bucket=bucket_name, **kwargs)
+
+
+@mock_aws
+def test_geojson_storage_gzips_content():
+    _ensure_bucket()
+    storage = GeoJsonFileStorage()
+    key = "geojson/vc-1/vc-1.geojson"
+
+    saved = storage.save(key, ContentFile(SAMPLE_GEOJSON_BYTES))
+
+    assert saved == key
+    raw = _read_object(saved)
+    assert json.loads(gzip.decompress(raw)) == SAMPLE_GEOJSON
+
+
+@mock_aws
+def test_geojson_storage_sets_http_metadata():
+    _ensure_bucket()
+    storage = GeoJsonFileStorage()
+    key = "geojson/vc-2/vc-2.geojson"
+
+    storage.save(key, ContentFile(SAMPLE_GEOJSON_BYTES))
+
+    metadata = _head_object(key)
+    assert metadata["ContentEncoding"] == "gzip"
+    assert metadata["ContentType"] == "application/geo+json"
+    assert metadata["ContentLength"] < len(SAMPLE_GEOJSON_BYTES)
+
+
+@mock_aws
+def test_gzip_compression_is_level_6_and_deterministic():
+    """The synchronous compression level is pinned to 6 (not gzip's default
+    9: ~3x the CPU for ~0.34pp more bytes on a 50MB payload) and mtime=0
+    makes identical input produce identical bytes / stable ETags."""
+    _ensure_bucket()
+    storage = GeoJsonFileStorage()
+
+    assert GZIP_COMPRESS_LEVEL == 6
+    first = storage._gzip_content(ContentFile(SAMPLE_GEOJSON_BYTES)).read()
+    second = storage._gzip_content(ContentFile(SAMPLE_GEOJSON_BYTES)).read()
+
+    assert first == second
+    assert first == gzip.compress(SAMPLE_GEOJSON_BYTES, compresslevel=GZIP_COMPRESS_LEVEL, mtime=0)
+
+    key = "geojson/vc-det/det.geojson"
+    storage.save(key, ContentFile(SAMPLE_GEOJSON_BYTES))
+    assert _read_object(key) == first
+
+
+@mock_aws
+def test_signed_url_serves_gzipped_body_and_metadata_over_http():
+    """Wire-level check: what actually arrives at a browser. moto serves the
+    presigned URL through its HTTP interception, so this proves real response
+    headers and body bytes delivered over an actual HTTP request.
+
+    What it proves / does not prove: requests auto-decodes Content-Encoding:
+    gzip in .content (exactly what a browser does), so the decoded body is
+    asserted to equal the original payload — requests raises
+    ContentDecodingError if the wire body were not valid gzip, and
+    Content-Length is asserted to be the canonical compressed byte count, so
+    the wire body is pinned to the gzip bytes. moto does not validate SigV4
+    signatures (it cannot reject a request), so signature expiry/authz
+    semantics remain covered by the real-browser e2e run."""
+    _ensure_bucket()
+    key = f"geojson/vc-{uuid.uuid4().hex[:8]}/points.geojson"
+    geojson_upload_service.storage.save(key, ContentFile(SAMPLE_GEOJSON_BYTES))
+
+    signed_url = geojson_upload_service.get_signed_url(key)
+
+    response = requests.get(signed_url, timeout=10)
+
+    assert response.status_code == 200
+    # Assert the served headers before reading .content (requests decodes the
+    # body on read, like a browser would).
+    assert response.headers["Content-Encoding"] == "gzip"
+    assert response.headers["Content-Type"] == "application/geo+json"
+    assert response.headers["Content-Length"] == str(
+        len(gzip.compress(SAMPLE_GEOJSON_BYTES, compresslevel=GZIP_COMPRESS_LEVEL, mtime=0))
+    )
+    assert response.content == SAMPLE_GEOJSON_BYTES
+
+
+@mock_aws
+def test_overwrite_writes_exact_key_even_when_save_would_rename():
+    _ensure_bucket()
+    storage = GeoJsonFileStorage()
+    key = "geojson/vc-3/vc-3.geojson"
+    storage.save(key, ContentFile(json.dumps(EMPTY_FEATURE_COLLECTION).encode("utf-8")))
+
+    with override_settings(AWS_S3_FILE_OVERWRITE=False):
+        renamer = GeoJsonFileStorage()
+        renamed = renamer.save(key, ContentFile(b"replacement"))
+    assert renamed != key
+
+    # The exact key still holds the original object: save() renamed the new
+    # content instead of rewriting in place.
+    original_bytes = _read_object(key)
+    assert json.loads(gzip.decompress(original_bytes)) == EMPTY_FEATURE_COLLECTION
+
+    returned = storage.overwrite(key, ContentFile(SAMPLE_GEOJSON_BYTES))
+
+    assert returned == key
+    raw = _read_object(key)
+    assert json.loads(gzip.decompress(raw)) == SAMPLE_GEOJSON
+    metadata = _head_object(key)
+    assert metadata["ContentEncoding"] == "gzip"


### PR DESCRIPTION
## Description
Automatically compresses visualization config GeoJSON on upload, and adds a management command to backfill existing GeoJSON with the same compression logic.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

### Related Issues
Related to https://github.com/techmatters/terraso-web-client/issues/3068

### Verification steps
Should be able to see a difference in the byte size and transferred amount in the browser network console for GeoJSON files loaded in story maps.